### PR TITLE
Make associated body functions generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ let cat_response = client.cat()
 
 let mut search_response = client
     // Value is the request body type
-    .search::<Value>(SearchUrlParts::None))
+    .search(SearchUrlParts::None)
     .body(Some(json!({
         "query": {
             "match_all": {}

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -63,7 +63,7 @@ pub mod tests {
     fn test_search_with_body() -> Result<(), failure::Error> {
         let client = Elasticsearch::default();
         let mut response = client
-            .search::<Value>(SearchUrlParts::None)
+            .search(SearchUrlParts::None)
             .body(Some(json!({
                 "query": {
                     "match_all": {}
@@ -83,7 +83,7 @@ pub mod tests {
     fn test_search_no_body() -> Result<(), failure::Error> {
         let client = Elasticsearch::default();
         let mut response = client
-            .search::<()>(SearchUrlParts::None)
+            .search(SearchUrlParts::None)
             .pretty(Some(true))
             .q(Some("title:Elasticsearch".into()))
             .send()?;
@@ -103,7 +103,7 @@ pub mod tests {
     fn test_serialize_vec_string_on_querystring() -> Result<(), failure::Error> {
         let client = Elasticsearch::default();
         let mut response = client
-            .search::<()>(SearchUrlParts::None)
+            .search(SearchUrlParts::None)
             .pretty(Some(true))
             .filter_path(Some(vec!["took".into()]))
             .q(Some("title:Elasticsearch".into()))
@@ -123,7 +123,7 @@ pub mod tests {
         let client = Elasticsearch::default();
 
         let request = client
-            .search::<Value>(SearchUrlParts::None)
+            .search(SearchUrlParts::None)
             .body(Some(json!({
                 "query": {
                     "match_all": {}
@@ -135,7 +135,7 @@ pub mod tests {
             .clone()
             .q(Some("title:Elasticsearch".into()))
             .size(Some(1))
-            .body(None)
+            .body(Option::<()>::None)
             .allow_no_indices(None);
 
         let mut response = request_clone.send()?;

--- a/elasticsearch/src/namespace_clients/ccr.rs
+++ b/elasticsearch/src/namespace_clients/ccr.rs
@@ -177,9 +177,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> CcrFollow<T>
+    where
+        T: Serialize,
+    {
+        CcrFollow {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -518,9 +530,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> CcrForgetFollower<T>
+    where
+        T: Serialize,
+    {
+        CcrForgetFollower {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -742,9 +765,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> CcrPauseFollow<T>
+    where
+        T: Serialize,
+    {
+        CcrPauseFollow {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -859,9 +893,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> CcrPutAutoFollowPattern<T>
+    where
+        T: Serialize,
+    {
+        CcrPutAutoFollowPattern {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -977,9 +1022,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> CcrResumeFollow<T>
+    where
+        T: Serialize,
+    {
+        CcrResumeFollow {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1194,9 +1250,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> CcrUnfollow<T>
+    where
+        T: Serialize,
+    {
+        CcrUnfollow {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1279,10 +1346,7 @@ impl Ccr {
     ) -> CcrDeleteAutoFollowPattern {
         CcrDeleteAutoFollowPattern::new(self.client.clone(), parts)
     }
-    pub fn follow<B>(&self, parts: CcrFollowUrlParts) -> CcrFollow<B>
-    where
-        B: Serialize,
-    {
+    pub fn follow(&self, parts: CcrFollowUrlParts) -> CcrFollow<()> {
         CcrFollow::new(self.client.clone(), parts)
     }
     pub fn follow_info(&self, parts: CcrFollowInfoUrlParts) -> CcrFollowInfo {
@@ -1291,10 +1355,7 @@ impl Ccr {
     pub fn follow_stats(&self, parts: CcrFollowStatsUrlParts) -> CcrFollowStats {
         CcrFollowStats::new(self.client.clone(), parts)
     }
-    pub fn forget_follower<B>(&self, parts: CcrForgetFollowerUrlParts) -> CcrForgetFollower<B>
-    where
-        B: Serialize,
-    {
+    pub fn forget_follower(&self, parts: CcrForgetFollowerUrlParts) -> CcrForgetFollower<()> {
         CcrForgetFollower::new(self.client.clone(), parts)
     }
     pub fn get_auto_follow_pattern(
@@ -1303,34 +1364,22 @@ impl Ccr {
     ) -> CcrGetAutoFollowPattern {
         CcrGetAutoFollowPattern::new(self.client.clone(), parts)
     }
-    pub fn pause_follow<B>(&self, parts: CcrPauseFollowUrlParts) -> CcrPauseFollow<B>
-    where
-        B: Serialize,
-    {
+    pub fn pause_follow(&self, parts: CcrPauseFollowUrlParts) -> CcrPauseFollow<()> {
         CcrPauseFollow::new(self.client.clone(), parts)
     }
-    pub fn put_auto_follow_pattern<B>(
+    pub fn put_auto_follow_pattern(
         &self,
         parts: CcrPutAutoFollowPatternUrlParts,
-    ) -> CcrPutAutoFollowPattern<B>
-    where
-        B: Serialize,
-    {
+    ) -> CcrPutAutoFollowPattern<()> {
         CcrPutAutoFollowPattern::new(self.client.clone(), parts)
     }
-    pub fn resume_follow<B>(&self, parts: CcrResumeFollowUrlParts) -> CcrResumeFollow<B>
-    where
-        B: Serialize,
-    {
+    pub fn resume_follow(&self, parts: CcrResumeFollowUrlParts) -> CcrResumeFollow<()> {
         CcrResumeFollow::new(self.client.clone(), parts)
     }
     pub fn stats(&self) -> CcrStats {
         CcrStats::new(self.client.clone())
     }
-    pub fn unfollow<B>(&self, parts: CcrUnfollowUrlParts) -> CcrUnfollow<B>
-    where
-        B: Serialize,
-    {
+    pub fn unfollow(&self, parts: CcrUnfollowUrlParts) -> CcrUnfollow<()> {
         CcrUnfollow::new(self.client.clone(), parts)
     }
 }

--- a/elasticsearch/src/namespace_clients/cluster.rs
+++ b/elasticsearch/src/namespace_clients/cluster.rs
@@ -69,9 +69,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> ClusterAllocationExplain<T>
+    where
+        T: Serialize,
+    {
+        ClusterAllocationExplain {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            include_disk_info: self.include_disk_info,
+            include_yes_decisions: self.include_yes_decisions,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -699,9 +712,23 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> ClusterPutSettings<T>
+    where
+        T: Serialize,
+    {
+        ClusterPutSettings {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            flat_settings: self.flat_settings,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -946,9 +973,26 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> ClusterReroute<T>
+    where
+        T: Serialize,
+    {
+        ClusterReroute {
+            client: self.client,
+            parts: self.parts,
+            body,
+            dry_run: self.dry_run,
+            error_trace: self.error_trace,
+            explain: self.explain,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            metric: self.metric,
+            pretty: self.pretty,
+            retry_failed: self.retry_failed,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Simulate the operation only and return the resulting state"]
     pub fn dry_run(mut self, dry_run: Option<bool>) -> Self {
@@ -1406,10 +1450,7 @@ impl Cluster {
         Cluster { client }
     }
     #[doc = "Provides explanations for shard allocations in the cluster."]
-    pub fn allocation_explain<B>(&self) -> ClusterAllocationExplain<B>
-    where
-        B: Serialize,
-    {
+    pub fn allocation_explain(&self) -> ClusterAllocationExplain<()> {
         ClusterAllocationExplain::new(self.client.clone())
     }
     #[doc = "Returns cluster settings."]
@@ -1425,10 +1466,7 @@ impl Cluster {
         ClusterPendingTasks::new(self.client.clone())
     }
     #[doc = "Updates the cluster settings."]
-    pub fn put_settings<B>(&self) -> ClusterPutSettings<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_settings(&self) -> ClusterPutSettings<()> {
         ClusterPutSettings::new(self.client.clone())
     }
     #[doc = "Returns the information about configured remote clusters."]
@@ -1436,10 +1474,7 @@ impl Cluster {
         ClusterRemoteInfo::new(self.client.clone())
     }
     #[doc = "Allows to manually change the allocation of individual shards in the cluster."]
-    pub fn reroute<B>(&self) -> ClusterReroute<B>
-    where
-        B: Serialize,
-    {
+    pub fn reroute(&self) -> ClusterReroute<()> {
         ClusterReroute::new(self.client.clone())
     }
     #[doc = "Returns a comprehensive information about the state of the cluster."]

--- a/elasticsearch/src/namespace_clients/data_frame.rs
+++ b/elasticsearch/src/namespace_clients/data_frame.rs
@@ -452,9 +452,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> DataFramePreviewDataFrameTransform<T>
+    where
+        T: Serialize,
+    {
+        DataFramePreviewDataFrameTransform {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -571,9 +582,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> DataFramePutDataFrameTransform<T>
+    where
+        T: Serialize,
+    {
+        DataFramePutDataFrameTransform {
+            client: self.client,
+            parts: self.parts,
+            body,
+            defer_validation: self.defer_validation,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "If validations should be deferred until data frame transform starts, defaults to false."]
     pub fn defer_validation(mut self, defer_validation: Option<bool>) -> Self {
@@ -699,9 +722,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> DataFrameStartDataFrameTransform<T>
+    where
+        T: Serialize,
+    {
+        DataFrameStartDataFrameTransform {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -836,9 +871,23 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> DataFrameStopDataFrameTransform<T>
+    where
+        T: Serialize,
+    {
+        DataFrameStopDataFrameTransform {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_match: self.allow_no_match,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_completion: self.wait_for_completion,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -978,9 +1027,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> DataFrameUpdateDataFrameTransform<T>
+    where
+        T: Serialize,
+    {
+        DataFrameUpdateDataFrameTransform {
+            client: self.client,
+            parts: self.parts,
+            body,
+            defer_validation: self.defer_validation,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "If validations should be deferred until data frame transform starts, defaults to false."]
     pub fn defer_validation(mut self, defer_validation: Option<bool>) -> Self {
@@ -1083,46 +1144,31 @@ impl DataFrame {
     ) -> DataFrameGetDataFrameTransformStats {
         DataFrameGetDataFrameTransformStats::new(self.client.clone(), parts)
     }
-    pub fn preview_data_frame_transform<B>(&self) -> DataFramePreviewDataFrameTransform<B>
-    where
-        B: Serialize,
-    {
+    pub fn preview_data_frame_transform(&self) -> DataFramePreviewDataFrameTransform<()> {
         DataFramePreviewDataFrameTransform::new(self.client.clone())
     }
-    pub fn put_data_frame_transform<B>(
+    pub fn put_data_frame_transform(
         &self,
         parts: DataFramePutDataFrameTransformUrlParts,
-    ) -> DataFramePutDataFrameTransform<B>
-    where
-        B: Serialize,
-    {
+    ) -> DataFramePutDataFrameTransform<()> {
         DataFramePutDataFrameTransform::new(self.client.clone(), parts)
     }
-    pub fn start_data_frame_transform<B>(
+    pub fn start_data_frame_transform(
         &self,
         parts: DataFrameStartDataFrameTransformUrlParts,
-    ) -> DataFrameStartDataFrameTransform<B>
-    where
-        B: Serialize,
-    {
+    ) -> DataFrameStartDataFrameTransform<()> {
         DataFrameStartDataFrameTransform::new(self.client.clone(), parts)
     }
-    pub fn stop_data_frame_transform<B>(
+    pub fn stop_data_frame_transform(
         &self,
         parts: DataFrameStopDataFrameTransformUrlParts,
-    ) -> DataFrameStopDataFrameTransform<B>
-    where
-        B: Serialize,
-    {
+    ) -> DataFrameStopDataFrameTransform<()> {
         DataFrameStopDataFrameTransform::new(self.client.clone(), parts)
     }
-    pub fn update_data_frame_transform<B>(
+    pub fn update_data_frame_transform(
         &self,
         parts: DataFrameUpdateDataFrameTransformUrlParts,
-    ) -> DataFrameUpdateDataFrameTransform<B>
-    where
-        B: Serialize,
-    {
+    ) -> DataFrameUpdateDataFrameTransform<()> {
         DataFrameUpdateDataFrameTransform::new(self.client.clone(), parts)
     }
 }

--- a/elasticsearch/src/namespace_clients/graph.rs
+++ b/elasticsearch/src/namespace_clients/graph.rs
@@ -88,9 +88,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> GraphExplore<T>
+    where
+        T: Serialize,
+    {
+        GraphExplore {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            routing: self.routing,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -186,10 +199,7 @@ impl Graph {
     pub fn new(client: Elasticsearch) -> Self {
         Graph { client }
     }
-    pub fn explore<B>(&self, parts: GraphExploreUrlParts) -> GraphExplore<B>
-    where
-        B: Serialize,
-    {
+    pub fn explore(&self, parts: GraphExploreUrlParts) -> GraphExplore<()> {
         GraphExplore::new(self.client.clone(), parts)
     }
 }

--- a/elasticsearch/src/namespace_clients/ilm.rs
+++ b/elasticsearch/src/namespace_clients/ilm.rs
@@ -504,9 +504,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IlmMoveToStep<T>
+    where
+        T: Serialize,
+    {
+        IlmMoveToStep {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -621,9 +632,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IlmPutLifecycle<T>
+    where
+        T: Serialize,
+    {
+        IlmPutLifecycle {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -739,9 +761,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IlmRemovePolicy<T>
+    where
+        T: Serialize,
+    {
+        IlmRemovePolicy {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -857,9 +890,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IlmRetry<T>
+    where
+        T: Serialize,
+    {
+        IlmRetry {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -969,9 +1013,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IlmStart<T>
+    where
+        T: Serialize,
+    {
+        IlmStart {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1081,9 +1136,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IlmStop<T>
+    where
+        T: Serialize,
+    {
+        IlmStop {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1172,40 +1238,22 @@ impl Ilm {
     pub fn get_status(&self) -> IlmGetStatus {
         IlmGetStatus::new(self.client.clone())
     }
-    pub fn move_to_step<B>(&self, parts: IlmMoveToStepUrlParts) -> IlmMoveToStep<B>
-    where
-        B: Serialize,
-    {
+    pub fn move_to_step(&self, parts: IlmMoveToStepUrlParts) -> IlmMoveToStep<()> {
         IlmMoveToStep::new(self.client.clone(), parts)
     }
-    pub fn put_lifecycle<B>(&self, parts: IlmPutLifecycleUrlParts) -> IlmPutLifecycle<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_lifecycle(&self, parts: IlmPutLifecycleUrlParts) -> IlmPutLifecycle<()> {
         IlmPutLifecycle::new(self.client.clone(), parts)
     }
-    pub fn remove_policy<B>(&self, parts: IlmRemovePolicyUrlParts) -> IlmRemovePolicy<B>
-    where
-        B: Serialize,
-    {
+    pub fn remove_policy(&self, parts: IlmRemovePolicyUrlParts) -> IlmRemovePolicy<()> {
         IlmRemovePolicy::new(self.client.clone(), parts)
     }
-    pub fn retry<B>(&self, parts: IlmRetryUrlParts) -> IlmRetry<B>
-    where
-        B: Serialize,
-    {
+    pub fn retry(&self, parts: IlmRetryUrlParts) -> IlmRetry<()> {
         IlmRetry::new(self.client.clone(), parts)
     }
-    pub fn start<B>(&self) -> IlmStart<B>
-    where
-        B: Serialize,
-    {
+    pub fn start(&self) -> IlmStart<()> {
         IlmStart::new(self.client.clone())
     }
-    pub fn stop<B>(&self) -> IlmStop<B>
-    where
-        B: Serialize,
-    {
+    pub fn stop(&self) -> IlmStop<()> {
         IlmStop::new(self.client.clone())
     }
 }

--- a/elasticsearch/src/namespace_clients/indices.rs
+++ b/elasticsearch/src/namespace_clients/indices.rs
@@ -75,9 +75,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesAnalyze<T>
+    where
+        T: Serialize,
+    {
+        IndicesAnalyze {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            index: self.index,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -228,9 +240,28 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesClearCache<T>
+    where
+        T: Serialize,
+    {
+        IndicesClearCache {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            fielddata: self.fielddata,
+            fields: self.fields,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            index: self.index,
+            pretty: self.pretty,
+            query: self.query,
+            request: self.request,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -420,9 +451,23 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesClone<T>
+    where
+        T: Serialize,
+    {
+        IndicesClone {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -583,9 +628,26 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesClose<T>
+    where
+        T: Serialize,
+    {
+        IndicesClose {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -754,9 +816,24 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesCreate<T>
+    where
+        T: Serialize,
+    {
+        IndicesCreate {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            include_type_name: self.include_type_name,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1936,9 +2013,25 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesFlush<T>
+    where
+        T: Serialize,
+    {
+        IndicesFlush {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            force: self.force,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            pretty: self.pretty,
+            source: self.source,
+            wait_if_ongoing: self.wait_if_ongoing,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2106,9 +2199,23 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesFlushSynced<T>
+    where
+        T: Serialize,
+    {
+        IndicesFlushSynced {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2266,9 +2373,26 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesForcemerge<T>
+    where
+        T: Serialize,
+    {
+        IndicesForcemerge {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            flush: self.flush,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            max_num_segments: self.max_num_segments,
+            only_expunge_deletes: self.only_expunge_deletes,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2447,9 +2571,26 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesFreeze<T>
+    where
+        T: Serialize,
+    {
+        IndicesFreeze {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -3853,9 +3994,26 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesOpen<T>
+    where
+        T: Serialize,
+    {
+        IndicesOpen {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -4023,9 +4181,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesPutAlias<T>
+    where
+        T: Serialize,
+    {
+        IndicesPutAlias {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -4193,9 +4364,26 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesPutMapping<T>
+    where
+        T: Serialize,
+    {
+        IndicesPutMapping {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            include_type_name: self.include_type_name,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -4376,9 +4564,27 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesPutSettings<T>
+    where
+        T: Serialize,
+    {
+        IndicesPutSettings {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            flat_settings: self.flat_settings,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            master_timeout: self.master_timeout,
+            preserve_existing: self.preserve_existing,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -4556,9 +4762,26 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesPutTemplate<T>
+    where
+        T: Serialize,
+    {
+        IndicesPutTemplate {
+            client: self.client,
+            parts: self.parts,
+            body,
+            create: self.create,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            flat_settings: self.flat_settings,
+            human: self.human,
+            include_type_name: self.include_type_name,
+            master_timeout: self.master_timeout,
+            order: self.order,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Whether the index template should only be added if new or can also replace an existing one"]
     pub fn create(mut self, create: Option<bool>) -> Self {
@@ -4864,9 +5087,23 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesRefresh<T>
+    where
+        T: Serialize,
+    {
+        IndicesRefresh {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5016,9 +5253,23 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesReloadSearchAnalyzers<T>
+    where
+        T: Serialize,
+    {
+        IndicesReloadSearchAnalyzers {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5175,9 +5426,25 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesRollover<T>
+    where
+        T: Serialize,
+    {
+        IndicesRollover {
+            client: self.client,
+            parts: self.parts,
+            body,
+            dry_run: self.dry_run,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            include_type_name: self.include_type_name,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false"]
     pub fn dry_run(mut self, dry_run: Option<bool>) -> Self {
@@ -5645,9 +5912,24 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesShrink<T>
+    where
+        T: Serialize,
+    {
+        IndicesShrink {
+            client: self.client,
+            parts: self.parts,
+            body,
+            copy_settings: self.copy_settings,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "whether or not to copy settings from the source index (defaults to false)"]
     pub fn copy_settings(mut self, copy_settings: Option<bool>) -> Self {
@@ -5807,9 +6089,24 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesSplit<T>
+    where
+        T: Serialize,
+    {
+        IndicesSplit {
+            client: self.client,
+            parts: self.parts,
+            body,
+            copy_settings: self.copy_settings,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "whether or not to copy settings from the source index (defaults to false)"]
     pub fn copy_settings(mut self, copy_settings: Option<bool>) -> Self {
@@ -6233,9 +6530,26 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesUnfreeze<T>
+    where
+        T: Serialize,
+    {
+        IndicesUnfreeze {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6395,9 +6709,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesUpdateAliases<T>
+    where
+        T: Serialize,
+    {
+        IndicesUpdateAliases {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6547,9 +6874,25 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesUpgrade<T>
+    where
+        T: Serialize,
+    {
+        IndicesUpgrade {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            only_ancient_segments: self.only_ancient_segments,
+            pretty: self.pretty,
+            source: self.source,
+            wait_for_completion: self.wait_for_completion,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6765,9 +7108,32 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IndicesValidateQuery<T>
+    where
+        T: Serialize,
+    {
+        IndicesValidateQuery {
+            client: self.client,
+            parts: self.parts,
+            body,
+            all_shards: self.all_shards,
+            allow_no_indices: self.allow_no_indices,
+            analyze_wildcard: self.analyze_wildcard,
+            analyzer: self.analyzer,
+            default_operator: self.default_operator,
+            df: self.df,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            explain: self.explain,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            lenient: self.lenient,
+            pretty: self.pretty,
+            q: self.q,
+            rewrite: self.rewrite,
+            source: self.source,
+        }
     }
     #[doc = "The default operator for query string query (AND or OR)"]
     pub fn default_operator(mut self, default_operator: Option<DefaultOperator>) -> Self {
@@ -6924,38 +7290,23 @@ impl Indices {
         Indices { client }
     }
     #[doc = "Performs the analysis process on a text and return the tokens breakdown of the text."]
-    pub fn analyze<B>(&self, parts: IndicesAnalyzeUrlParts) -> IndicesAnalyze<B>
-    where
-        B: Serialize,
-    {
+    pub fn analyze(&self, parts: IndicesAnalyzeUrlParts) -> IndicesAnalyze<()> {
         IndicesAnalyze::new(self.client.clone(), parts)
     }
     #[doc = "Clears all or specific caches for one or more indices."]
-    pub fn clear_cache<B>(&self, parts: IndicesClearCacheUrlParts) -> IndicesClearCache<B>
-    where
-        B: Serialize,
-    {
+    pub fn clear_cache(&self, parts: IndicesClearCacheUrlParts) -> IndicesClearCache<()> {
         IndicesClearCache::new(self.client.clone(), parts)
     }
     #[doc = "Clones an index"]
-    pub fn clone<B>(&self, parts: IndicesCloneUrlParts) -> IndicesClone<B>
-    where
-        B: Serialize,
-    {
+    pub fn clone(&self, parts: IndicesCloneUrlParts) -> IndicesClone<()> {
         IndicesClone::new(self.client.clone(), parts)
     }
     #[doc = "Closes an index."]
-    pub fn close<B>(&self, parts: IndicesCloseUrlParts) -> IndicesClose<B>
-    where
-        B: Serialize,
-    {
+    pub fn close(&self, parts: IndicesCloseUrlParts) -> IndicesClose<()> {
         IndicesClose::new(self.client.clone(), parts)
     }
     #[doc = "Creates an index with optional settings and mappings."]
-    pub fn create<B>(&self, parts: IndicesCreateUrlParts) -> IndicesCreate<B>
-    where
-        B: Serialize,
-    {
+    pub fn create(&self, parts: IndicesCreateUrlParts) -> IndicesCreate<()> {
         IndicesCreate::new(self.client.clone(), parts)
     }
     #[doc = "Deletes an index."]
@@ -6987,30 +7338,18 @@ impl Indices {
         IndicesExistsType::new(self.client.clone(), parts)
     }
     #[doc = "Performs the flush operation on one or more indices."]
-    pub fn flush<B>(&self, parts: IndicesFlushUrlParts) -> IndicesFlush<B>
-    where
-        B: Serialize,
-    {
+    pub fn flush(&self, parts: IndicesFlushUrlParts) -> IndicesFlush<()> {
         IndicesFlush::new(self.client.clone(), parts)
     }
     #[doc = "Performs a synced flush operation on one or more indices."]
-    pub fn flush_synced<B>(&self, parts: IndicesFlushSyncedUrlParts) -> IndicesFlushSynced<B>
-    where
-        B: Serialize,
-    {
+    pub fn flush_synced(&self, parts: IndicesFlushSyncedUrlParts) -> IndicesFlushSynced<()> {
         IndicesFlushSynced::new(self.client.clone(), parts)
     }
     #[doc = "Performs the force merge operation on one or more indices."]
-    pub fn forcemerge<B>(&self, parts: IndicesForcemergeUrlParts) -> IndicesForcemerge<B>
-    where
-        B: Serialize,
-    {
+    pub fn forcemerge(&self, parts: IndicesForcemergeUrlParts) -> IndicesForcemerge<()> {
         IndicesForcemerge::new(self.client.clone(), parts)
     }
-    pub fn freeze<B>(&self, parts: IndicesFreezeUrlParts) -> IndicesFreeze<B>
-    where
-        B: Serialize,
-    {
+    pub fn freeze(&self, parts: IndicesFreezeUrlParts) -> IndicesFreeze<()> {
         IndicesFreeze::new(self.client.clone(), parts)
     }
     #[doc = "Returns information about one or more indices."]
@@ -7045,38 +7384,23 @@ impl Indices {
         IndicesGetUpgrade::new(self.client.clone(), parts)
     }
     #[doc = "Opens an index."]
-    pub fn open<B>(&self, parts: IndicesOpenUrlParts) -> IndicesOpen<B>
-    where
-        B: Serialize,
-    {
+    pub fn open(&self, parts: IndicesOpenUrlParts) -> IndicesOpen<()> {
         IndicesOpen::new(self.client.clone(), parts)
     }
     #[doc = "Creates or updates an alias."]
-    pub fn put_alias<B>(&self, parts: IndicesPutAliasUrlParts) -> IndicesPutAlias<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_alias(&self, parts: IndicesPutAliasUrlParts) -> IndicesPutAlias<()> {
         IndicesPutAlias::new(self.client.clone(), parts)
     }
     #[doc = "Updates the index mappings."]
-    pub fn put_mapping<B>(&self, parts: IndicesPutMappingUrlParts) -> IndicesPutMapping<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_mapping(&self, parts: IndicesPutMappingUrlParts) -> IndicesPutMapping<()> {
         IndicesPutMapping::new(self.client.clone(), parts)
     }
     #[doc = "Updates the index settings."]
-    pub fn put_settings<B>(&self, parts: IndicesPutSettingsUrlParts) -> IndicesPutSettings<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_settings(&self, parts: IndicesPutSettingsUrlParts) -> IndicesPutSettings<()> {
         IndicesPutSettings::new(self.client.clone(), parts)
     }
     #[doc = "Creates or updates an index template."]
-    pub fn put_template<B>(&self, parts: IndicesPutTemplateUrlParts) -> IndicesPutTemplate<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_template(&self, parts: IndicesPutTemplateUrlParts) -> IndicesPutTemplate<()> {
         IndicesPutTemplate::new(self.client.clone(), parts)
     }
     #[doc = "Returns information about ongoing index shard recoveries."]
@@ -7084,26 +7408,17 @@ impl Indices {
         IndicesRecovery::new(self.client.clone(), parts)
     }
     #[doc = "Performs the refresh operation in one or more indices."]
-    pub fn refresh<B>(&self, parts: IndicesRefreshUrlParts) -> IndicesRefresh<B>
-    where
-        B: Serialize,
-    {
+    pub fn refresh(&self, parts: IndicesRefreshUrlParts) -> IndicesRefresh<()> {
         IndicesRefresh::new(self.client.clone(), parts)
     }
-    pub fn reload_search_analyzers<B>(
+    pub fn reload_search_analyzers(
         &self,
         parts: IndicesReloadSearchAnalyzersUrlParts,
-    ) -> IndicesReloadSearchAnalyzers<B>
-    where
-        B: Serialize,
-    {
+    ) -> IndicesReloadSearchAnalyzers<()> {
         IndicesReloadSearchAnalyzers::new(self.client.clone(), parts)
     }
     #[doc = "Updates an alias to point to a new index when the existing index\nis considered to be too large or too old."]
-    pub fn rollover<B>(&self, parts: IndicesRolloverUrlParts) -> IndicesRollover<B>
-    where
-        B: Serialize,
-    {
+    pub fn rollover(&self, parts: IndicesRolloverUrlParts) -> IndicesRollover<()> {
         IndicesRollover::new(self.client.clone(), parts)
     }
     #[doc = "Provides low-level information about segments in a Lucene index."]
@@ -7115,48 +7430,30 @@ impl Indices {
         IndicesShardStores::new(self.client.clone(), parts)
     }
     #[doc = "Allow to shrink an existing index into a new index with fewer primary shards."]
-    pub fn shrink<B>(&self, parts: IndicesShrinkUrlParts) -> IndicesShrink<B>
-    where
-        B: Serialize,
-    {
+    pub fn shrink(&self, parts: IndicesShrinkUrlParts) -> IndicesShrink<()> {
         IndicesShrink::new(self.client.clone(), parts)
     }
     #[doc = "Allows you to split an existing index into a new index with more primary shards."]
-    pub fn split<B>(&self, parts: IndicesSplitUrlParts) -> IndicesSplit<B>
-    where
-        B: Serialize,
-    {
+    pub fn split(&self, parts: IndicesSplitUrlParts) -> IndicesSplit<()> {
         IndicesSplit::new(self.client.clone(), parts)
     }
     #[doc = "Provides statistics on operations happening in an index."]
     pub fn stats(&self, parts: IndicesStatsUrlParts) -> IndicesStats {
         IndicesStats::new(self.client.clone(), parts)
     }
-    pub fn unfreeze<B>(&self, parts: IndicesUnfreezeUrlParts) -> IndicesUnfreeze<B>
-    where
-        B: Serialize,
-    {
+    pub fn unfreeze(&self, parts: IndicesUnfreezeUrlParts) -> IndicesUnfreeze<()> {
         IndicesUnfreeze::new(self.client.clone(), parts)
     }
     #[doc = "Updates index aliases."]
-    pub fn update_aliases<B>(&self) -> IndicesUpdateAliases<B>
-    where
-        B: Serialize,
-    {
+    pub fn update_aliases(&self) -> IndicesUpdateAliases<()> {
         IndicesUpdateAliases::new(self.client.clone())
     }
     #[doc = "The _upgrade API is no longer useful and will be removed."]
-    pub fn upgrade<B>(&self, parts: IndicesUpgradeUrlParts) -> IndicesUpgrade<B>
-    where
-        B: Serialize,
-    {
+    pub fn upgrade(&self, parts: IndicesUpgradeUrlParts) -> IndicesUpgrade<()> {
         IndicesUpgrade::new(self.client.clone(), parts)
     }
     #[doc = "Allows a user to validate a potentially expensive query without executing it."]
-    pub fn validate_query<B>(&self, parts: IndicesValidateQueryUrlParts) -> IndicesValidateQuery<B>
-    where
-        B: Serialize,
-    {
+    pub fn validate_query(&self, parts: IndicesValidateQueryUrlParts) -> IndicesValidateQuery<()> {
         IndicesValidateQuery::new(self.client.clone(), parts)
     }
 }

--- a/elasticsearch/src/namespace_clients/ingest.rs
+++ b/elasticsearch/src/namespace_clients/ingest.rs
@@ -413,9 +413,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IngestPutPipeline<T>
+    where
+        T: Serialize,
+    {
+        IngestPutPipeline {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -551,9 +564,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> IngestSimulate<T>
+    where
+        T: Serialize,
+    {
+        IngestSimulate {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            verbose: self.verbose,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -654,17 +679,11 @@ impl Ingest {
         IngestProcessorGrok::new(self.client.clone())
     }
     #[doc = "Creates or updates a pipeline."]
-    pub fn put_pipeline<B>(&self, parts: IngestPutPipelineUrlParts) -> IngestPutPipeline<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_pipeline(&self, parts: IngestPutPipelineUrlParts) -> IngestPutPipeline<()> {
         IngestPutPipeline::new(self.client.clone(), parts)
     }
     #[doc = "Allows to simulate a pipeline with example documents."]
-    pub fn simulate<B>(&self, parts: IngestSimulateUrlParts) -> IngestSimulate<B>
-    where
-        B: Serialize,
-    {
+    pub fn simulate(&self, parts: IngestSimulateUrlParts) -> IngestSimulate<()> {
         IngestSimulate::new(self.client.clone(), parts)
     }
 }

--- a/elasticsearch/src/namespace_clients/license.rs
+++ b/elasticsearch/src/namespace_clients/license.rs
@@ -478,9 +478,21 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> LicensePost<T>
+    where
+        T: Serialize,
+    {
+        LicensePost {
+            client: self.client,
+            parts: self.parts,
+            body,
+            acknowledge: self.acknowledge,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -600,9 +612,21 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> LicensePostStartBasic<T>
+    where
+        T: Serialize,
+    {
+        LicensePostStartBasic {
+            client: self.client,
+            parts: self.parts,
+            body,
+            acknowledge: self.acknowledge,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -724,9 +748,22 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> LicensePostStartTrial<T>
+    where
+        T: Serialize,
+    {
+        LicensePostStartTrial {
+            client: self.client,
+            parts: self.parts,
+            body,
+            acknowledge: self.acknowledge,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            ty: self.ty,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -826,22 +863,13 @@ impl License {
     pub fn get_trial_status(&self) -> LicenseGetTrialStatus {
         LicenseGetTrialStatus::new(self.client.clone())
     }
-    pub fn post<B>(&self) -> LicensePost<B>
-    where
-        B: Serialize,
-    {
+    pub fn post(&self) -> LicensePost<()> {
         LicensePost::new(self.client.clone())
     }
-    pub fn post_start_basic<B>(&self) -> LicensePostStartBasic<B>
-    where
-        B: Serialize,
-    {
+    pub fn post_start_basic(&self) -> LicensePostStartBasic<()> {
         LicensePostStartBasic::new(self.client.clone())
     }
-    pub fn post_start_trial<B>(&self) -> LicensePostStartTrial<B>
-    where
-        B: Serialize,
-    {
+    pub fn post_start_trial(&self) -> LicensePostStartTrial<()> {
         LicensePostStartTrial::new(self.client.clone())
     }
 }

--- a/elasticsearch/src/namespace_clients/ml.rs
+++ b/elasticsearch/src/namespace_clients/ml.rs
@@ -82,9 +82,23 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlCloseJob<T>
+    where
+        T: Serialize,
+    {
+        MlCloseJob {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_jobs: self.allow_no_jobs,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            force: self.force,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1319,9 +1333,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlEstimateMemoryUsage<T>
+    where
+        T: Serialize,
+    {
+        MlEstimateMemoryUsage {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1431,9 +1456,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlEvaluateDataFrame<T>
+    where
+        T: Serialize,
+    {
+        MlEvaluateDataFrame {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1571,9 +1607,34 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlFindFileStructure<T>
+    where
+        T: Serialize,
+    {
+        MlFindFileStructure {
+            client: self.client,
+            parts: self.parts,
+            body,
+            charset: self.charset,
+            column_names: self.column_names,
+            delimiter: self.delimiter,
+            error_trace: self.error_trace,
+            explain: self.explain,
+            filter_path: self.filter_path,
+            format: self.format,
+            grok_pattern: self.grok_pattern,
+            has_header_row: self.has_header_row,
+            human: self.human,
+            line_merge_size_limit: self.line_merge_size_limit,
+            lines_to_sample: self.lines_to_sample,
+            pretty: self.pretty,
+            quote: self.quote,
+            should_trim_fields: self.should_trim_fields,
+            source: self.source,
+            timeout: self.timeout,
+            timestamp_field: self.timestamp_field,
+            timestamp_format: self.timestamp_format,
+        }
     }
     #[doc = "Optional parameter to specify the character set of the file"]
     pub fn charset(mut self, charset: Option<String>) -> Self {
@@ -1823,9 +1884,25 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlFlushJob<T>
+    where
+        T: Serialize,
+    {
+        MlFlushJob {
+            client: self.client,
+            parts: self.parts,
+            body,
+            advance_time: self.advance_time,
+            calc_interim: self.calc_interim,
+            end: self.end,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            skip_time: self.skip_time,
+            source: self.source,
+            start: self.start,
+        }
     }
     #[doc = "Calculates interim results for the most recent bucket or all buckets within the latency period"]
     pub fn calc_interim(mut self, calc_interim: Option<bool>) -> Self {
@@ -1980,9 +2057,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlForecast<T>
+    where
+        T: Serialize,
+    {
+        MlForecast {
+            client: self.client,
+            parts: self.parts,
+            body,
+            duration: self.duration,
+            error_trace: self.error_trace,
+            expires_in: self.expires_in,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "The duration of the forecast"]
     pub fn duration(mut self, duration: Option<String>) -> Self {
@@ -2146,9 +2236,29 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlGetBuckets<T>
+    where
+        T: Serialize,
+    {
+        MlGetBuckets {
+            client: self.client,
+            parts: self.parts,
+            body,
+            anomaly_score: self.anomaly_score,
+            desc: self.desc,
+            end: self.end,
+            error_trace: self.error_trace,
+            exclude_interim: self.exclude_interim,
+            expand: self.expand,
+            filter_path: self.filter_path,
+            from: self.from,
+            human: self.human,
+            pretty: self.pretty,
+            size: self.size,
+            sort: self.sort,
+            source: self.source,
+            start: self.start,
+        }
     }
     #[doc = "Set the sort direction"]
     pub fn desc(mut self, desc: Option<bool>) -> Self {
@@ -2494,9 +2604,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlGetCalendars<T>
+    where
+        T: Serialize,
+    {
+        MlGetCalendars {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            from: self.from,
+            human: self.human,
+            pretty: self.pretty,
+            size: self.size,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2645,9 +2768,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlGetCategories<T>
+    where
+        T: Serialize,
+    {
+        MlGetCategories {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            from: self.from,
+            human: self.human,
+            pretty: self.pretty,
+            size: self.size,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -3430,9 +3566,28 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlGetInfluencers<T>
+    where
+        T: Serialize,
+    {
+        MlGetInfluencers {
+            client: self.client,
+            parts: self.parts,
+            body,
+            desc: self.desc,
+            end: self.end,
+            error_trace: self.error_trace,
+            exclude_interim: self.exclude_interim,
+            filter_path: self.filter_path,
+            from: self.from,
+            human: self.human,
+            influencer_score: self.influencer_score,
+            pretty: self.pretty,
+            size: self.size,
+            sort: self.sort,
+            source: self.source,
+            start: self.start,
+        }
     }
     #[doc = "whether the results should be sorted in decending order"]
     pub fn desc(mut self, desc: Option<bool>) -> Self {
@@ -3869,9 +4024,26 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlGetModelSnapshots<T>
+    where
+        T: Serialize,
+    {
+        MlGetModelSnapshots {
+            client: self.client,
+            parts: self.parts,
+            body,
+            desc: self.desc,
+            end: self.end,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            from: self.from,
+            human: self.human,
+            pretty: self.pretty,
+            size: self.size,
+            sort: self.sort,
+            source: self.source,
+            start: self.start,
+        }
     }
     #[doc = "True if the results should be sorted in descending order"]
     pub fn desc(mut self, desc: Option<bool>) -> Self {
@@ -4057,9 +4229,27 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlGetOverallBuckets<T>
+    where
+        T: Serialize,
+    {
+        MlGetOverallBuckets {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_jobs: self.allow_no_jobs,
+            bucket_span: self.bucket_span,
+            end: self.end,
+            error_trace: self.error_trace,
+            exclude_interim: self.exclude_interim,
+            filter_path: self.filter_path,
+            human: self.human,
+            overall_score: self.overall_score,
+            pretty: self.pretty,
+            source: self.source,
+            start: self.start,
+            top_n: self.top_n,
+        }
     }
     #[doc = "The span of the overall buckets. Defaults to the longest job bucket_span"]
     pub fn bucket_span(mut self, bucket_span: Option<String>) -> Self {
@@ -4245,9 +4435,28 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlGetRecords<T>
+    where
+        T: Serialize,
+    {
+        MlGetRecords {
+            client: self.client,
+            parts: self.parts,
+            body,
+            desc: self.desc,
+            end: self.end,
+            error_trace: self.error_trace,
+            exclude_interim: self.exclude_interim,
+            filter_path: self.filter_path,
+            from: self.from,
+            human: self.human,
+            pretty: self.pretty,
+            record_score: self.record_score,
+            size: self.size,
+            sort: self.sort,
+            source: self.source,
+            start: self.start,
+        }
     }
     #[doc = "Set the sort direction"]
     pub fn desc(mut self, desc: Option<bool>) -> Self {
@@ -4528,9 +4737,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlOpenJob<T>
+    where
+        T: Serialize,
+    {
+        MlOpenJob {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -4646,9 +4866,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlPostCalendarEvents<T>
+    where
+        T: Serialize,
+    {
+        MlPostCalendarEvents {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -4768,9 +4999,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlPostData<T>
+    where
+        T: Serialize,
+    {
+        MlPostData {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            reset_end: self.reset_end,
+            reset_start: self.reset_start,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5006,9 +5250,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlPutCalendar<T>
+    where
+        T: Serialize,
+    {
+        MlPutCalendar {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5125,9 +5380,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlPutCalendarJob<T>
+    where
+        T: Serialize,
+    {
+        MlPutCalendarJob {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5242,9 +5508,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlPutDataFrameAnalytics<T>
+    where
+        T: Serialize,
+    {
+        MlPutDataFrameAnalytics {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5359,9 +5636,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlPutDatafeed<T>
+    where
+        T: Serialize,
+    {
+        MlPutDatafeed {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5476,9 +5764,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlPutFilter<T>
+    where
+        T: Serialize,
+    {
+        MlPutFilter {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5593,9 +5892,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlPutJob<T>
+    where
+        T: Serialize,
+    {
+        MlPutJob {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5715,9 +6025,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlRevertModelSnapshot<T>
+    where
+        T: Serialize,
+    {
+        MlRevertModelSnapshot {
+            client: self.client,
+            parts: self.parts,
+            body,
+            delete_intervening_results: self.delete_intervening_results,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Should we reset the results back to the time of the snapshot?"]
     pub fn delete_intervening_results(mut self, delete_intervening_results: Option<bool>) -> Self {
@@ -5842,9 +6164,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlSetUpgradeMode<T>
+    where
+        T: Serialize,
+    {
+        MlSetUpgradeMode {
+            client: self.client,
+            parts: self.parts,
+            body,
+            enabled: self.enabled,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Whether to enable upgrade_mode ML setting or not. Defaults to false."]
     pub fn enabled(mut self, enabled: Option<bool>) -> Self {
@@ -5978,9 +6313,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlStartDataFrameAnalytics<T>
+    where
+        T: Serialize,
+    {
+        MlStartDataFrameAnalytics {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6110,9 +6457,23 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlStartDatafeed<T>
+    where
+        T: Serialize,
+    {
+        MlStartDatafeed {
+            client: self.client,
+            parts: self.parts,
+            body,
+            end: self.end,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            start: self.start,
+            timeout: self.timeout,
+        }
     }
     #[doc = "The end time when the datafeed should stop. When not set, the datafeed continues in real time"]
     pub fn end(mut self, end: Option<String>) -> Self {
@@ -6263,9 +6624,23 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlStopDataFrameAnalytics<T>
+    where
+        T: Serialize,
+    {
+        MlStopDataFrameAnalytics {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_match: self.allow_no_match,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            force: self.force,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6411,9 +6786,23 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlStopDatafeed<T>
+    where
+        T: Serialize,
+    {
+        MlStopDatafeed {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_datafeeds: self.allow_no_datafeeds,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            force: self.force,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6548,9 +6937,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlUpdateDatafeed<T>
+    where
+        T: Serialize,
+    {
+        MlUpdateDatafeed {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6666,9 +7066,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlUpdateFilter<T>
+    where
+        T: Serialize,
+    {
+        MlUpdateFilter {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6784,9 +7195,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlUpdateJob<T>
+    where
+        T: Serialize,
+    {
+        MlUpdateJob {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6904,9 +7326,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlUpdateModelSnapshot<T>
+    where
+        T: Serialize,
+    {
+        MlUpdateModelSnapshot {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -7016,9 +7449,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlValidate<T>
+    where
+        T: Serialize,
+    {
+        MlValidate {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -7128,9 +7572,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MlValidateDetector<T>
+    where
+        T: Serialize,
+    {
+        MlValidateDetector {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -7207,10 +7662,7 @@ impl Ml {
     pub fn new(client: Elasticsearch) -> Self {
         Ml { client }
     }
-    pub fn close_job<B>(&self, parts: MlCloseJobUrlParts) -> MlCloseJob<B>
-    where
-        B: Serialize,
-    {
+    pub fn close_job(&self, parts: MlCloseJobUrlParts) -> MlCloseJob<()> {
         MlCloseJob::new(self.client.clone(), parts)
     }
     pub fn delete_calendar(&self, parts: MlDeleteCalendarUrlParts) -> MlDeleteCalendar {
@@ -7252,55 +7704,31 @@ impl Ml {
     ) -> MlDeleteModelSnapshot {
         MlDeleteModelSnapshot::new(self.client.clone(), parts)
     }
-    pub fn estimate_memory_usage<B>(&self) -> MlEstimateMemoryUsage<B>
-    where
-        B: Serialize,
-    {
+    pub fn estimate_memory_usage(&self) -> MlEstimateMemoryUsage<()> {
         MlEstimateMemoryUsage::new(self.client.clone())
     }
-    pub fn evaluate_data_frame<B>(&self) -> MlEvaluateDataFrame<B>
-    where
-        B: Serialize,
-    {
+    pub fn evaluate_data_frame(&self) -> MlEvaluateDataFrame<()> {
         MlEvaluateDataFrame::new(self.client.clone())
     }
-    pub fn find_file_structure<B>(&self) -> MlFindFileStructure<B>
-    where
-        B: Serialize,
-    {
+    pub fn find_file_structure(&self) -> MlFindFileStructure<()> {
         MlFindFileStructure::new(self.client.clone())
     }
-    pub fn flush_job<B>(&self, parts: MlFlushJobUrlParts) -> MlFlushJob<B>
-    where
-        B: Serialize,
-    {
+    pub fn flush_job(&self, parts: MlFlushJobUrlParts) -> MlFlushJob<()> {
         MlFlushJob::new(self.client.clone(), parts)
     }
-    pub fn forecast<B>(&self, parts: MlForecastUrlParts) -> MlForecast<B>
-    where
-        B: Serialize,
-    {
+    pub fn forecast(&self, parts: MlForecastUrlParts) -> MlForecast<()> {
         MlForecast::new(self.client.clone(), parts)
     }
-    pub fn get_buckets<B>(&self, parts: MlGetBucketsUrlParts) -> MlGetBuckets<B>
-    where
-        B: Serialize,
-    {
+    pub fn get_buckets(&self, parts: MlGetBucketsUrlParts) -> MlGetBuckets<()> {
         MlGetBuckets::new(self.client.clone(), parts)
     }
     pub fn get_calendar_events(&self, parts: MlGetCalendarEventsUrlParts) -> MlGetCalendarEvents {
         MlGetCalendarEvents::new(self.client.clone(), parts)
     }
-    pub fn get_calendars<B>(&self, parts: MlGetCalendarsUrlParts) -> MlGetCalendars<B>
-    where
-        B: Serialize,
-    {
+    pub fn get_calendars(&self, parts: MlGetCalendarsUrlParts) -> MlGetCalendars<()> {
         MlGetCalendars::new(self.client.clone(), parts)
     }
-    pub fn get_categories<B>(&self, parts: MlGetCategoriesUrlParts) -> MlGetCategories<B>
-    where
-        B: Serialize,
-    {
+    pub fn get_categories(&self, parts: MlGetCategoriesUrlParts) -> MlGetCategories<()> {
         MlGetCategories::new(self.client.clone(), parts)
     }
     pub fn get_data_frame_analytics(
@@ -7324,10 +7752,7 @@ impl Ml {
     pub fn get_filters(&self, parts: MlGetFiltersUrlParts) -> MlGetFilters {
         MlGetFilters::new(self.client.clone(), parts)
     }
-    pub fn get_influencers<B>(&self, parts: MlGetInfluencersUrlParts) -> MlGetInfluencers<B>
-    where
-        B: Serialize,
-    {
+    pub fn get_influencers(&self, parts: MlGetInfluencersUrlParts) -> MlGetInfluencers<()> {
         MlGetInfluencers::new(self.client.clone(), parts)
     }
     pub fn get_job_stats(&self, parts: MlGetJobStatsUrlParts) -> MlGetJobStats {
@@ -7336,178 +7761,106 @@ impl Ml {
     pub fn get_jobs(&self, parts: MlGetJobsUrlParts) -> MlGetJobs {
         MlGetJobs::new(self.client.clone(), parts)
     }
-    pub fn get_model_snapshots<B>(
+    pub fn get_model_snapshots(
         &self,
         parts: MlGetModelSnapshotsUrlParts,
-    ) -> MlGetModelSnapshots<B>
-    where
-        B: Serialize,
-    {
+    ) -> MlGetModelSnapshots<()> {
         MlGetModelSnapshots::new(self.client.clone(), parts)
     }
-    pub fn get_overall_buckets<B>(
+    pub fn get_overall_buckets(
         &self,
         parts: MlGetOverallBucketsUrlParts,
-    ) -> MlGetOverallBuckets<B>
-    where
-        B: Serialize,
-    {
+    ) -> MlGetOverallBuckets<()> {
         MlGetOverallBuckets::new(self.client.clone(), parts)
     }
-    pub fn get_records<B>(&self, parts: MlGetRecordsUrlParts) -> MlGetRecords<B>
-    where
-        B: Serialize,
-    {
+    pub fn get_records(&self, parts: MlGetRecordsUrlParts) -> MlGetRecords<()> {
         MlGetRecords::new(self.client.clone(), parts)
     }
     pub fn info(&self) -> MlInfo {
         MlInfo::new(self.client.clone())
     }
-    pub fn open_job<B>(&self, parts: MlOpenJobUrlParts) -> MlOpenJob<B>
-    where
-        B: Serialize,
-    {
+    pub fn open_job(&self, parts: MlOpenJobUrlParts) -> MlOpenJob<()> {
         MlOpenJob::new(self.client.clone(), parts)
     }
-    pub fn post_calendar_events<B>(
+    pub fn post_calendar_events(
         &self,
         parts: MlPostCalendarEventsUrlParts,
-    ) -> MlPostCalendarEvents<B>
-    where
-        B: Serialize,
-    {
+    ) -> MlPostCalendarEvents<()> {
         MlPostCalendarEvents::new(self.client.clone(), parts)
     }
-    pub fn post_data<B>(&self, parts: MlPostDataUrlParts) -> MlPostData<B>
-    where
-        B: Serialize,
-    {
+    pub fn post_data(&self, parts: MlPostDataUrlParts) -> MlPostData<()> {
         MlPostData::new(self.client.clone(), parts)
     }
     pub fn preview_datafeed(&self, parts: MlPreviewDatafeedUrlParts) -> MlPreviewDatafeed {
         MlPreviewDatafeed::new(self.client.clone(), parts)
     }
-    pub fn put_calendar<B>(&self, parts: MlPutCalendarUrlParts) -> MlPutCalendar<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_calendar(&self, parts: MlPutCalendarUrlParts) -> MlPutCalendar<()> {
         MlPutCalendar::new(self.client.clone(), parts)
     }
-    pub fn put_calendar_job<B>(&self, parts: MlPutCalendarJobUrlParts) -> MlPutCalendarJob<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_calendar_job(&self, parts: MlPutCalendarJobUrlParts) -> MlPutCalendarJob<()> {
         MlPutCalendarJob::new(self.client.clone(), parts)
     }
-    pub fn put_data_frame_analytics<B>(
+    pub fn put_data_frame_analytics(
         &self,
         parts: MlPutDataFrameAnalyticsUrlParts,
-    ) -> MlPutDataFrameAnalytics<B>
-    where
-        B: Serialize,
-    {
+    ) -> MlPutDataFrameAnalytics<()> {
         MlPutDataFrameAnalytics::new(self.client.clone(), parts)
     }
-    pub fn put_datafeed<B>(&self, parts: MlPutDatafeedUrlParts) -> MlPutDatafeed<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_datafeed(&self, parts: MlPutDatafeedUrlParts) -> MlPutDatafeed<()> {
         MlPutDatafeed::new(self.client.clone(), parts)
     }
-    pub fn put_filter<B>(&self, parts: MlPutFilterUrlParts) -> MlPutFilter<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_filter(&self, parts: MlPutFilterUrlParts) -> MlPutFilter<()> {
         MlPutFilter::new(self.client.clone(), parts)
     }
-    pub fn put_job<B>(&self, parts: MlPutJobUrlParts) -> MlPutJob<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_job(&self, parts: MlPutJobUrlParts) -> MlPutJob<()> {
         MlPutJob::new(self.client.clone(), parts)
     }
-    pub fn revert_model_snapshot<B>(
+    pub fn revert_model_snapshot(
         &self,
         parts: MlRevertModelSnapshotUrlParts,
-    ) -> MlRevertModelSnapshot<B>
-    where
-        B: Serialize,
-    {
+    ) -> MlRevertModelSnapshot<()> {
         MlRevertModelSnapshot::new(self.client.clone(), parts)
     }
-    pub fn set_upgrade_mode<B>(&self) -> MlSetUpgradeMode<B>
-    where
-        B: Serialize,
-    {
+    pub fn set_upgrade_mode(&self) -> MlSetUpgradeMode<()> {
         MlSetUpgradeMode::new(self.client.clone())
     }
-    pub fn start_data_frame_analytics<B>(
+    pub fn start_data_frame_analytics(
         &self,
         parts: MlStartDataFrameAnalyticsUrlParts,
-    ) -> MlStartDataFrameAnalytics<B>
-    where
-        B: Serialize,
-    {
+    ) -> MlStartDataFrameAnalytics<()> {
         MlStartDataFrameAnalytics::new(self.client.clone(), parts)
     }
-    pub fn start_datafeed<B>(&self, parts: MlStartDatafeedUrlParts) -> MlStartDatafeed<B>
-    where
-        B: Serialize,
-    {
+    pub fn start_datafeed(&self, parts: MlStartDatafeedUrlParts) -> MlStartDatafeed<()> {
         MlStartDatafeed::new(self.client.clone(), parts)
     }
-    pub fn stop_data_frame_analytics<B>(
+    pub fn stop_data_frame_analytics(
         &self,
         parts: MlStopDataFrameAnalyticsUrlParts,
-    ) -> MlStopDataFrameAnalytics<B>
-    where
-        B: Serialize,
-    {
+    ) -> MlStopDataFrameAnalytics<()> {
         MlStopDataFrameAnalytics::new(self.client.clone(), parts)
     }
-    pub fn stop_datafeed<B>(&self, parts: MlStopDatafeedUrlParts) -> MlStopDatafeed<B>
-    where
-        B: Serialize,
-    {
+    pub fn stop_datafeed(&self, parts: MlStopDatafeedUrlParts) -> MlStopDatafeed<()> {
         MlStopDatafeed::new(self.client.clone(), parts)
     }
-    pub fn update_datafeed<B>(&self, parts: MlUpdateDatafeedUrlParts) -> MlUpdateDatafeed<B>
-    where
-        B: Serialize,
-    {
+    pub fn update_datafeed(&self, parts: MlUpdateDatafeedUrlParts) -> MlUpdateDatafeed<()> {
         MlUpdateDatafeed::new(self.client.clone(), parts)
     }
-    pub fn update_filter<B>(&self, parts: MlUpdateFilterUrlParts) -> MlUpdateFilter<B>
-    where
-        B: Serialize,
-    {
+    pub fn update_filter(&self, parts: MlUpdateFilterUrlParts) -> MlUpdateFilter<()> {
         MlUpdateFilter::new(self.client.clone(), parts)
     }
-    pub fn update_job<B>(&self, parts: MlUpdateJobUrlParts) -> MlUpdateJob<B>
-    where
-        B: Serialize,
-    {
+    pub fn update_job(&self, parts: MlUpdateJobUrlParts) -> MlUpdateJob<()> {
         MlUpdateJob::new(self.client.clone(), parts)
     }
-    pub fn update_model_snapshot<B>(
+    pub fn update_model_snapshot(
         &self,
         parts: MlUpdateModelSnapshotUrlParts,
-    ) -> MlUpdateModelSnapshot<B>
-    where
-        B: Serialize,
-    {
+    ) -> MlUpdateModelSnapshot<()> {
         MlUpdateModelSnapshot::new(self.client.clone(), parts)
     }
-    pub fn validate<B>(&self) -> MlValidate<B>
-    where
-        B: Serialize,
-    {
+    pub fn validate(&self) -> MlValidate<()> {
         MlValidate::new(self.client.clone())
     }
-    pub fn validate_detector<B>(&self) -> MlValidateDetector<B>
-    where
-        B: Serialize,
-    {
+    pub fn validate_detector(&self) -> MlValidateDetector<()> {
         MlValidateDetector::new(self.client.clone())
     }
 }

--- a/elasticsearch/src/namespace_clients/monitoring.rs
+++ b/elasticsearch/src/namespace_clients/monitoring.rs
@@ -79,9 +79,23 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MonitoringBulk<T>
+    where
+        T: Serialize,
+    {
+        MonitoringBulk {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            interval: self.interval,
+            pretty: self.pretty,
+            source: self.source,
+            system_api_version: self.system_api_version,
+            system_id: self.system_id,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -182,10 +196,7 @@ impl Monitoring {
     pub fn new(client: Elasticsearch) -> Self {
         Monitoring { client }
     }
-    pub fn bulk<B>(&self, parts: MonitoringBulkUrlParts) -> MonitoringBulk<B>
-    where
-        B: Serialize,
-    {
+    pub fn bulk(&self, parts: MonitoringBulkUrlParts) -> MonitoringBulk<()> {
         MonitoringBulk::new(self.client.clone(), parts)
     }
 }

--- a/elasticsearch/src/namespace_clients/nodes.rs
+++ b/elasticsearch/src/namespace_clients/nodes.rs
@@ -393,9 +393,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> NodesReloadSecureSettings<T>
+    where
+        T: Serialize,
+    {
+        NodesReloadSecureSettings {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -884,13 +896,10 @@ impl Nodes {
         NodesInfo::new(self.client.clone(), parts)
     }
     #[doc = "Reloads secure settings."]
-    pub fn reload_secure_settings<B>(
+    pub fn reload_secure_settings(
         &self,
         parts: NodesReloadSecureSettingsUrlParts,
-    ) -> NodesReloadSecureSettings<B>
-    where
-        B: Serialize,
-    {
+    ) -> NodesReloadSecureSettings<()> {
         NodesReloadSecureSettings::new(self.client.clone(), parts)
     }
     #[doc = "Returns statistical information about nodes in the cluster."]

--- a/elasticsearch/src/namespace_clients/rollup.rs
+++ b/elasticsearch/src/namespace_clients/rollup.rs
@@ -491,9 +491,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> RollupPutJob<T>
+    where
+        T: Serialize,
+    {
+        RollupPutJob {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -625,9 +636,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> RollupRollupSearch<T>
+    where
+        T: Serialize,
+    {
+        RollupRollupSearch {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            rest_total_hits_as_int: self.rest_total_hits_as_int,
+            source: self.source,
+            typed_keys: self.typed_keys,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -765,9 +789,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> RollupStartJob<T>
+    where
+        T: Serialize,
+    {
+        RollupStartJob {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -887,9 +922,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> RollupStopJob<T>
+    where
+        T: Serialize,
+    {
+        RollupStopJob {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_completion: self.wait_for_completion,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1000,28 +1048,16 @@ impl Rollup {
     ) -> RollupGetRollupIndexCaps {
         RollupGetRollupIndexCaps::new(self.client.clone(), parts)
     }
-    pub fn put_job<B>(&self, parts: RollupPutJobUrlParts) -> RollupPutJob<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_job(&self, parts: RollupPutJobUrlParts) -> RollupPutJob<()> {
         RollupPutJob::new(self.client.clone(), parts)
     }
-    pub fn rollup_search<B>(&self, parts: RollupRollupSearchUrlParts) -> RollupRollupSearch<B>
-    where
-        B: Serialize,
-    {
+    pub fn rollup_search(&self, parts: RollupRollupSearchUrlParts) -> RollupRollupSearch<()> {
         RollupRollupSearch::new(self.client.clone(), parts)
     }
-    pub fn start_job<B>(&self, parts: RollupStartJobUrlParts) -> RollupStartJob<B>
-    where
-        B: Serialize,
-    {
+    pub fn start_job(&self, parts: RollupStartJobUrlParts) -> RollupStartJob<()> {
         RollupStartJob::new(self.client.clone(), parts)
     }
-    pub fn stop_job<B>(&self, parts: RollupStopJobUrlParts) -> RollupStopJob<B>
-    where
-        B: Serialize,
-    {
+    pub fn stop_job(&self, parts: RollupStopJobUrlParts) -> RollupStopJob<()> {
         RollupStopJob::new(self.client.clone(), parts)
     }
 }

--- a/elasticsearch/src/namespace_clients/security.rs
+++ b/elasticsearch/src/namespace_clients/security.rs
@@ -174,9 +174,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityChangePassword<T>
+    where
+        T: Serialize,
+    {
+        SecurityChangePassword {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -303,9 +315,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityClearCachedRealms<T>
+    where
+        T: Serialize,
+    {
+        SecurityClearCachedRealms {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+            usernames: self.usernames,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -434,9 +458,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityClearCachedRoles<T>
+    where
+        T: Serialize,
+    {
+        SecurityClearCachedRoles {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -548,9 +583,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityCreateApiKey<T>
+    where
+        T: Serialize,
+    {
+        SecurityCreateApiKey {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1134,9 +1181,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityDisableUser<T>
+    where
+        T: Serialize,
+    {
+        SecurityDisableUser {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1262,9 +1321,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityEnableUser<T>
+    where
+        T: Serialize,
+    {
+        SecurityEnableUser {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1947,9 +2018,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityGetToken<T>
+    where
+        T: Serialize,
+    {
+        SecurityGetToken {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2273,9 +2355,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityHasPrivileges<T>
+    where
+        T: Serialize,
+    {
+        SecurityHasPrivileges {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2388,9 +2481,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityInvalidateApiKey<T>
+    where
+        T: Serialize,
+    {
+        SecurityInvalidateApiKey {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2500,9 +2604,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityInvalidateToken<T>
+    where
+        T: Serialize,
+    {
+        SecurityInvalidateToken {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2614,9 +2729,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityPutPrivileges<T>
+    where
+        T: Serialize,
+    {
+        SecurityPutPrivileges {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2741,9 +2868,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityPutRole<T>
+    where
+        T: Serialize,
+    {
+        SecurityPutRole {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2868,9 +3007,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityPutRoleMapping<T>
+    where
+        T: Serialize,
+    {
+        SecurityPutRoleMapping {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2995,9 +3146,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SecurityPutUser<T>
+    where
+        T: Serialize,
+    {
+        SecurityPutUser {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -3085,37 +3248,25 @@ impl Security {
     pub fn authenticate(&self) -> SecurityAuthenticate {
         SecurityAuthenticate::new(self.client.clone())
     }
-    pub fn change_password<B>(
+    pub fn change_password(
         &self,
         parts: SecurityChangePasswordUrlParts,
-    ) -> SecurityChangePassword<B>
-    where
-        B: Serialize,
-    {
+    ) -> SecurityChangePassword<()> {
         SecurityChangePassword::new(self.client.clone(), parts)
     }
-    pub fn clear_cached_realms<B>(
+    pub fn clear_cached_realms(
         &self,
         parts: SecurityClearCachedRealmsUrlParts,
-    ) -> SecurityClearCachedRealms<B>
-    where
-        B: Serialize,
-    {
+    ) -> SecurityClearCachedRealms<()> {
         SecurityClearCachedRealms::new(self.client.clone(), parts)
     }
-    pub fn clear_cached_roles<B>(
+    pub fn clear_cached_roles(
         &self,
         parts: SecurityClearCachedRolesUrlParts,
-    ) -> SecurityClearCachedRoles<B>
-    where
-        B: Serialize,
-    {
+    ) -> SecurityClearCachedRoles<()> {
         SecurityClearCachedRoles::new(self.client.clone(), parts)
     }
-    pub fn create_api_key<B>(&self) -> SecurityCreateApiKey<B>
-    where
-        B: Serialize,
-    {
+    pub fn create_api_key(&self) -> SecurityCreateApiKey<()> {
         SecurityCreateApiKey::new(self.client.clone())
     }
     pub fn delete_privileges(
@@ -3136,16 +3287,10 @@ impl Security {
     pub fn delete_user(&self, parts: SecurityDeleteUserUrlParts) -> SecurityDeleteUser {
         SecurityDeleteUser::new(self.client.clone(), parts)
     }
-    pub fn disable_user<B>(&self, parts: SecurityDisableUserUrlParts) -> SecurityDisableUser<B>
-    where
-        B: Serialize,
-    {
+    pub fn disable_user(&self, parts: SecurityDisableUserUrlParts) -> SecurityDisableUser<()> {
         SecurityDisableUser::new(self.client.clone(), parts)
     }
-    pub fn enable_user<B>(&self, parts: SecurityEnableUserUrlParts) -> SecurityEnableUser<B>
-    where
-        B: Serialize,
-    {
+    pub fn enable_user(&self, parts: SecurityEnableUserUrlParts) -> SecurityEnableUser<()> {
         SecurityEnableUser::new(self.client.clone(), parts)
     }
     pub fn get_api_key(&self) -> SecurityGetApiKey {
@@ -3166,10 +3311,7 @@ impl Security {
     ) -> SecurityGetRoleMapping {
         SecurityGetRoleMapping::new(self.client.clone(), parts)
     }
-    pub fn get_token<B>(&self) -> SecurityGetToken<B>
-    where
-        B: Serialize,
-    {
+    pub fn get_token(&self) -> SecurityGetToken<()> {
         SecurityGetToken::new(self.client.clone())
     }
     pub fn get_user(&self, parts: SecurityGetUserUrlParts) -> SecurityGetUser {
@@ -3178,52 +3320,31 @@ impl Security {
     pub fn get_user_privileges(&self) -> SecurityGetUserPrivileges {
         SecurityGetUserPrivileges::new(self.client.clone())
     }
-    pub fn has_privileges<B>(
+    pub fn has_privileges(
         &self,
         parts: SecurityHasPrivilegesUrlParts,
-    ) -> SecurityHasPrivileges<B>
-    where
-        B: Serialize,
-    {
+    ) -> SecurityHasPrivileges<()> {
         SecurityHasPrivileges::new(self.client.clone(), parts)
     }
-    pub fn invalidate_api_key<B>(&self) -> SecurityInvalidateApiKey<B>
-    where
-        B: Serialize,
-    {
+    pub fn invalidate_api_key(&self) -> SecurityInvalidateApiKey<()> {
         SecurityInvalidateApiKey::new(self.client.clone())
     }
-    pub fn invalidate_token<B>(&self) -> SecurityInvalidateToken<B>
-    where
-        B: Serialize,
-    {
+    pub fn invalidate_token(&self) -> SecurityInvalidateToken<()> {
         SecurityInvalidateToken::new(self.client.clone())
     }
-    pub fn put_privileges<B>(&self) -> SecurityPutPrivileges<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_privileges(&self) -> SecurityPutPrivileges<()> {
         SecurityPutPrivileges::new(self.client.clone())
     }
-    pub fn put_role<B>(&self, parts: SecurityPutRoleUrlParts) -> SecurityPutRole<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_role(&self, parts: SecurityPutRoleUrlParts) -> SecurityPutRole<()> {
         SecurityPutRole::new(self.client.clone(), parts)
     }
-    pub fn put_role_mapping<B>(
+    pub fn put_role_mapping(
         &self,
         parts: SecurityPutRoleMappingUrlParts,
-    ) -> SecurityPutRoleMapping<B>
-    where
-        B: Serialize,
-    {
+    ) -> SecurityPutRoleMapping<()> {
         SecurityPutRoleMapping::new(self.client.clone(), parts)
     }
-    pub fn put_user<B>(&self, parts: SecurityPutUserUrlParts) -> SecurityPutUser<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_user(&self, parts: SecurityPutUserUrlParts) -> SecurityPutUser<()> {
         SecurityPutUser::new(self.client.clone(), parts)
     }
 }

--- a/elasticsearch/src/namespace_clients/slm.rs
+++ b/elasticsearch/src/namespace_clients/slm.rs
@@ -175,9 +175,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SlmExecuteLifecycle<T>
+    where
+        T: Serialize,
+    {
+        SlmExecuteLifecycle {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -398,9 +409,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SlmPutLifecycle<T>
+    where
+        T: Serialize,
+    {
+        SlmPutLifecycle {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -480,19 +502,13 @@ impl Slm {
     pub fn delete_lifecycle(&self, parts: SlmDeleteLifecycleUrlParts) -> SlmDeleteLifecycle {
         SlmDeleteLifecycle::new(self.client.clone(), parts)
     }
-    pub fn execute_lifecycle<B>(&self, parts: SlmExecuteLifecycleUrlParts) -> SlmExecuteLifecycle<B>
-    where
-        B: Serialize,
-    {
+    pub fn execute_lifecycle(&self, parts: SlmExecuteLifecycleUrlParts) -> SlmExecuteLifecycle<()> {
         SlmExecuteLifecycle::new(self.client.clone(), parts)
     }
     pub fn get_lifecycle(&self, parts: SlmGetLifecycleUrlParts) -> SlmGetLifecycle {
         SlmGetLifecycle::new(self.client.clone(), parts)
     }
-    pub fn put_lifecycle<B>(&self, parts: SlmPutLifecycleUrlParts) -> SlmPutLifecycle<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_lifecycle(&self, parts: SlmPutLifecycleUrlParts) -> SlmPutLifecycle<()> {
         SlmPutLifecycle::new(self.client.clone(), parts)
     }
 }

--- a/elasticsearch/src/namespace_clients/snapshot.rs
+++ b/elasticsearch/src/namespace_clients/snapshot.rs
@@ -75,9 +75,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SnapshotCleanupRepository<T>
+    where
+        T: Serialize,
+    {
+        SnapshotCleanupRepository {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -214,9 +227,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SnapshotCreate<T>
+    where
+        T: Serialize,
+    {
+        SnapshotCreate {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            wait_for_completion: self.wait_for_completion,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -356,9 +382,23 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SnapshotCreateRepository<T>
+    where
+        T: Serialize,
+    {
+        SnapshotCreateRepository {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+            verify: self.verify,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1009,9 +1049,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SnapshotRestore<T>
+    where
+        T: Serialize,
+    {
+        SnapshotRestore {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            wait_for_completion: self.wait_for_completion,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1288,9 +1341,22 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SnapshotVerifyRepository<T>
+    where
+        T: Serialize,
+    {
+        SnapshotVerifyRepository {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1384,30 +1450,21 @@ impl Snapshot {
         Snapshot { client }
     }
     #[doc = "Removes stale data from repository."]
-    pub fn cleanup_repository<B>(
+    pub fn cleanup_repository(
         &self,
         parts: SnapshotCleanupRepositoryUrlParts,
-    ) -> SnapshotCleanupRepository<B>
-    where
-        B: Serialize,
-    {
+    ) -> SnapshotCleanupRepository<()> {
         SnapshotCleanupRepository::new(self.client.clone(), parts)
     }
     #[doc = "Creates a snapshot in a repository."]
-    pub fn create<B>(&self, parts: SnapshotCreateUrlParts) -> SnapshotCreate<B>
-    where
-        B: Serialize,
-    {
+    pub fn create(&self, parts: SnapshotCreateUrlParts) -> SnapshotCreate<()> {
         SnapshotCreate::new(self.client.clone(), parts)
     }
     #[doc = "Creates a repository."]
-    pub fn create_repository<B>(
+    pub fn create_repository(
         &self,
         parts: SnapshotCreateRepositoryUrlParts,
-    ) -> SnapshotCreateRepository<B>
-    where
-        B: Serialize,
-    {
+    ) -> SnapshotCreateRepository<()> {
         SnapshotCreateRepository::new(self.client.clone(), parts)
     }
     #[doc = "Deletes a snapshot."]
@@ -1430,10 +1487,7 @@ impl Snapshot {
         SnapshotGetRepository::new(self.client.clone(), parts)
     }
     #[doc = "Restores a snapshot."]
-    pub fn restore<B>(&self, parts: SnapshotRestoreUrlParts) -> SnapshotRestore<B>
-    where
-        B: Serialize,
-    {
+    pub fn restore(&self, parts: SnapshotRestoreUrlParts) -> SnapshotRestore<()> {
         SnapshotRestore::new(self.client.clone(), parts)
     }
     #[doc = "Returns information about the status of a snapshot."]
@@ -1441,13 +1495,10 @@ impl Snapshot {
         SnapshotStatus::new(self.client.clone(), parts)
     }
     #[doc = "Verifies a repository."]
-    pub fn verify_repository<B>(
+    pub fn verify_repository(
         &self,
         parts: SnapshotVerifyRepositoryUrlParts,
-    ) -> SnapshotVerifyRepository<B>
-    where
-        B: Serialize,
-    {
+    ) -> SnapshotVerifyRepository<()> {
         SnapshotVerifyRepository::new(self.client.clone(), parts)
     }
 }

--- a/elasticsearch/src/namespace_clients/sql.rs
+++ b/elasticsearch/src/namespace_clients/sql.rs
@@ -65,9 +65,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SqlClearCursor<T>
+    where
+        T: Serialize,
+    {
+        SqlClearCursor {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -179,9 +190,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SqlQuery<T>
+    where
+        T: Serialize,
+    {
+        SqlQuery {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            format: self.format,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -302,9 +325,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SqlTranslate<T>
+    where
+        T: Serialize,
+    {
+        SqlTranslate {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -384,22 +418,13 @@ impl Sql {
     pub fn new(client: Elasticsearch) -> Self {
         Sql { client }
     }
-    pub fn clear_cursor<B>(&self) -> SqlClearCursor<B>
-    where
-        B: Serialize,
-    {
+    pub fn clear_cursor(&self) -> SqlClearCursor<()> {
         SqlClearCursor::new(self.client.clone())
     }
-    pub fn query<B>(&self) -> SqlQuery<B>
-    where
-        B: Serialize,
-    {
+    pub fn query(&self) -> SqlQuery<()> {
         SqlQuery::new(self.client.clone())
     }
-    pub fn translate<B>(&self) -> SqlTranslate<B>
-    where
-        B: Serialize,
-    {
+    pub fn translate(&self) -> SqlTranslate<()> {
         SqlTranslate::new(self.client.clone())
     }
 }

--- a/elasticsearch/src/namespace_clients/tasks.rs
+++ b/elasticsearch/src/namespace_clients/tasks.rs
@@ -84,9 +84,23 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> TasksCancel<T>
+    where
+        T: Serialize,
+    {
+        TasksCancel {
+            client: self.client,
+            parts: self.parts,
+            body,
+            actions: self.actions,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            nodes: self.nodes,
+            parent_task_id: self.parent_task_id,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -498,10 +512,7 @@ impl Tasks {
         Tasks { client }
     }
     #[doc = "Cancels a task, if it can be cancelled through an API."]
-    pub fn cancel<B>(&self, parts: TasksCancelUrlParts) -> TasksCancel<B>
-    where
-        B: Serialize,
-    {
+    pub fn cancel(&self, parts: TasksCancelUrlParts) -> TasksCancel<()> {
         TasksCancel::new(self.client.clone(), parts)
     }
     #[doc = "Returns information about a task."]

--- a/elasticsearch/src/namespace_clients/watcher.rs
+++ b/elasticsearch/src/namespace_clients/watcher.rs
@@ -81,9 +81,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> WatcherAckWatch<T>
+    where
+        T: Serialize,
+    {
+        WatcherAckWatch {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -199,9 +210,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> WatcherActivateWatch<T>
+    where
+        T: Serialize,
+    {
+        WatcherActivateWatch {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -317,9 +339,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> WatcherDeactivateWatch<T>
+    where
+        T: Serialize,
+    {
+        WatcherDeactivateWatch {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -543,9 +576,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> WatcherExecuteWatch<T>
+    where
+        T: Serialize,
+    {
+        WatcherExecuteWatch {
+            client: self.client,
+            parts: self.parts,
+            body,
+            debug: self.debug,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "indicates whether the watch should execute in debug mode"]
     pub fn debug(mut self, debug: Option<bool>) -> Self {
@@ -785,9 +830,24 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> WatcherPutWatch<T>
+    where
+        T: Serialize,
+    {
+        WatcherPutWatch {
+            client: self.client,
+            parts: self.parts,
+            body,
+            active: self.active,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            if_primary_term: self.if_primary_term,
+            if_seq_no: self.if_seq_no,
+            pretty: self.pretty,
+            source: self.source,
+            version: self.version,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -924,9 +984,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> WatcherStart<T>
+    where
+        T: Serialize,
+    {
+        WatcherStart {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1167,9 +1238,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> WatcherStop<T>
+    where
+        T: Serialize,
+    {
+        WatcherStop {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1246,58 +1328,37 @@ impl Watcher {
     pub fn new(client: Elasticsearch) -> Self {
         Watcher { client }
     }
-    pub fn ack_watch<B>(&self, parts: WatcherAckWatchUrlParts) -> WatcherAckWatch<B>
-    where
-        B: Serialize,
-    {
+    pub fn ack_watch(&self, parts: WatcherAckWatchUrlParts) -> WatcherAckWatch<()> {
         WatcherAckWatch::new(self.client.clone(), parts)
     }
-    pub fn activate_watch<B>(&self, parts: WatcherActivateWatchUrlParts) -> WatcherActivateWatch<B>
-    where
-        B: Serialize,
-    {
+    pub fn activate_watch(&self, parts: WatcherActivateWatchUrlParts) -> WatcherActivateWatch<()> {
         WatcherActivateWatch::new(self.client.clone(), parts)
     }
-    pub fn deactivate_watch<B>(
+    pub fn deactivate_watch(
         &self,
         parts: WatcherDeactivateWatchUrlParts,
-    ) -> WatcherDeactivateWatch<B>
-    where
-        B: Serialize,
-    {
+    ) -> WatcherDeactivateWatch<()> {
         WatcherDeactivateWatch::new(self.client.clone(), parts)
     }
     pub fn delete_watch(&self, parts: WatcherDeleteWatchUrlParts) -> WatcherDeleteWatch {
         WatcherDeleteWatch::new(self.client.clone(), parts)
     }
-    pub fn execute_watch<B>(&self, parts: WatcherExecuteWatchUrlParts) -> WatcherExecuteWatch<B>
-    where
-        B: Serialize,
-    {
+    pub fn execute_watch(&self, parts: WatcherExecuteWatchUrlParts) -> WatcherExecuteWatch<()> {
         WatcherExecuteWatch::new(self.client.clone(), parts)
     }
     pub fn get_watch(&self, parts: WatcherGetWatchUrlParts) -> WatcherGetWatch {
         WatcherGetWatch::new(self.client.clone(), parts)
     }
-    pub fn put_watch<B>(&self, parts: WatcherPutWatchUrlParts) -> WatcherPutWatch<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_watch(&self, parts: WatcherPutWatchUrlParts) -> WatcherPutWatch<()> {
         WatcherPutWatch::new(self.client.clone(), parts)
     }
-    pub fn start<B>(&self) -> WatcherStart<B>
-    where
-        B: Serialize,
-    {
+    pub fn start(&self) -> WatcherStart<()> {
         WatcherStart::new(self.client.clone())
     }
     pub fn stats(&self, parts: WatcherStatsUrlParts) -> WatcherStats {
         WatcherStats::new(self.client.clone(), parts)
     }
-    pub fn stop<B>(&self) -> WatcherStop<B>
-    where
-        B: Serialize,
-    {
+    pub fn stop(&self) -> WatcherStop<()> {
         WatcherStop::new(self.client.clone())
     }
 }

--- a/elasticsearch/src/root.rs
+++ b/elasticsearch/src/root.rs
@@ -116,9 +116,29 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Bulk<T>
+    where
+        T: Serialize,
+    {
+        Bulk {
+            client: self.client,
+            parts: self.parts,
+            body,
+            _source: self._source,
+            _source_excludes: self._source_excludes,
+            _source_includes: self._source_includes,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pipeline: self.pipeline,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            routing: self.routing,
+            source: self.source,
+            timeout: self.timeout,
+            ty: self.ty,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -308,9 +328,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> ClearScroll<T>
+    where
+        T: Serialize,
+    {
+        ClearScroll {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -484,9 +515,34 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Count<T>
+    where
+        T: Serialize,
+    {
+        Count {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            analyze_wildcard: self.analyze_wildcard,
+            analyzer: self.analyzer,
+            default_operator: self.default_operator,
+            df: self.df,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_throttled: self.ignore_throttled,
+            ignore_unavailable: self.ignore_unavailable,
+            lenient: self.lenient,
+            min_score: self.min_score,
+            preference: self.preference,
+            pretty: self.pretty,
+            q: self.q,
+            routing: self.routing,
+            source: self.source,
+            terminate_after: self.terminate_after,
+        }
     }
     #[doc = "The default operator for query string query (AND or OR)"]
     pub fn default_operator(mut self, default_operator: Option<DefaultOperator>) -> Self {
@@ -733,9 +789,27 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Create<T>
+    where
+        T: Serialize,
+    {
+        Create {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pipeline: self.pipeline,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            routing: self.routing,
+            source: self.source,
+            timeout: self.timeout,
+            version: self.version,
+            version_type: self.version_type,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -1212,9 +1286,52 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> DeleteByQuery<T>
+    where
+        T: Serialize,
+    {
+        DeleteByQuery {
+            client: self.client,
+            parts: self.parts,
+            body,
+            _source: self._source,
+            _source_excludes: self._source_excludes,
+            _source_includes: self._source_includes,
+            allow_no_indices: self.allow_no_indices,
+            analyze_wildcard: self.analyze_wildcard,
+            conflicts: self.conflicts,
+            default_operator: self.default_operator,
+            df: self.df,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            from: self.from,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            lenient: self.lenient,
+            max_docs: self.max_docs,
+            preference: self.preference,
+            pretty: self.pretty,
+            q: self.q,
+            refresh: self.refresh,
+            request_cache: self.request_cache,
+            requests_per_second: self.requests_per_second,
+            routing: self.routing,
+            scroll: self.scroll,
+            scroll_size: self.scroll_size,
+            search_timeout: self.search_timeout,
+            search_type: self.search_type,
+            size: self.size,
+            slices: self.slices,
+            sort: self.sort,
+            source: self.source,
+            stats: self.stats,
+            terminate_after: self.terminate_after,
+            timeout: self.timeout,
+            version: self.version,
+            wait_for_active_shards: self.wait_for_active_shards,
+            wait_for_completion: self.wait_for_completion,
+        }
     }
     #[doc = "What to do when the delete by query hits version conflicts?"]
     pub fn conflicts(mut self, conflicts: Option<Conflicts>) -> Self {
@@ -1596,9 +1713,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> DeleteByQueryRethrottle<T>
+    where
+        T: Serialize,
+    {
+        DeleteByQueryRethrottle {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            requests_per_second: self.requests_per_second,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -2364,9 +2493,32 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Explain<T>
+    where
+        T: Serialize,
+    {
+        Explain {
+            client: self.client,
+            parts: self.parts,
+            body,
+            _source: self._source,
+            _source_excludes: self._source_excludes,
+            _source_includes: self._source_includes,
+            analyze_wildcard: self.analyze_wildcard,
+            analyzer: self.analyzer,
+            default_operator: self.default_operator,
+            df: self.df,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            lenient: self.lenient,
+            preference: self.preference,
+            pretty: self.pretty,
+            q: self.q,
+            routing: self.routing,
+            source: self.source,
+            stored_fields: self.stored_fields,
+        }
     }
     #[doc = "The default operator for query string query (AND or OR)"]
     pub fn default_operator(mut self, default_operator: Option<DefaultOperator>) -> Self {
@@ -2590,9 +2742,25 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> FieldCaps<T>
+    where
+        T: Serialize,
+    {
+        FieldCaps {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            fields: self.fields,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            include_unmapped: self.include_unmapped,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -3366,9 +3534,30 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Index<T>
+    where
+        T: Serialize,
+    {
+        Index {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            if_primary_term: self.if_primary_term,
+            if_seq_no: self.if_seq_no,
+            op_type: self.op_type,
+            pipeline: self.pipeline,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            routing: self.routing,
+            source: self.source,
+            timeout: self.timeout,
+            version: self.version,
+            version_type: self.version_type,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -3709,9 +3898,28 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Mget<T>
+    where
+        T: Serialize,
+    {
+        Mget {
+            client: self.client,
+            parts: self.parts,
+            body,
+            _source: self._source,
+            _source_excludes: self._source_excludes,
+            _source_includes: self._source_includes,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            preference: self.preference,
+            pretty: self.pretty,
+            realtime: self.realtime,
+            refresh: self.refresh,
+            routing: self.routing,
+            source: self.source,
+            stored_fields: self.stored_fields,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -3924,9 +4132,27 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Msearch<T>
+    where
+        T: Serialize,
+    {
+        Msearch {
+            client: self.client,
+            parts: self.parts,
+            body,
+            ccs_minimize_roundtrips: self.ccs_minimize_roundtrips,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            max_concurrent_searches: self.max_concurrent_searches,
+            max_concurrent_shard_requests: self.max_concurrent_shard_requests,
+            pre_filter_shard_size: self.pre_filter_shard_size,
+            pretty: self.pretty,
+            rest_total_hits_as_int: self.rest_total_hits_as_int,
+            search_type: self.search_type,
+            source: self.source,
+            typed_keys: self.typed_keys,
+        }
     }
     #[doc = "Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution"]
     pub fn ccs_minimize_roundtrips(mut self, ccs_minimize_roundtrips: Option<bool>) -> Self {
@@ -4142,9 +4368,24 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> MsearchTemplate<T>
+    where
+        T: Serialize,
+    {
+        MsearchTemplate {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            max_concurrent_searches: self.max_concurrent_searches,
+            pretty: self.pretty,
+            rest_total_hits_as_int: self.rest_total_hits_as_int,
+            search_type: self.search_type,
+            source: self.source,
+            typed_keys: self.typed_keys,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -4337,9 +4578,32 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Mtermvectors<T>
+    where
+        T: Serialize,
+    {
+        Mtermvectors {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            field_statistics: self.field_statistics,
+            fields: self.fields,
+            filter_path: self.filter_path,
+            human: self.human,
+            ids: self.ids,
+            offsets: self.offsets,
+            payloads: self.payloads,
+            positions: self.positions,
+            preference: self.preference,
+            pretty: self.pretty,
+            realtime: self.realtime,
+            routing: self.routing,
+            source: self.source,
+            term_statistics: self.term_statistics,
+            version: self.version,
+            version_type: self.version_type,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -4675,9 +4939,23 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> PutScript<T>
+    where
+        T: Serialize,
+    {
+        PutScript {
+            client: self.client,
+            parts: self.parts,
+            body,
+            context: self.context,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            master_timeout: self.master_timeout,
+            pretty: self.pretty,
+            source: self.source,
+            timeout: self.timeout,
+        }
     }
     #[doc = "Context name to compile script against"]
     pub fn context(mut self, context: Option<String>) -> Self {
@@ -4831,9 +5109,23 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> RankEval<T>
+    where
+        T: Serialize,
+    {
+        RankEval {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -4981,9 +5273,28 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Reindex<T>
+    where
+        T: Serialize,
+    {
+        Reindex {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            max_docs: self.max_docs,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            requests_per_second: self.requests_per_second,
+            scroll: self.scroll,
+            slices: self.slices,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+            wait_for_completion: self.wait_for_completion,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5174,9 +5485,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> ReindexRethrottle<T>
+    where
+        T: Serialize,
+    {
+        ReindexRethrottle {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            requests_per_second: self.requests_per_second,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5304,9 +5627,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> RenderSearchTemplate<T>
+    where
+        T: Serialize,
+    {
+        RenderSearchTemplate {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5419,9 +5753,20 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> ScriptsPainlessExecute<T>
+    where
+        T: Serialize,
+    {
+        ScriptsPainlessExecute {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5547,9 +5892,23 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Scroll<T>
+    where
+        T: Serialize,
+    {
+        Scroll {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            rest_total_hits_as_int: self.rest_total_hits_as_int,
+            scroll: self.scroll,
+            scroll_id: self.scroll_id,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -5837,9 +6196,62 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Search<T>
+    where
+        T: Serialize,
+    {
+        Search {
+            client: self.client,
+            parts: self.parts,
+            body,
+            _source: self._source,
+            _source_excludes: self._source_excludes,
+            _source_includes: self._source_includes,
+            allow_no_indices: self.allow_no_indices,
+            allow_partial_search_results: self.allow_partial_search_results,
+            analyze_wildcard: self.analyze_wildcard,
+            analyzer: self.analyzer,
+            batched_reduce_size: self.batched_reduce_size,
+            ccs_minimize_roundtrips: self.ccs_minimize_roundtrips,
+            default_operator: self.default_operator,
+            df: self.df,
+            docvalue_fields: self.docvalue_fields,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            explain: self.explain,
+            filter_path: self.filter_path,
+            from: self.from,
+            human: self.human,
+            ignore_throttled: self.ignore_throttled,
+            ignore_unavailable: self.ignore_unavailable,
+            lenient: self.lenient,
+            max_concurrent_shard_requests: self.max_concurrent_shard_requests,
+            pre_filter_shard_size: self.pre_filter_shard_size,
+            preference: self.preference,
+            pretty: self.pretty,
+            q: self.q,
+            request_cache: self.request_cache,
+            rest_total_hits_as_int: self.rest_total_hits_as_int,
+            routing: self.routing,
+            scroll: self.scroll,
+            search_type: self.search_type,
+            seq_no_primary_term: self.seq_no_primary_term,
+            size: self.size,
+            sort: self.sort,
+            source: self.source,
+            stats: self.stats,
+            stored_fields: self.stored_fields,
+            suggest_field: self.suggest_field,
+            suggest_mode: self.suggest_mode,
+            suggest_size: self.suggest_size,
+            suggest_text: self.suggest_text,
+            terminate_after: self.terminate_after,
+            timeout: self.timeout,
+            track_scores: self.track_scores,
+            track_total_hits: self.track_total_hits,
+            typed_keys: self.typed_keys,
+            version: self.version,
+        }
     }
     #[doc = "Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution"]
     pub fn ccs_minimize_roundtrips(mut self, ccs_minimize_roundtrips: Option<bool>) -> Self {
@@ -6330,9 +6742,26 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SearchShards<T>
+    where
+        T: Serialize,
+    {
+        SearchShards {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            local: self.local,
+            preference: self.preference,
+            pretty: self.pretty,
+            routing: self.routing,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6538,9 +6967,32 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> SearchTemplate<T>
+    where
+        T: Serialize,
+    {
+        SearchTemplate {
+            client: self.client,
+            parts: self.parts,
+            body,
+            allow_no_indices: self.allow_no_indices,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            explain: self.explain,
+            filter_path: self.filter_path,
+            human: self.human,
+            ignore_throttled: self.ignore_throttled,
+            ignore_unavailable: self.ignore_unavailable,
+            preference: self.preference,
+            pretty: self.pretty,
+            profile: self.profile,
+            rest_total_hits_as_int: self.rest_total_hits_as_int,
+            routing: self.routing,
+            scroll: self.scroll,
+            search_type: self.search_type,
+            source: self.source,
+            typed_keys: self.typed_keys,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -6810,9 +7262,31 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Termvectors<T>
+    where
+        T: Serialize,
+    {
+        Termvectors {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            field_statistics: self.field_statistics,
+            fields: self.fields,
+            filter_path: self.filter_path,
+            human: self.human,
+            offsets: self.offsets,
+            payloads: self.payloads,
+            positions: self.positions,
+            preference: self.preference,
+            pretty: self.pretty,
+            realtime: self.realtime,
+            routing: self.routing,
+            source: self.source,
+            term_statistics: self.term_statistics,
+            version: self.version,
+            version_type: self.version_type,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -7073,9 +7547,31 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> Update<T>
+    where
+        T: Serialize,
+    {
+        Update {
+            client: self.client,
+            parts: self.parts,
+            body,
+            _source: self._source,
+            _source_excludes: self._source_excludes,
+            _source_includes: self._source_includes,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            if_primary_term: self.if_primary_term,
+            if_seq_no: self.if_seq_no,
+            lang: self.lang,
+            pretty: self.pretty,
+            refresh: self.refresh,
+            retry_on_conflict: self.retry_on_conflict,
+            routing: self.routing,
+            source: self.source,
+            timeout: self.timeout,
+            wait_for_active_shards: self.wait_for_active_shards,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -7392,9 +7888,55 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> UpdateByQuery<T>
+    where
+        T: Serialize,
+    {
+        UpdateByQuery {
+            client: self.client,
+            parts: self.parts,
+            body,
+            _source: self._source,
+            _source_excludes: self._source_excludes,
+            _source_includes: self._source_includes,
+            allow_no_indices: self.allow_no_indices,
+            analyze_wildcard: self.analyze_wildcard,
+            analyzer: self.analyzer,
+            conflicts: self.conflicts,
+            default_operator: self.default_operator,
+            df: self.df,
+            error_trace: self.error_trace,
+            expand_wildcards: self.expand_wildcards,
+            filter_path: self.filter_path,
+            from: self.from,
+            human: self.human,
+            ignore_unavailable: self.ignore_unavailable,
+            lenient: self.lenient,
+            max_docs: self.max_docs,
+            pipeline: self.pipeline,
+            preference: self.preference,
+            pretty: self.pretty,
+            q: self.q,
+            refresh: self.refresh,
+            request_cache: self.request_cache,
+            requests_per_second: self.requests_per_second,
+            routing: self.routing,
+            scroll: self.scroll,
+            scroll_size: self.scroll_size,
+            search_timeout: self.search_timeout,
+            search_type: self.search_type,
+            size: self.size,
+            slices: self.slices,
+            sort: self.sort,
+            source: self.source,
+            stats: self.stats,
+            terminate_after: self.terminate_after,
+            timeout: self.timeout,
+            version: self.version,
+            version_type: self.version_type,
+            wait_for_active_shards: self.wait_for_active_shards,
+            wait_for_completion: self.wait_for_completion,
+        }
     }
     #[doc = "What to do when the update by query hits version conflicts?"]
     pub fn conflicts(mut self, conflicts: Option<Conflicts>) -> Self {
@@ -7795,9 +8337,21 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body(mut self, body: Option<B>) -> Self {
-        self.body = body;
-        self
+    pub fn body<T>(self, body: Option<T>) -> UpdateByQueryRethrottle<T>
+    where
+        T: Serialize,
+    {
+        UpdateByQueryRethrottle {
+            client: self.client,
+            parts: self.parts,
+            body,
+            error_trace: self.error_trace,
+            filter_path: self.filter_path,
+            human: self.human,
+            pretty: self.pretty,
+            requests_per_second: self.requests_per_second,
+            source: self.source,
+        }
     }
     #[doc = "Include the stack trace of returned errors."]
     pub fn error_trace(mut self, error_trace: Option<bool>) -> Self {
@@ -7879,31 +8433,19 @@ where
 }
 impl Elasticsearch {
     #[doc = "Allows to perform multiple index/update/delete operations in a single request."]
-    pub fn bulk<B>(&self, parts: BulkUrlParts) -> Bulk<B>
-    where
-        B: Serialize,
-    {
+    pub fn bulk(&self, parts: BulkUrlParts) -> Bulk<()> {
         Bulk::new(self.clone(), parts)
     }
     #[doc = "Explicitly clears the search context for a scroll."]
-    pub fn clear_scroll<B>(&self, parts: ClearScrollUrlParts) -> ClearScroll<B>
-    where
-        B: Serialize,
-    {
+    pub fn clear_scroll(&self, parts: ClearScrollUrlParts) -> ClearScroll<()> {
         ClearScroll::new(self.clone(), parts)
     }
     #[doc = "Returns number of documents matching a query."]
-    pub fn count<B>(&self, parts: CountUrlParts) -> Count<B>
-    where
-        B: Serialize,
-    {
+    pub fn count(&self, parts: CountUrlParts) -> Count<()> {
         Count::new(self.clone(), parts)
     }
     #[doc = "Creates a new document in the index.\n\nReturns a 409 response when a document with a same ID already exists in the index."]
-    pub fn create<B>(&self, parts: CreateUrlParts) -> Create<B>
-    where
-        B: Serialize,
-    {
+    pub fn create(&self, parts: CreateUrlParts) -> Create<()> {
         Create::new(self.clone(), parts)
     }
     #[doc = "Removes a document from the index."]
@@ -7911,20 +8453,14 @@ impl Elasticsearch {
         Delete::new(self.clone(), parts)
     }
     #[doc = "Deletes documents matching the provided query."]
-    pub fn delete_by_query<B>(&self, parts: DeleteByQueryUrlParts) -> DeleteByQuery<B>
-    where
-        B: Serialize,
-    {
+    pub fn delete_by_query(&self, parts: DeleteByQueryUrlParts) -> DeleteByQuery<()> {
         DeleteByQuery::new(self.clone(), parts)
     }
     #[doc = "Changes the number of requests per second for a particular Delete By Query operation."]
-    pub fn delete_by_query_rethrottle<B>(
+    pub fn delete_by_query_rethrottle(
         &self,
         parts: DeleteByQueryRethrottleUrlParts,
-    ) -> DeleteByQueryRethrottle<B>
-    where
-        B: Serialize,
-    {
+    ) -> DeleteByQueryRethrottle<()> {
         DeleteByQueryRethrottle::new(self.clone(), parts)
     }
     #[doc = "Deletes a script."]
@@ -7940,17 +8476,11 @@ impl Elasticsearch {
         ExistsSource::new(self.clone(), parts)
     }
     #[doc = "Returns information about why a specific matches (or doesn't match) a query."]
-    pub fn explain<B>(&self, parts: ExplainUrlParts) -> Explain<B>
-    where
-        B: Serialize,
-    {
+    pub fn explain(&self, parts: ExplainUrlParts) -> Explain<()> {
         Explain::new(self.clone(), parts)
     }
     #[doc = "Returns the information about the capabilities of fields among multiple indices."]
-    pub fn field_caps<B>(&self, parts: FieldCapsUrlParts) -> FieldCaps<B>
-    where
-        B: Serialize,
-    {
+    pub fn field_caps(&self, parts: FieldCapsUrlParts) -> FieldCaps<()> {
         FieldCaps::new(self.clone(), parts)
     }
     #[doc = "Returns a document."]
@@ -7966,10 +8496,7 @@ impl Elasticsearch {
         GetSource::new(self.clone(), parts)
     }
     #[doc = "Creates or updates a document in an index."]
-    pub fn index<B>(&self, parts: IndexUrlParts) -> Index<B>
-    where
-        B: Serialize,
-    {
+    pub fn index(&self, parts: IndexUrlParts) -> Index<()> {
         Index::new(self.clone(), parts)
     }
     #[doc = "Returns basic information about the cluster."]
@@ -7977,31 +8504,19 @@ impl Elasticsearch {
         Info::new(self.clone())
     }
     #[doc = "Allows to get multiple documents in one request."]
-    pub fn mget<B>(&self, parts: MgetUrlParts) -> Mget<B>
-    where
-        B: Serialize,
-    {
+    pub fn mget(&self, parts: MgetUrlParts) -> Mget<()> {
         Mget::new(self.clone(), parts)
     }
     #[doc = "Allows to execute several search operations in one request."]
-    pub fn msearch<B>(&self, parts: MsearchUrlParts) -> Msearch<B>
-    where
-        B: Serialize,
-    {
+    pub fn msearch(&self, parts: MsearchUrlParts) -> Msearch<()> {
         Msearch::new(self.clone(), parts)
     }
     #[doc = "Allows to execute several search template operations in one request."]
-    pub fn msearch_template<B>(&self, parts: MsearchTemplateUrlParts) -> MsearchTemplate<B>
-    where
-        B: Serialize,
-    {
+    pub fn msearch_template(&self, parts: MsearchTemplateUrlParts) -> MsearchTemplate<()> {
         MsearchTemplate::new(self.clone(), parts)
     }
     #[doc = "Returns multiple termvectors in one request."]
-    pub fn mtermvectors<B>(&self, parts: MtermvectorsUrlParts) -> Mtermvectors<B>
-    where
-        B: Serialize,
-    {
+    pub fn mtermvectors(&self, parts: MtermvectorsUrlParts) -> Mtermvectors<()> {
         Mtermvectors::new(self.clone(), parts)
     }
     #[doc = "Returns whether the cluster is running."]
@@ -8009,107 +8524,65 @@ impl Elasticsearch {
         Ping::new(self.clone())
     }
     #[doc = "Creates or updates a script."]
-    pub fn put_script<B>(&self, parts: PutScriptUrlParts) -> PutScript<B>
-    where
-        B: Serialize,
-    {
+    pub fn put_script(&self, parts: PutScriptUrlParts) -> PutScript<()> {
         PutScript::new(self.clone(), parts)
     }
     #[doc = "Allows to evaluate the quality of ranked search results over a set of typical search queries"]
-    pub fn rank_eval<B>(&self, parts: RankEvalUrlParts) -> RankEval<B>
-    where
-        B: Serialize,
-    {
+    pub fn rank_eval(&self, parts: RankEvalUrlParts) -> RankEval<()> {
         RankEval::new(self.clone(), parts)
     }
     #[doc = "Allows to copy documents from one index to another, optionally filtering the source\ndocuments by a query, changing the destination index settings, or fetching the\ndocuments from a remote cluster."]
-    pub fn reindex<B>(&self) -> Reindex<B>
-    where
-        B: Serialize,
-    {
+    pub fn reindex(&self) -> Reindex<()> {
         Reindex::new(self.clone())
     }
     #[doc = "Changes the number of requests per second for a particular Reindex operation."]
-    pub fn reindex_rethrottle<B>(&self, parts: ReindexRethrottleUrlParts) -> ReindexRethrottle<B>
-    where
-        B: Serialize,
-    {
+    pub fn reindex_rethrottle(&self, parts: ReindexRethrottleUrlParts) -> ReindexRethrottle<()> {
         ReindexRethrottle::new(self.clone(), parts)
     }
     #[doc = "Allows to use the Mustache language to pre-render a search definition."]
-    pub fn render_search_template<B>(
+    pub fn render_search_template(
         &self,
         parts: RenderSearchTemplateUrlParts,
-    ) -> RenderSearchTemplate<B>
-    where
-        B: Serialize,
-    {
+    ) -> RenderSearchTemplate<()> {
         RenderSearchTemplate::new(self.clone(), parts)
     }
     #[doc = "Allows an arbitrary script to be executed and a result to be returned"]
-    pub fn scripts_painless_execute<B>(&self) -> ScriptsPainlessExecute<B>
-    where
-        B: Serialize,
-    {
+    pub fn scripts_painless_execute(&self) -> ScriptsPainlessExecute<()> {
         ScriptsPainlessExecute::new(self.clone())
     }
     #[doc = "Allows to retrieve a large numbers of results from a single search request."]
-    pub fn scroll<B>(&self, parts: ScrollUrlParts) -> Scroll<B>
-    where
-        B: Serialize,
-    {
+    pub fn scroll(&self, parts: ScrollUrlParts) -> Scroll<()> {
         Scroll::new(self.clone(), parts)
     }
     #[doc = "Returns results matching a query."]
-    pub fn search<B>(&self, parts: SearchUrlParts) -> Search<B>
-    where
-        B: Serialize,
-    {
+    pub fn search(&self, parts: SearchUrlParts) -> Search<()> {
         Search::new(self.clone(), parts)
     }
     #[doc = "Returns information about the indices and shards that a search request would be executed against."]
-    pub fn search_shards<B>(&self, parts: SearchShardsUrlParts) -> SearchShards<B>
-    where
-        B: Serialize,
-    {
+    pub fn search_shards(&self, parts: SearchShardsUrlParts) -> SearchShards<()> {
         SearchShards::new(self.clone(), parts)
     }
     #[doc = "Allows to use the Mustache language to pre-render a search definition."]
-    pub fn search_template<B>(&self, parts: SearchTemplateUrlParts) -> SearchTemplate<B>
-    where
-        B: Serialize,
-    {
+    pub fn search_template(&self, parts: SearchTemplateUrlParts) -> SearchTemplate<()> {
         SearchTemplate::new(self.clone(), parts)
     }
     #[doc = "Returns information and statistics about terms in the fields of a particular document."]
-    pub fn termvectors<B>(&self, parts: TermvectorsUrlParts) -> Termvectors<B>
-    where
-        B: Serialize,
-    {
+    pub fn termvectors(&self, parts: TermvectorsUrlParts) -> Termvectors<()> {
         Termvectors::new(self.clone(), parts)
     }
     #[doc = "Updates a document with a script or partial document."]
-    pub fn update<B>(&self, parts: UpdateUrlParts) -> Update<B>
-    where
-        B: Serialize,
-    {
+    pub fn update(&self, parts: UpdateUrlParts) -> Update<()> {
         Update::new(self.clone(), parts)
     }
     #[doc = "Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change."]
-    pub fn update_by_query<B>(&self, parts: UpdateByQueryUrlParts) -> UpdateByQuery<B>
-    where
-        B: Serialize,
-    {
+    pub fn update_by_query(&self, parts: UpdateByQueryUrlParts) -> UpdateByQuery<()> {
         UpdateByQuery::new(self.clone(), parts)
     }
     #[doc = "Changes the number of requests per second for a particular Update By Query operation."]
-    pub fn update_by_query_rethrottle<B>(
+    pub fn update_by_query_rethrottle(
         &self,
         parts: UpdateByQueryRethrottleUrlParts,
-    ) -> UpdateByQueryRethrottle<B>
-    where
-        B: Serialize,
-    {
+    ) -> UpdateByQueryRethrottle<()> {
         UpdateByQueryRethrottle::new(self.clone(), parts)
     }
 }


### PR DESCRIPTION
This commit makes body functions generic for those APIs that support sending a body, and removes the generic parameter on the associated API method on the root or namespaced_client. This makes it simpler to chain function calls, often with type inference being able to correctly infer the body type T from the argument. It also allows a builder to be cloned and for a different type of body to be set on the clone.

Closes #9