### PR TITLE
Pass reference to Elasticsearch struct to builder structs

### DIFF
--- a/api_generator/src/api_generator/code_gen/mod.rs
+++ b/api_generator/src/api_generator/code_gen/mod.rs
@@ -126,10 +126,10 @@ fn typekind_to_ty(name: &str, kind: TypeKind, required: bool) -> syn::Ty {
         v.push_str("Option<");
     }
 
-    let str_type = "&'a str";
+    let str_type = "&'b str";
     match kind {
         TypeKind::None => v.push_str(str_type),
-        TypeKind::List => v.push_str(format!("&'a [{}]", str_type).as_ref()),
+        TypeKind::List => v.push_str(format!("&'b [{}]", str_type).as_ref()),
         TypeKind::Enum => v.push_str(name.to_pascal_case().as_str()),
         TypeKind::String => v.push_str(str_type),
         TypeKind::Text => v.push_str(str_type),
@@ -150,10 +150,10 @@ fn typekind_to_ty(name: &str, kind: TypeKind, required: bool) -> syn::Ty {
     syn::parse_type(v.as_str()).unwrap()
 }
 
-/// A standard `'a` lifetime
-pub fn lifetime_a() -> syn::Lifetime {
+/// A standard `'b` lifetime
+pub fn lifetime_b() -> syn::Lifetime {
     syn::Lifetime {
-        ident: syn::Ident::new("'a"),
+        ident: syn::Ident::new("'b"),
     }
 }
 
@@ -170,9 +170,9 @@ impl<T: GetPath> HasLifetime for T {
     }
 }
 
-/// Generics with a standard `'a` lifetime
-pub fn generics_a() -> syn::Generics {
-    generics(vec![lifetime_a()], vec![])
+/// Generics with a standard `'b` lifetime
+pub fn generics_b() -> syn::Generics {
+    generics(vec![lifetime_b()], vec![])
 }
 
 /// Generics with no parameters.
@@ -201,9 +201,9 @@ pub fn ty_path(ty: &str, lifetimes: Vec<syn::Lifetime>, types: Vec<syn::Ty>) -> 
     syn::Ty::Path(None, path(ty, lifetimes, types))
 }
 
-/// AST for a path type with a `'a` lifetime.
-pub fn ty_a(ty: &str) -> syn::Ty {
-    ty_path(ty, vec![lifetime_a()], vec![])
+/// AST for a path type with a `'b` lifetime.
+pub fn ty_b(ty: &str) -> syn::Ty {
+    ty_path(ty, vec![lifetime_b()], vec![])
 }
 
 /// AST for a simple path type.

--- a/api_generator/src/api_generator/code_gen/namespace_clients.rs
+++ b/api_generator/src/api_generator/code_gen/namespace_clients.rs
@@ -49,13 +49,13 @@ pub fn generate(api: &Api) -> Result<Vec<(String, String)>, failure::Error> {
             #(#builders)*
 
             #namespace_doc
-            pub struct #namespace_client_name {
-                client: Elasticsearch
+            pub struct #namespace_client_name<'a> {
+                client: &'a Elasticsearch
             }
 
-            impl #namespace_client_name {
+            impl<'a> #namespace_client_name<'a> {
                 #new_namespace_client_doc
-                pub fn new(client: Elasticsearch) -> Self {
+                pub fn new(client: &'a Elasticsearch) -> Self {
                     Self {
                         client
                     }
@@ -66,7 +66,7 @@ pub fn generate(api: &Api) -> Result<Vec<(String, String)>, failure::Error> {
             impl Elasticsearch {
                 #namespace_fn_doc
                 pub fn #namespace_name(&self) -> #namespace_client_name {
-                    #namespace_client_name::new(self.clone())
+                    #namespace_client_name::new(&self)
                 }
             }
         ));

--- a/api_generator/src/api_generator/code_gen/url/enum_builder.rs
+++ b/api_generator/src/api_generator/code_gen/url/enum_builder.rs
@@ -163,7 +163,7 @@ impl<'a> EnumBuilder<'a> {
 
         let (enum_ty, generics) = {
             if self.has_lifetime {
-                (ty_a(self.ident.as_ref()), generics_a())
+                (ty_b(self.ident.as_ref()), generics_b())
             } else {
                 (ty(self.ident.as_ref()), generics_none())
             }
@@ -350,25 +350,25 @@ mod tests {
 
         let (enum_ty, enum_decl, enum_impl) = EnumBuilder::from(&endpoint).build();
 
-        assert_eq!(ty_a("SearchParts"), enum_ty);
+        assert_eq!(ty_b("SearchParts"), enum_ty);
 
         let expected_decl = quote!(
             #[derive(Debug, Clone, PartialEq)]
             #[doc = "API parts for the Search API"]
-            pub enum SearchParts<'a> {
+            pub enum SearchParts<'b> {
                 #[doc = "No parts"]
                 None,
                 #[doc = "Index"]
-                Index(&'a [&'a str]),
+                Index(&'b [&'b str]),
                 #[doc = "Index and Type"]
-                IndexType(&'a [&'a str], &'a [&'a str]),
+                IndexType(&'b [&'b str], &'b [&'b str]),
             }
         );
 
         ast_eq(expected_decl, enum_decl);
 
         let expected_impl = quote!(
-            impl<'a> SearchParts<'a> {
+            impl<'b> SearchParts<'b> {
                 #[doc = "Builds a relative URL path to the Search API"]
                 pub fn url(self) -> Cow<'static, str> {
                     match self {

--- a/elasticsearch/src/generated/namespace_clients/cat.rs
+++ b/elasticsearch/src/generated/namespace_clients/cat.rs
@@ -31,13 +31,13 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Aliases API"]
-pub enum CatAliasesParts<'a> {
+pub enum CatAliasesParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Name"]
-    Name(&'a [&'a str]),
+    Name(&'b [&'b str]),
 }
-impl<'a> CatAliasesParts<'a> {
+impl<'b> CatAliasesParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Aliases API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -54,25 +54,25 @@ impl<'a> CatAliasesParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Aliases API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html). Shows information about currently configured aliases to indices including filter and routing infos."]
-pub struct CatAliases<'a> {
-    client: Elasticsearch,
-    parts: CatAliasesParts<'a>,
+pub struct CatAliases<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatAliasesParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatAliases<'a> {
+impl<'a, 'b> CatAliases<'a, 'b> {
     #[doc = "Creates a new instance of [CatAliases] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatAliasesParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatAliasesParts<'b>) -> Self {
         CatAliases {
             client,
             parts,
@@ -96,17 +96,17 @@ impl<'a> CatAliases<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -136,12 +136,12 @@ impl<'a> CatAliases<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -158,18 +158,18 @@ impl<'a> CatAliases<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -179,9 +179,9 @@ impl<'a> CatAliases<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -210,13 +210,13 @@ impl<'a> CatAliases<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Allocation API"]
-pub enum CatAllocationParts<'a> {
+pub enum CatAllocationParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "NodeId"]
-    NodeId(&'a [&'a str]),
+    NodeId(&'b [&'b str]),
 }
-impl<'a> CatAllocationParts<'a> {
+impl<'b> CatAllocationParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Allocation API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -233,27 +233,27 @@ impl<'a> CatAllocationParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Allocation API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html). Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using."]
-pub struct CatAllocation<'a> {
-    client: Elasticsearch,
-    parts: CatAllocationParts<'a>,
+pub struct CatAllocation<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatAllocationParts<'b>,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatAllocation<'a> {
+impl<'a, 'b> CatAllocation<'a, 'b> {
     #[doc = "Creates a new instance of [CatAllocation] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatAllocationParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatAllocationParts<'b>) -> Self {
         CatAllocation {
             client,
             parts,
@@ -284,17 +284,17 @@ impl<'a> CatAllocation<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -319,7 +319,7 @@ impl<'a> CatAllocation<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -329,12 +329,12 @@ impl<'a> CatAllocation<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -351,7 +351,7 @@ impl<'a> CatAllocation<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "bytes")]
                 bytes: Option<Bytes>,
                 #[serde(rename = "error_trace")]
@@ -360,11 +360,11 @@ impl<'a> CatAllocation<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -372,13 +372,13 @@ impl<'a> CatAllocation<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -409,13 +409,13 @@ impl<'a> CatAllocation<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Count API"]
-pub enum CatCountParts<'a> {
+pub enum CatCountParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> CatCountParts<'a> {
+impl<'b> CatCountParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Count API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -432,24 +432,24 @@ impl<'a> CatCountParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Count API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html). Provides quick access to the document count of the entire cluster, or individual indices."]
-pub struct CatCount<'a> {
-    client: Elasticsearch,
-    parts: CatCountParts<'a>,
+pub struct CatCount<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatCountParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatCount<'a> {
+impl<'a, 'b> CatCount<'a, 'b> {
     #[doc = "Creates a new instance of [CatCount] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatCountParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatCountParts<'b>) -> Self {
         CatCount {
             client,
             parts,
@@ -472,17 +472,17 @@ impl<'a> CatCount<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -507,12 +507,12 @@ impl<'a> CatCount<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -529,18 +529,18 @@ impl<'a> CatCount<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -548,9 +548,9 @@ impl<'a> CatCount<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -578,13 +578,13 @@ impl<'a> CatCount<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Fielddata API"]
-pub enum CatFielddataParts<'a> {
+pub enum CatFielddataParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Fields"]
-    Fields(&'a [&'a str]),
+    Fields(&'b [&'b str]),
 }
-impl<'a> CatFielddataParts<'a> {
+impl<'b> CatFielddataParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Fielddata API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -601,26 +601,26 @@ impl<'a> CatFielddataParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Fielddata API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html). Shows how much heap memory is currently being used by fielddata on every data node in the cluster."]
-pub struct CatFielddata<'a> {
-    client: Elasticsearch,
-    parts: CatFielddataParts<'a>,
+pub struct CatFielddata<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatFielddataParts<'b>,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
-    fields: Option<&'a [&'a str]>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    fields: Option<&'b [&'b str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatFielddata<'a> {
+impl<'a, 'b> CatFielddata<'a, 'b> {
     #[doc = "Creates a new instance of [CatFielddata] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatFielddataParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatFielddataParts<'b>) -> Self {
         CatFielddata {
             client,
             parts,
@@ -650,22 +650,22 @@ impl<'a> CatFielddata<'a> {
         self
     }
     #[doc = "A comma-separated list of fields to return in the output"]
-    pub fn fields(mut self, fields: &'a [&'a str]) -> Self {
+    pub fn fields(mut self, fields: &'b [&'b str]) -> Self {
         self.fields = Some(fields);
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -690,12 +690,12 @@ impl<'a> CatFielddata<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -712,22 +712,22 @@ impl<'a> CatFielddata<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "bytes")]
                 bytes: Option<Bytes>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "fields", serialize_with = "crate::client::serialize_coll_qs")]
-                fields: Option<&'a [&'a str]>,
+                fields: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -735,9 +735,9 @@ impl<'a> CatFielddata<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -781,26 +781,26 @@ impl CatHealthParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Health API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html). Returns a concise representation of the cluster health."]
-pub struct CatHealth<'a> {
-    client: Elasticsearch,
+pub struct CatHealth<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: CatHealthParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     time: Option<Time>,
     ts: Option<bool>,
     v: Option<bool>,
 }
-impl<'a> CatHealth<'a> {
+impl<'a, 'b> CatHealth<'a, 'b> {
     #[doc = "Creates a new instance of [CatHealth]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         CatHealth {
             client,
             parts: CatHealthParts::None,
@@ -825,17 +825,17 @@ impl<'a> CatHealth<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -860,12 +860,12 @@ impl<'a> CatHealth<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -892,18 +892,18 @@ impl<'a> CatHealth<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -911,9 +911,9 @@ impl<'a> CatHealth<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "time")]
                 time: Option<Time>,
                 #[serde(rename = "ts")]
@@ -961,21 +961,21 @@ impl CatHelpParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Help API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html). Returns help for the Cat APIs."]
-pub struct CatHelp<'a> {
-    client: Elasticsearch,
+pub struct CatHelp<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: CatHelpParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
 }
-impl<'a> CatHelp<'a> {
+impl<'a, 'b> CatHelp<'a, 'b> {
     #[doc = "Creates a new instance of [CatHelp]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         CatHelp {
             client,
             parts: CatHelpParts::None,
@@ -995,7 +995,7 @@ impl<'a> CatHelp<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1020,12 +1020,12 @@ impl<'a> CatHelp<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1037,14 +1037,14 @@ impl<'a> CatHelp<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -1052,9 +1052,9 @@ impl<'a> CatHelp<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1077,13 +1077,13 @@ impl<'a> CatHelp<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Indices API"]
-pub enum CatIndicesParts<'a> {
+pub enum CatIndicesParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> CatIndicesParts<'a> {
+impl<'b> CatIndicesParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Indices API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1100,31 +1100,31 @@ impl<'a> CatIndicesParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Indices API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html). Returns information about indices: number of primaries and replicas, document counts, disk size, ..."]
-pub struct CatIndices<'a> {
-    client: Elasticsearch,
-    parts: CatIndicesParts<'a>,
+pub struct CatIndices<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatIndicesParts<'b>,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     health: Option<Health>,
     help: Option<bool>,
     human: Option<bool>,
     include_unloaded_segments: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
     pri: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     time: Option<Time>,
     v: Option<bool>,
 }
-impl<'a> CatIndices<'a> {
+impl<'a, 'b> CatIndices<'a, 'b> {
     #[doc = "Creates a new instance of [CatIndices] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatIndicesParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatIndicesParts<'b>) -> Self {
         CatIndices {
             client,
             parts,
@@ -1159,17 +1159,17 @@ impl<'a> CatIndices<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -1204,7 +1204,7 @@ impl<'a> CatIndices<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1219,12 +1219,12 @@ impl<'a> CatIndices<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1246,7 +1246,7 @@ impl<'a> CatIndices<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "bytes")]
                 bytes: Option<Bytes>,
                 #[serde(rename = "error_trace")]
@@ -1255,11 +1255,11 @@ impl<'a> CatIndices<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "health")]
                 health: Option<Health>,
                 #[serde(rename = "help")]
@@ -1271,15 +1271,15 @@ impl<'a> CatIndices<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "pri")]
                 pri: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "time")]
                 time: Option<Time>,
                 #[serde(rename = "v")]
@@ -1330,26 +1330,26 @@ impl CatMasterParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Master API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html). Returns information about the master node."]
-pub struct CatMaster<'a> {
-    client: Elasticsearch,
+pub struct CatMaster<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: CatMasterParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatMaster<'a> {
+impl<'a, 'b> CatMaster<'a, 'b> {
     #[doc = "Creates a new instance of [CatMaster]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         CatMaster {
             client,
             parts: CatMasterParts::None,
@@ -1374,17 +1374,17 @@ impl<'a> CatMaster<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -1409,7 +1409,7 @@ impl<'a> CatMaster<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1419,12 +1419,12 @@ impl<'a> CatMaster<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1441,18 +1441,18 @@ impl<'a> CatMaster<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -1460,13 +1460,13 @@ impl<'a> CatMaster<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -1510,26 +1510,26 @@ impl CatNodeattrsParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Nodeattrs API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html). Returns information about custom node attributes."]
-pub struct CatNodeattrs<'a> {
-    client: Elasticsearch,
+pub struct CatNodeattrs<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: CatNodeattrsParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatNodeattrs<'a> {
+impl<'a, 'b> CatNodeattrs<'a, 'b> {
     #[doc = "Creates a new instance of [CatNodeattrs]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         CatNodeattrs {
             client,
             parts: CatNodeattrsParts::None,
@@ -1554,17 +1554,17 @@ impl<'a> CatNodeattrs<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -1589,7 +1589,7 @@ impl<'a> CatNodeattrs<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1599,12 +1599,12 @@ impl<'a> CatNodeattrs<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1621,18 +1621,18 @@ impl<'a> CatNodeattrs<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -1640,13 +1640,13 @@ impl<'a> CatNodeattrs<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -1690,29 +1690,29 @@ impl CatNodesParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Nodes API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html). Returns basic statistics about performance of cluster nodes."]
-pub struct CatNodes<'a> {
-    client: Elasticsearch,
+pub struct CatNodes<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: CatNodesParts,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
     full_id: Option<bool>,
-    h: Option<&'a [&'a str]>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     time: Option<Time>,
     v: Option<bool>,
 }
-impl<'a> CatNodes<'a> {
+impl<'a, 'b> CatNodes<'a, 'b> {
     #[doc = "Creates a new instance of [CatNodes]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         CatNodes {
             client,
             parts: CatNodesParts::None,
@@ -1745,12 +1745,12 @@ impl<'a> CatNodes<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
@@ -1760,7 +1760,7 @@ impl<'a> CatNodes<'a> {
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -1785,7 +1785,7 @@ impl<'a> CatNodes<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1795,12 +1795,12 @@ impl<'a> CatNodes<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1822,7 +1822,7 @@ impl<'a> CatNodes<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "bytes")]
                 bytes: Option<Bytes>,
                 #[serde(rename = "error_trace")]
@@ -1831,13 +1831,13 @@ impl<'a> CatNodes<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "full_id")]
                 full_id: Option<bool>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -1845,13 +1845,13 @@ impl<'a> CatNodes<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "time")]
                 time: Option<Time>,
                 #[serde(rename = "v")]
@@ -1900,27 +1900,27 @@ impl CatPendingTasksParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Pending Tasks API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html). Returns a concise representation of the cluster pending tasks."]
-pub struct CatPendingTasks<'a> {
-    client: Elasticsearch,
+pub struct CatPendingTasks<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: CatPendingTasksParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     time: Option<Time>,
     v: Option<bool>,
 }
-impl<'a> CatPendingTasks<'a> {
+impl<'a, 'b> CatPendingTasks<'a, 'b> {
     #[doc = "Creates a new instance of [CatPendingTasks]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         CatPendingTasks {
             client,
             parts: CatPendingTasksParts::None,
@@ -1946,17 +1946,17 @@ impl<'a> CatPendingTasks<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -1981,7 +1981,7 @@ impl<'a> CatPendingTasks<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1991,12 +1991,12 @@ impl<'a> CatPendingTasks<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2018,18 +2018,18 @@ impl<'a> CatPendingTasks<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -2037,13 +2037,13 @@ impl<'a> CatPendingTasks<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "time")]
                 time: Option<Time>,
                 #[serde(rename = "v")]
@@ -2090,26 +2090,26 @@ impl CatPluginsParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Plugins API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html). Returns information about installed plugins across nodes node."]
-pub struct CatPlugins<'a> {
-    client: Elasticsearch,
+pub struct CatPlugins<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: CatPluginsParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatPlugins<'a> {
+impl<'a, 'b> CatPlugins<'a, 'b> {
     #[doc = "Creates a new instance of [CatPlugins]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         CatPlugins {
             client,
             parts: CatPluginsParts::None,
@@ -2134,17 +2134,17 @@ impl<'a> CatPlugins<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -2169,7 +2169,7 @@ impl<'a> CatPlugins<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -2179,12 +2179,12 @@ impl<'a> CatPlugins<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2201,18 +2201,18 @@ impl<'a> CatPlugins<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -2220,13 +2220,13 @@ impl<'a> CatPlugins<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -2256,13 +2256,13 @@ impl<'a> CatPlugins<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Recovery API"]
-pub enum CatRecoveryParts<'a> {
+pub enum CatRecoveryParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> CatRecoveryParts<'a> {
+impl<'b> CatRecoveryParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Recovery API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2279,29 +2279,29 @@ impl<'a> CatRecoveryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Recovery API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html). Returns information about index shard recoveries, both on-going completed."]
-pub struct CatRecovery<'a> {
-    client: Elasticsearch,
-    parts: CatRecoveryParts<'a>,
+pub struct CatRecovery<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatRecoveryParts<'b>,
     active_only: Option<bool>,
     bytes: Option<Bytes>,
     detailed: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
-    index: Option<&'a [&'a str]>,
+    index: Option<&'b [&'b str]>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     time: Option<Time>,
     v: Option<bool>,
 }
-impl<'a> CatRecovery<'a> {
+impl<'a, 'b> CatRecovery<'a, 'b> {
     #[doc = "Creates a new instance of [CatRecovery] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatRecoveryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatRecoveryParts<'b>) -> Self {
         CatRecovery {
             client,
             parts,
@@ -2344,17 +2344,17 @@ impl<'a> CatRecovery<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -2374,7 +2374,7 @@ impl<'a> CatRecovery<'a> {
         self
     }
     #[doc = "Comma-separated list or wildcard expression of index names to limit the returned information"]
-    pub fn index(mut self, index: &'a [&'a str]) -> Self {
+    pub fn index(mut self, index: &'b [&'b str]) -> Self {
         self.index = Some(index);
         self
     }
@@ -2384,12 +2384,12 @@ impl<'a> CatRecovery<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2411,7 +2411,7 @@ impl<'a> CatRecovery<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "active_only")]
                 active_only: Option<bool>,
                 #[serde(rename = "bytes")]
@@ -2424,23 +2424,23 @@ impl<'a> CatRecovery<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "index", serialize_with = "crate::client::serialize_coll_qs")]
-                index: Option<&'a [&'a str]>,
+                index: Option<&'b [&'b str]>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "time")]
                 time: Option<Time>,
                 #[serde(rename = "v")]
@@ -2489,26 +2489,26 @@ impl CatRepositoriesParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Repositories API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html). Returns information about snapshot repositories registered in the cluster."]
-pub struct CatRepositories<'a> {
-    client: Elasticsearch,
+pub struct CatRepositories<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: CatRepositoriesParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatRepositories<'a> {
+impl<'a, 'b> CatRepositories<'a, 'b> {
     #[doc = "Creates a new instance of [CatRepositories]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         CatRepositories {
             client,
             parts: CatRepositoriesParts::None,
@@ -2533,17 +2533,17 @@ impl<'a> CatRepositories<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -2568,7 +2568,7 @@ impl<'a> CatRepositories<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -2578,12 +2578,12 @@ impl<'a> CatRepositories<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2600,18 +2600,18 @@ impl<'a> CatRepositories<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -2619,13 +2619,13 @@ impl<'a> CatRepositories<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -2655,13 +2655,13 @@ impl<'a> CatRepositories<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Segments API"]
-pub enum CatSegmentsParts<'a> {
+pub enum CatSegmentsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> CatSegmentsParts<'a> {
+impl<'b> CatSegmentsParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Segments API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2678,25 +2678,25 @@ impl<'a> CatSegmentsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Segments API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html). Provides low-level information about the segments in the shards of an index."]
-pub struct CatSegments<'a> {
-    client: Elasticsearch,
-    parts: CatSegmentsParts<'a>,
+pub struct CatSegments<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatSegmentsParts<'b>,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatSegments<'a> {
+impl<'a, 'b> CatSegments<'a, 'b> {
     #[doc = "Creates a new instance of [CatSegments] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatSegmentsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatSegmentsParts<'b>) -> Self {
         CatSegments {
             client,
             parts,
@@ -2725,17 +2725,17 @@ impl<'a> CatSegments<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -2760,12 +2760,12 @@ impl<'a> CatSegments<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2782,7 +2782,7 @@ impl<'a> CatSegments<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "bytes")]
                 bytes: Option<Bytes>,
                 #[serde(rename = "error_trace")]
@@ -2791,11 +2791,11 @@ impl<'a> CatSegments<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -2803,9 +2803,9 @@ impl<'a> CatSegments<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -2834,13 +2834,13 @@ impl<'a> CatSegments<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Shards API"]
-pub enum CatShardsParts<'a> {
+pub enum CatShardsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> CatShardsParts<'a> {
+impl<'b> CatShardsParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Shards API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2857,28 +2857,28 @@ impl<'a> CatShardsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Shards API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html). Provides a detailed view of shard allocation on nodes."]
-pub struct CatShards<'a> {
-    client: Elasticsearch,
-    parts: CatShardsParts<'a>,
+pub struct CatShards<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatShardsParts<'b>,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     time: Option<Time>,
     v: Option<bool>,
 }
-impl<'a> CatShards<'a> {
+impl<'a, 'b> CatShards<'a, 'b> {
     #[doc = "Creates a new instance of [CatShards] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatShardsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatShardsParts<'b>) -> Self {
         CatShards {
             client,
             parts,
@@ -2910,17 +2910,17 @@ impl<'a> CatShards<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -2945,7 +2945,7 @@ impl<'a> CatShards<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -2955,12 +2955,12 @@ impl<'a> CatShards<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2982,7 +2982,7 @@ impl<'a> CatShards<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "bytes")]
                 bytes: Option<Bytes>,
                 #[serde(rename = "error_trace")]
@@ -2991,11 +2991,11 @@ impl<'a> CatShards<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -3003,13 +3003,13 @@ impl<'a> CatShards<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "time")]
                 time: Option<Time>,
                 #[serde(rename = "v")]
@@ -3043,13 +3043,13 @@ impl<'a> CatShards<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Snapshots API"]
-pub enum CatSnapshotsParts<'a> {
+pub enum CatSnapshotsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Repository"]
-    Repository(&'a [&'a str]),
+    Repository(&'b [&'b str]),
 }
-impl<'a> CatSnapshotsParts<'a> {
+impl<'b> CatSnapshotsParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Snapshots API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3066,27 +3066,27 @@ impl<'a> CatSnapshotsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Snapshots API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html). Returns all snapshots in a specific repository."]
-pub struct CatSnapshots<'a> {
-    client: Elasticsearch,
-    parts: CatSnapshotsParts<'a>,
+pub struct CatSnapshots<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatSnapshotsParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     time: Option<Time>,
     v: Option<bool>,
 }
-impl<'a> CatSnapshots<'a> {
+impl<'a, 'b> CatSnapshots<'a, 'b> {
     #[doc = "Creates a new instance of [CatSnapshots] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatSnapshotsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatSnapshotsParts<'b>) -> Self {
         CatSnapshots {
             client,
             parts,
@@ -3112,17 +3112,17 @@ impl<'a> CatSnapshots<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -3147,7 +3147,7 @@ impl<'a> CatSnapshots<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -3157,12 +3157,12 @@ impl<'a> CatSnapshots<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3184,18 +3184,18 @@ impl<'a> CatSnapshots<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -3203,13 +3203,13 @@ impl<'a> CatSnapshots<'a> {
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "time")]
                 time: Option<Time>,
                 #[serde(rename = "v")]
@@ -3256,29 +3256,29 @@ impl CatTasksParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Tasks API](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html). Returns information about the tasks currently executing on one or more nodes in the cluster."]
-pub struct CatTasks<'a> {
-    client: Elasticsearch,
+pub struct CatTasks<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: CatTasksParts,
-    actions: Option<&'a [&'a str]>,
+    actions: Option<&'b [&'b str]>,
     detailed: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
-    node_id: Option<&'a [&'a str]>,
+    node_id: Option<&'b [&'b str]>,
     parent_task: Option<i64>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     time: Option<Time>,
     v: Option<bool>,
 }
-impl<'a> CatTasks<'a> {
+impl<'a, 'b> CatTasks<'a, 'b> {
     #[doc = "Creates a new instance of [CatTasks]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         CatTasks {
             client,
             parts: CatTasksParts::None,
@@ -3301,7 +3301,7 @@ impl<'a> CatTasks<'a> {
         }
     }
     #[doc = "A comma-separated list of actions that should be returned. Leave empty to return all."]
-    pub fn actions(mut self, actions: &'a [&'a str]) -> Self {
+    pub fn actions(mut self, actions: &'b [&'b str]) -> Self {
         self.actions = Some(actions);
         self
     }
@@ -3316,17 +3316,17 @@ impl<'a> CatTasks<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -3346,7 +3346,7 @@ impl<'a> CatTasks<'a> {
         self
     }
     #[doc = "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"]
-    pub fn node_id(mut self, node_id: &'a [&'a str]) -> Self {
+    pub fn node_id(mut self, node_id: &'b [&'b str]) -> Self {
         self.node_id = Some(node_id);
         self
     }
@@ -3361,12 +3361,12 @@ impl<'a> CatTasks<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3388,12 +3388,12 @@ impl<'a> CatTasks<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "actions",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                actions: Option<&'a [&'a str]>,
+                actions: Option<&'b [&'b str]>,
                 #[serde(rename = "detailed")]
                 detailed: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -3402,11 +3402,11 @@ impl<'a> CatTasks<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -3415,15 +3415,15 @@ impl<'a> CatTasks<'a> {
                     rename = "node_id",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                node_id: Option<&'a [&'a str]>,
+                node_id: Option<&'b [&'b str]>,
                 #[serde(rename = "parent_task")]
                 parent_task: Option<i64>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "time")]
                 time: Option<Time>,
                 #[serde(rename = "v")]
@@ -3458,13 +3458,13 @@ impl<'a> CatTasks<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Templates API"]
-pub enum CatTemplatesParts<'a> {
+pub enum CatTemplatesParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> CatTemplatesParts<'a> {
+impl<'b> CatTemplatesParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Templates API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3480,26 +3480,26 @@ impl<'a> CatTemplatesParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Templates API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html). Returns information about existing templates."]
-pub struct CatTemplates<'a> {
-    client: Elasticsearch,
-    parts: CatTemplatesParts<'a>,
+pub struct CatTemplates<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatTemplatesParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    s: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatTemplates<'a> {
+impl<'a, 'b> CatTemplates<'a, 'b> {
     #[doc = "Creates a new instance of [CatTemplates] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatTemplatesParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatTemplatesParts<'b>) -> Self {
         CatTemplates {
             client,
             parts,
@@ -3524,17 +3524,17 @@ impl<'a> CatTemplates<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -3559,7 +3559,7 @@ impl<'a> CatTemplates<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -3569,12 +3569,12 @@ impl<'a> CatTemplates<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3591,18 +3591,18 @@ impl<'a> CatTemplates<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -3610,13 +3610,13 @@ impl<'a> CatTemplates<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -3646,13 +3646,13 @@ impl<'a> CatTemplates<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cat Thread Pool API"]
-pub enum CatThreadPoolParts<'a> {
+pub enum CatThreadPoolParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "ThreadPoolPatterns"]
-    ThreadPoolPatterns(&'a [&'a str]),
+    ThreadPoolPatterns(&'b [&'b str]),
 }
-impl<'a> CatThreadPoolParts<'a> {
+impl<'b> CatThreadPoolParts<'b> {
     #[doc = "Builds a relative URL path to the Cat Thread Pool API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3669,27 +3669,27 @@ impl<'a> CatThreadPoolParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Thread Pool API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html). Returns cluster-wide thread pool statistics per node.\nBy default the active, queue and rejected statistics are returned for all thread pools."]
-pub struct CatThreadPool<'a> {
-    client: Elasticsearch,
-    parts: CatThreadPoolParts<'a>,
+pub struct CatThreadPool<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CatThreadPoolParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
-    h: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
+    h: Option<&'b [&'b str]>,
     headers: HeaderMap,
     help: Option<bool>,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    s: Option<&'a [&'a str]>,
+    s: Option<&'b [&'b str]>,
     size: Option<Size>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     v: Option<bool>,
 }
-impl<'a> CatThreadPool<'a> {
+impl<'a, 'b> CatThreadPool<'a, 'b> {
     #[doc = "Creates a new instance of [CatThreadPool] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CatThreadPoolParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CatThreadPoolParts<'b>) -> Self {
         CatThreadPool {
             client,
             parts,
@@ -3715,17 +3715,17 @@ impl<'a> CatThreadPool<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
     #[doc = "Comma-separated list of column names to display"]
-    pub fn h(mut self, h: &'a [&'a str]) -> Self {
+    pub fn h(mut self, h: &'b [&'b str]) -> Self {
         self.h = Some(h);
         self
     }
@@ -3750,7 +3750,7 @@ impl<'a> CatThreadPool<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -3760,7 +3760,7 @@ impl<'a> CatThreadPool<'a> {
         self
     }
     #[doc = "Comma-separated list of column names or column aliases to sort by"]
-    pub fn s(mut self, s: &'a [&'a str]) -> Self {
+    pub fn s(mut self, s: &'b [&'b str]) -> Self {
         self.s = Some(s);
         self
     }
@@ -3770,7 +3770,7 @@ impl<'a> CatThreadPool<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3787,18 +3787,18 @@ impl<'a> CatThreadPool<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "h", serialize_with = "crate::client::serialize_coll_qs")]
-                h: Option<&'a [&'a str]>,
+                h: Option<&'b [&'b str]>,
                 #[serde(rename = "help")]
                 help: Option<bool>,
                 #[serde(rename = "human")]
@@ -3806,15 +3806,15 @@ impl<'a> CatThreadPool<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "s", serialize_with = "crate::client::serialize_coll_qs")]
-                s: Option<&'a [&'a str]>,
+                s: Option<&'b [&'b str]>,
                 #[serde(rename = "size")]
                 size: Option<Size>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "v")]
                 v: Option<bool>,
             }
@@ -3844,98 +3844,98 @@ impl<'a> CatThreadPool<'a> {
     }
 }
 #[doc = "Namespace client for Cat APIs"]
-pub struct Cat {
-    client: Elasticsearch,
+pub struct Cat<'a> {
+    client: &'a Elasticsearch,
 }
-impl Cat {
+impl<'a> Cat<'a> {
     #[doc = "Creates a new instance of [Cat]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
     #[doc = "Shows information about currently configured aliases to indices including filter and routing infos."]
-    pub fn aliases<'a>(&self, parts: CatAliasesParts<'a>) -> CatAliases<'a> {
-        CatAliases::new(self.client.clone(), parts)
+    pub fn aliases<'b>(&'a self, parts: CatAliasesParts<'b>) -> CatAliases<'a, 'b> {
+        CatAliases::new(&self.client, parts)
     }
     #[doc = "Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using."]
-    pub fn allocation<'a>(&self, parts: CatAllocationParts<'a>) -> CatAllocation<'a> {
-        CatAllocation::new(self.client.clone(), parts)
+    pub fn allocation<'b>(&'a self, parts: CatAllocationParts<'b>) -> CatAllocation<'a, 'b> {
+        CatAllocation::new(&self.client, parts)
     }
     #[doc = "Provides quick access to the document count of the entire cluster, or individual indices."]
-    pub fn count<'a>(&self, parts: CatCountParts<'a>) -> CatCount<'a> {
-        CatCount::new(self.client.clone(), parts)
+    pub fn count<'b>(&'a self, parts: CatCountParts<'b>) -> CatCount<'a, 'b> {
+        CatCount::new(&self.client, parts)
     }
     #[doc = "Shows how much heap memory is currently being used by fielddata on every data node in the cluster."]
-    pub fn fielddata<'a>(&self, parts: CatFielddataParts<'a>) -> CatFielddata<'a> {
-        CatFielddata::new(self.client.clone(), parts)
+    pub fn fielddata<'b>(&'a self, parts: CatFielddataParts<'b>) -> CatFielddata<'a, 'b> {
+        CatFielddata::new(&self.client, parts)
     }
     #[doc = "Returns a concise representation of the cluster health."]
-    pub fn health<'a>(&self) -> CatHealth<'a> {
-        CatHealth::new(self.client.clone())
+    pub fn health<'b>(&'a self) -> CatHealth<'a, 'b> {
+        CatHealth::new(&self.client)
     }
     #[doc = "Returns help for the Cat APIs."]
-    pub fn help<'a>(&self) -> CatHelp<'a> {
-        CatHelp::new(self.client.clone())
+    pub fn help<'b>(&'a self) -> CatHelp<'a, 'b> {
+        CatHelp::new(&self.client)
     }
     #[doc = "Returns information about indices: number of primaries and replicas, document counts, disk size, ..."]
-    pub fn indices<'a>(&self, parts: CatIndicesParts<'a>) -> CatIndices<'a> {
-        CatIndices::new(self.client.clone(), parts)
+    pub fn indices<'b>(&'a self, parts: CatIndicesParts<'b>) -> CatIndices<'a, 'b> {
+        CatIndices::new(&self.client, parts)
     }
     #[doc = "Returns information about the master node."]
-    pub fn master<'a>(&self) -> CatMaster<'a> {
-        CatMaster::new(self.client.clone())
+    pub fn master<'b>(&'a self) -> CatMaster<'a, 'b> {
+        CatMaster::new(&self.client)
     }
     #[doc = "Returns information about custom node attributes."]
-    pub fn nodeattrs<'a>(&self) -> CatNodeattrs<'a> {
-        CatNodeattrs::new(self.client.clone())
+    pub fn nodeattrs<'b>(&'a self) -> CatNodeattrs<'a, 'b> {
+        CatNodeattrs::new(&self.client)
     }
     #[doc = "Returns basic statistics about performance of cluster nodes."]
-    pub fn nodes<'a>(&self) -> CatNodes<'a> {
-        CatNodes::new(self.client.clone())
+    pub fn nodes<'b>(&'a self) -> CatNodes<'a, 'b> {
+        CatNodes::new(&self.client)
     }
     #[doc = "Returns a concise representation of the cluster pending tasks."]
-    pub fn pending_tasks<'a>(&self) -> CatPendingTasks<'a> {
-        CatPendingTasks::new(self.client.clone())
+    pub fn pending_tasks<'b>(&'a self) -> CatPendingTasks<'a, 'b> {
+        CatPendingTasks::new(&self.client)
     }
     #[doc = "Returns information about installed plugins across nodes node."]
-    pub fn plugins<'a>(&self) -> CatPlugins<'a> {
-        CatPlugins::new(self.client.clone())
+    pub fn plugins<'b>(&'a self) -> CatPlugins<'a, 'b> {
+        CatPlugins::new(&self.client)
     }
     #[doc = "Returns information about index shard recoveries, both on-going completed."]
-    pub fn recovery<'a>(&self, parts: CatRecoveryParts<'a>) -> CatRecovery<'a> {
-        CatRecovery::new(self.client.clone(), parts)
+    pub fn recovery<'b>(&'a self, parts: CatRecoveryParts<'b>) -> CatRecovery<'a, 'b> {
+        CatRecovery::new(&self.client, parts)
     }
     #[doc = "Returns information about snapshot repositories registered in the cluster."]
-    pub fn repositories<'a>(&self) -> CatRepositories<'a> {
-        CatRepositories::new(self.client.clone())
+    pub fn repositories<'b>(&'a self) -> CatRepositories<'a, 'b> {
+        CatRepositories::new(&self.client)
     }
     #[doc = "Provides low-level information about the segments in the shards of an index."]
-    pub fn segments<'a>(&self, parts: CatSegmentsParts<'a>) -> CatSegments<'a> {
-        CatSegments::new(self.client.clone(), parts)
+    pub fn segments<'b>(&'a self, parts: CatSegmentsParts<'b>) -> CatSegments<'a, 'b> {
+        CatSegments::new(&self.client, parts)
     }
     #[doc = "Provides a detailed view of shard allocation on nodes."]
-    pub fn shards<'a>(&self, parts: CatShardsParts<'a>) -> CatShards<'a> {
-        CatShards::new(self.client.clone(), parts)
+    pub fn shards<'b>(&'a self, parts: CatShardsParts<'b>) -> CatShards<'a, 'b> {
+        CatShards::new(&self.client, parts)
     }
     #[doc = "Returns all snapshots in a specific repository."]
-    pub fn snapshots<'a>(&self, parts: CatSnapshotsParts<'a>) -> CatSnapshots<'a> {
-        CatSnapshots::new(self.client.clone(), parts)
+    pub fn snapshots<'b>(&'a self, parts: CatSnapshotsParts<'b>) -> CatSnapshots<'a, 'b> {
+        CatSnapshots::new(&self.client, parts)
     }
     #[doc = "Returns information about the tasks currently executing on one or more nodes in the cluster."]
-    pub fn tasks<'a>(&self) -> CatTasks<'a> {
-        CatTasks::new(self.client.clone())
+    pub fn tasks<'b>(&'a self) -> CatTasks<'a, 'b> {
+        CatTasks::new(&self.client)
     }
     #[doc = "Returns information about existing templates."]
-    pub fn templates<'a>(&self, parts: CatTemplatesParts<'a>) -> CatTemplates<'a> {
-        CatTemplates::new(self.client.clone(), parts)
+    pub fn templates<'b>(&'a self, parts: CatTemplatesParts<'b>) -> CatTemplates<'a, 'b> {
+        CatTemplates::new(&self.client, parts)
     }
     #[doc = "Returns cluster-wide thread pool statistics per node.\nBy default the active, queue and rejected statistics are returned for all thread pools."]
-    pub fn thread_pool<'a>(&self, parts: CatThreadPoolParts<'a>) -> CatThreadPool<'a> {
-        CatThreadPool::new(self.client.clone(), parts)
+    pub fn thread_pool<'b>(&'a self, parts: CatThreadPoolParts<'b>) -> CatThreadPool<'a, 'b> {
+        CatThreadPool::new(&self.client, parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Cat APIs"]
     pub fn cat(&self) -> Cat {
-        Cat::new(self.clone())
+        Cat::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/ccr.rs
+++ b/elasticsearch/src/generated/namespace_clients/ccr.rs
@@ -31,11 +31,11 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Delete Auto Follow Pattern API"]
-pub enum CcrDeleteAutoFollowPatternParts<'a> {
+pub enum CcrDeleteAutoFollowPatternParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> CcrDeleteAutoFollowPatternParts<'a> {
+impl<'b> CcrDeleteAutoFollowPatternParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Delete Auto Follow Pattern API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -50,19 +50,19 @@ impl<'a> CcrDeleteAutoFollowPatternParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Delete Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html)."]
-pub struct CcrDeleteAutoFollowPattern<'a> {
-    client: Elasticsearch,
-    parts: CcrDeleteAutoFollowPatternParts<'a>,
+pub struct CcrDeleteAutoFollowPattern<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CcrDeleteAutoFollowPatternParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> CcrDeleteAutoFollowPattern<'a> {
+impl<'a, 'b> CcrDeleteAutoFollowPattern<'a, 'b> {
     #[doc = "Creates a new instance of [CcrDeleteAutoFollowPattern] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrDeleteAutoFollowPatternParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrDeleteAutoFollowPatternParts<'b>) -> Self {
         CcrDeleteAutoFollowPattern {
             client,
             parts,
@@ -80,7 +80,7 @@ impl<'a> CcrDeleteAutoFollowPattern<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -100,7 +100,7 @@ impl<'a> CcrDeleteAutoFollowPattern<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -112,20 +112,20 @@ impl<'a> CcrDeleteAutoFollowPattern<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -146,11 +146,11 @@ impl<'a> CcrDeleteAutoFollowPattern<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Follow API"]
-pub enum CcrFollowParts<'a> {
+pub enum CcrFollowParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> CcrFollowParts<'a> {
+impl<'b> CcrFollowParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Follow API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -166,24 +166,24 @@ impl<'a> CcrFollowParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Follow API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html)."]
-pub struct CcrFollow<'a, B> {
-    client: Elasticsearch,
-    parts: CcrFollowParts<'a>,
+pub struct CcrFollow<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: CcrFollowParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> CcrFollow<'a, B>
+impl<'a, 'b, B> CcrFollow<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrFollow] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrFollowParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrFollowParts<'b>) -> Self {
         CcrFollow {
             client,
             parts,
@@ -198,7 +198,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> CcrFollow<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> CcrFollow<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -221,7 +221,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -241,12 +241,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Sets the number of shard copies that must be active before returning. Defaults to 0. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -258,22 +258,22 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -295,11 +295,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Follow Info API"]
-pub enum CcrFollowInfoParts<'a> {
+pub enum CcrFollowInfoParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> CcrFollowInfoParts<'a> {
+impl<'b> CcrFollowInfoParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Follow Info API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -316,19 +316,19 @@ impl<'a> CcrFollowInfoParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Follow Info API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-info.html)."]
-pub struct CcrFollowInfo<'a> {
-    client: Elasticsearch,
-    parts: CcrFollowInfoParts<'a>,
+pub struct CcrFollowInfo<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CcrFollowInfoParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> CcrFollowInfo<'a> {
+impl<'a, 'b> CcrFollowInfo<'a, 'b> {
     #[doc = "Creates a new instance of [CcrFollowInfo] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrFollowInfoParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrFollowInfoParts<'b>) -> Self {
         CcrFollowInfo {
             client,
             parts,
@@ -346,7 +346,7 @@ impl<'a> CcrFollowInfo<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -366,7 +366,7 @@ impl<'a> CcrFollowInfo<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -378,20 +378,20 @@ impl<'a> CcrFollowInfo<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -412,11 +412,11 @@ impl<'a> CcrFollowInfo<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Follow Stats API"]
-pub enum CcrFollowStatsParts<'a> {
+pub enum CcrFollowStatsParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> CcrFollowStatsParts<'a> {
+impl<'b> CcrFollowStatsParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Follow Stats API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -433,19 +433,19 @@ impl<'a> CcrFollowStatsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Follow Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html)."]
-pub struct CcrFollowStats<'a> {
-    client: Elasticsearch,
-    parts: CcrFollowStatsParts<'a>,
+pub struct CcrFollowStats<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CcrFollowStatsParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> CcrFollowStats<'a> {
+impl<'a, 'b> CcrFollowStats<'a, 'b> {
     #[doc = "Creates a new instance of [CcrFollowStats] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrFollowStatsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrFollowStatsParts<'b>) -> Self {
         CcrFollowStats {
             client,
             parts,
@@ -463,7 +463,7 @@ impl<'a> CcrFollowStats<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -483,7 +483,7 @@ impl<'a> CcrFollowStats<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -495,20 +495,20 @@ impl<'a> CcrFollowStats<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -529,11 +529,11 @@ impl<'a> CcrFollowStats<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Forget Follower API"]
-pub enum CcrForgetFollowerParts<'a> {
+pub enum CcrForgetFollowerParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> CcrForgetFollowerParts<'a> {
+impl<'b> CcrForgetFollowerParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Forget Follower API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -549,23 +549,23 @@ impl<'a> CcrForgetFollowerParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Forget Follower API](http://www.elastic.co/guide/en/elasticsearch/reference/current)."]
-pub struct CcrForgetFollower<'a, B> {
-    client: Elasticsearch,
-    parts: CcrForgetFollowerParts<'a>,
+pub struct CcrForgetFollower<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: CcrForgetFollowerParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> CcrForgetFollower<'a, B>
+impl<'a, 'b, B> CcrForgetFollower<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrForgetFollower] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrForgetFollowerParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrForgetFollowerParts<'b>) -> Self {
         CcrForgetFollower {
             client,
             parts,
@@ -579,7 +579,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> CcrForgetFollower<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> CcrForgetFollower<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -601,7 +601,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -621,7 +621,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -633,20 +633,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -667,13 +667,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Get Auto Follow Pattern API"]
-pub enum CcrGetAutoFollowPatternParts<'a> {
+pub enum CcrGetAutoFollowPatternParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> CcrGetAutoFollowPatternParts<'a> {
+impl<'b> CcrGetAutoFollowPatternParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Get Auto Follow Pattern API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -689,19 +689,19 @@ impl<'a> CcrGetAutoFollowPatternParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Get Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html)."]
-pub struct CcrGetAutoFollowPattern<'a> {
-    client: Elasticsearch,
-    parts: CcrGetAutoFollowPatternParts<'a>,
+pub struct CcrGetAutoFollowPattern<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: CcrGetAutoFollowPatternParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> CcrGetAutoFollowPattern<'a> {
+impl<'a, 'b> CcrGetAutoFollowPattern<'a, 'b> {
     #[doc = "Creates a new instance of [CcrGetAutoFollowPattern] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrGetAutoFollowPatternParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrGetAutoFollowPatternParts<'b>) -> Self {
         CcrGetAutoFollowPattern {
             client,
             parts,
@@ -719,7 +719,7 @@ impl<'a> CcrGetAutoFollowPattern<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -739,7 +739,7 @@ impl<'a> CcrGetAutoFollowPattern<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -751,20 +751,20 @@ impl<'a> CcrGetAutoFollowPattern<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -785,11 +785,11 @@ impl<'a> CcrGetAutoFollowPattern<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Pause Auto Follow Pattern API"]
-pub enum CcrPauseAutoFollowPatternParts<'a> {
+pub enum CcrPauseAutoFollowPatternParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> CcrPauseAutoFollowPatternParts<'a> {
+impl<'b> CcrPauseAutoFollowPatternParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Pause Auto Follow Pattern API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -805,23 +805,23 @@ impl<'a> CcrPauseAutoFollowPatternParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Pause Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-pause-auto-follow-pattern.html)."]
-pub struct CcrPauseAutoFollowPattern<'a, B> {
-    client: Elasticsearch,
-    parts: CcrPauseAutoFollowPatternParts<'a>,
+pub struct CcrPauseAutoFollowPattern<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: CcrPauseAutoFollowPatternParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> CcrPauseAutoFollowPattern<'a, B>
+impl<'a, 'b, B> CcrPauseAutoFollowPattern<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrPauseAutoFollowPattern] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrPauseAutoFollowPatternParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrPauseAutoFollowPatternParts<'b>) -> Self {
         CcrPauseAutoFollowPattern {
             client,
             parts,
@@ -835,7 +835,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> CcrPauseAutoFollowPattern<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> CcrPauseAutoFollowPattern<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -857,7 +857,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -877,7 +877,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -889,20 +889,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -923,11 +923,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Pause Follow API"]
-pub enum CcrPauseFollowParts<'a> {
+pub enum CcrPauseFollowParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> CcrPauseFollowParts<'a> {
+impl<'b> CcrPauseFollowParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Pause Follow API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -943,23 +943,23 @@ impl<'a> CcrPauseFollowParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Pause Follow API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html)."]
-pub struct CcrPauseFollow<'a, B> {
-    client: Elasticsearch,
-    parts: CcrPauseFollowParts<'a>,
+pub struct CcrPauseFollow<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: CcrPauseFollowParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> CcrPauseFollow<'a, B>
+impl<'a, 'b, B> CcrPauseFollow<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrPauseFollow] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrPauseFollowParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrPauseFollowParts<'b>) -> Self {
         CcrPauseFollow {
             client,
             parts,
@@ -973,7 +973,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> CcrPauseFollow<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> CcrPauseFollow<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -995,7 +995,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1015,7 +1015,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1027,20 +1027,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1061,11 +1061,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Put Auto Follow Pattern API"]
-pub enum CcrPutAutoFollowPatternParts<'a> {
+pub enum CcrPutAutoFollowPatternParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> CcrPutAutoFollowPatternParts<'a> {
+impl<'b> CcrPutAutoFollowPatternParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Put Auto Follow Pattern API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1080,23 +1080,23 @@ impl<'a> CcrPutAutoFollowPatternParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Put Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html)."]
-pub struct CcrPutAutoFollowPattern<'a, B> {
-    client: Elasticsearch,
-    parts: CcrPutAutoFollowPatternParts<'a>,
+pub struct CcrPutAutoFollowPattern<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: CcrPutAutoFollowPatternParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> CcrPutAutoFollowPattern<'a, B>
+impl<'a, 'b, B> CcrPutAutoFollowPattern<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrPutAutoFollowPattern] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrPutAutoFollowPatternParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrPutAutoFollowPatternParts<'b>) -> Self {
         CcrPutAutoFollowPattern {
             client,
             parts,
@@ -1110,7 +1110,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> CcrPutAutoFollowPattern<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> CcrPutAutoFollowPattern<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1132,7 +1132,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1152,7 +1152,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1164,20 +1164,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1198,11 +1198,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Resume Auto Follow Pattern API"]
-pub enum CcrResumeAutoFollowPatternParts<'a> {
+pub enum CcrResumeAutoFollowPatternParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> CcrResumeAutoFollowPatternParts<'a> {
+impl<'b> CcrResumeAutoFollowPatternParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Resume Auto Follow Pattern API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1218,23 +1218,23 @@ impl<'a> CcrResumeAutoFollowPatternParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Resume Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-resume-auto-follow-pattern.html)."]
-pub struct CcrResumeAutoFollowPattern<'a, B> {
-    client: Elasticsearch,
-    parts: CcrResumeAutoFollowPatternParts<'a>,
+pub struct CcrResumeAutoFollowPattern<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: CcrResumeAutoFollowPatternParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> CcrResumeAutoFollowPattern<'a, B>
+impl<'a, 'b, B> CcrResumeAutoFollowPattern<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrResumeAutoFollowPattern] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrResumeAutoFollowPatternParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrResumeAutoFollowPatternParts<'b>) -> Self {
         CcrResumeAutoFollowPattern {
             client,
             parts,
@@ -1248,7 +1248,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> CcrResumeAutoFollowPattern<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> CcrResumeAutoFollowPattern<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1270,7 +1270,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1290,7 +1290,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1302,20 +1302,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1336,11 +1336,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Resume Follow API"]
-pub enum CcrResumeFollowParts<'a> {
+pub enum CcrResumeFollowParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> CcrResumeFollowParts<'a> {
+impl<'b> CcrResumeFollowParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Resume Follow API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1356,23 +1356,23 @@ impl<'a> CcrResumeFollowParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Resume Follow API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html)."]
-pub struct CcrResumeFollow<'a, B> {
-    client: Elasticsearch,
-    parts: CcrResumeFollowParts<'a>,
+pub struct CcrResumeFollow<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: CcrResumeFollowParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> CcrResumeFollow<'a, B>
+impl<'a, 'b, B> CcrResumeFollow<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrResumeFollow] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrResumeFollowParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrResumeFollowParts<'b>) -> Self {
         CcrResumeFollow {
             client,
             parts,
@@ -1386,7 +1386,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> CcrResumeFollow<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> CcrResumeFollow<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1408,7 +1408,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1428,7 +1428,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1440,20 +1440,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1488,19 +1488,19 @@ impl CcrStatsParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html)."]
-pub struct CcrStats<'a> {
-    client: Elasticsearch,
+pub struct CcrStats<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: CcrStatsParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> CcrStats<'a> {
+impl<'a, 'b> CcrStats<'a, 'b> {
     #[doc = "Creates a new instance of [CcrStats]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         CcrStats {
             client,
             parts: CcrStatsParts::None,
@@ -1518,7 +1518,7 @@ impl<'a> CcrStats<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1538,7 +1538,7 @@ impl<'a> CcrStats<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1550,20 +1550,20 @@ impl<'a> CcrStats<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1584,11 +1584,11 @@ impl<'a> CcrStats<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ccr Unfollow API"]
-pub enum CcrUnfollowParts<'a> {
+pub enum CcrUnfollowParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> CcrUnfollowParts<'a> {
+impl<'b> CcrUnfollowParts<'b> {
     #[doc = "Builds a relative URL path to the Ccr Unfollow API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1604,23 +1604,23 @@ impl<'a> CcrUnfollowParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Unfollow API](http://www.elastic.co/guide/en/elasticsearch/reference/current)."]
-pub struct CcrUnfollow<'a, B> {
-    client: Elasticsearch,
-    parts: CcrUnfollowParts<'a>,
+pub struct CcrUnfollow<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: CcrUnfollowParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> CcrUnfollow<'a, B>
+impl<'a, 'b, B> CcrUnfollow<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrUnfollow] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CcrUnfollowParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CcrUnfollowParts<'b>) -> Self {
         CcrUnfollow {
             client,
             parts,
@@ -1634,7 +1634,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> CcrUnfollow<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> CcrUnfollow<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1656,7 +1656,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1676,7 +1676,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1688,20 +1688,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1721,75 +1721,81 @@ where
     }
 }
 #[doc = "Namespace client for Cross Cluster Replication APIs"]
-pub struct Ccr {
-    client: Elasticsearch,
+pub struct Ccr<'a> {
+    client: &'a Elasticsearch,
 }
-impl Ccr {
+impl<'a> Ccr<'a> {
     #[doc = "Creates a new instance of [Ccr]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn delete_auto_follow_pattern<'a>(
-        &self,
-        parts: CcrDeleteAutoFollowPatternParts<'a>,
-    ) -> CcrDeleteAutoFollowPattern<'a> {
-        CcrDeleteAutoFollowPattern::new(self.client.clone(), parts)
+    pub fn delete_auto_follow_pattern<'b>(
+        &'a self,
+        parts: CcrDeleteAutoFollowPatternParts<'b>,
+    ) -> CcrDeleteAutoFollowPattern<'a, 'b> {
+        CcrDeleteAutoFollowPattern::new(&self.client, parts)
     }
-    pub fn follow<'a>(&self, parts: CcrFollowParts<'a>) -> CcrFollow<'a, ()> {
-        CcrFollow::new(self.client.clone(), parts)
+    pub fn follow<'b>(&'a self, parts: CcrFollowParts<'b>) -> CcrFollow<'a, 'b, ()> {
+        CcrFollow::new(&self.client, parts)
     }
-    pub fn follow_info<'a>(&self, parts: CcrFollowInfoParts<'a>) -> CcrFollowInfo<'a> {
-        CcrFollowInfo::new(self.client.clone(), parts)
+    pub fn follow_info<'b>(&'a self, parts: CcrFollowInfoParts<'b>) -> CcrFollowInfo<'a, 'b> {
+        CcrFollowInfo::new(&self.client, parts)
     }
-    pub fn follow_stats<'a>(&self, parts: CcrFollowStatsParts<'a>) -> CcrFollowStats<'a> {
-        CcrFollowStats::new(self.client.clone(), parts)
+    pub fn follow_stats<'b>(&'a self, parts: CcrFollowStatsParts<'b>) -> CcrFollowStats<'a, 'b> {
+        CcrFollowStats::new(&self.client, parts)
     }
-    pub fn forget_follower<'a>(
-        &self,
-        parts: CcrForgetFollowerParts<'a>,
-    ) -> CcrForgetFollower<'a, ()> {
-        CcrForgetFollower::new(self.client.clone(), parts)
+    pub fn forget_follower<'b>(
+        &'a self,
+        parts: CcrForgetFollowerParts<'b>,
+    ) -> CcrForgetFollower<'a, 'b, ()> {
+        CcrForgetFollower::new(&self.client, parts)
     }
-    pub fn get_auto_follow_pattern<'a>(
-        &self,
-        parts: CcrGetAutoFollowPatternParts<'a>,
-    ) -> CcrGetAutoFollowPattern<'a> {
-        CcrGetAutoFollowPattern::new(self.client.clone(), parts)
+    pub fn get_auto_follow_pattern<'b>(
+        &'a self,
+        parts: CcrGetAutoFollowPatternParts<'b>,
+    ) -> CcrGetAutoFollowPattern<'a, 'b> {
+        CcrGetAutoFollowPattern::new(&self.client, parts)
     }
-    pub fn pause_auto_follow_pattern<'a>(
-        &self,
-        parts: CcrPauseAutoFollowPatternParts<'a>,
-    ) -> CcrPauseAutoFollowPattern<'a, ()> {
-        CcrPauseAutoFollowPattern::new(self.client.clone(), parts)
+    pub fn pause_auto_follow_pattern<'b>(
+        &'a self,
+        parts: CcrPauseAutoFollowPatternParts<'b>,
+    ) -> CcrPauseAutoFollowPattern<'a, 'b, ()> {
+        CcrPauseAutoFollowPattern::new(&self.client, parts)
     }
-    pub fn pause_follow<'a>(&self, parts: CcrPauseFollowParts<'a>) -> CcrPauseFollow<'a, ()> {
-        CcrPauseFollow::new(self.client.clone(), parts)
+    pub fn pause_follow<'b>(
+        &'a self,
+        parts: CcrPauseFollowParts<'b>,
+    ) -> CcrPauseFollow<'a, 'b, ()> {
+        CcrPauseFollow::new(&self.client, parts)
     }
-    pub fn put_auto_follow_pattern<'a>(
-        &self,
-        parts: CcrPutAutoFollowPatternParts<'a>,
-    ) -> CcrPutAutoFollowPattern<'a, ()> {
-        CcrPutAutoFollowPattern::new(self.client.clone(), parts)
+    pub fn put_auto_follow_pattern<'b>(
+        &'a self,
+        parts: CcrPutAutoFollowPatternParts<'b>,
+    ) -> CcrPutAutoFollowPattern<'a, 'b, ()> {
+        CcrPutAutoFollowPattern::new(&self.client, parts)
     }
-    pub fn resume_auto_follow_pattern<'a>(
-        &self,
-        parts: CcrResumeAutoFollowPatternParts<'a>,
-    ) -> CcrResumeAutoFollowPattern<'a, ()> {
-        CcrResumeAutoFollowPattern::new(self.client.clone(), parts)
+    pub fn resume_auto_follow_pattern<'b>(
+        &'a self,
+        parts: CcrResumeAutoFollowPatternParts<'b>,
+    ) -> CcrResumeAutoFollowPattern<'a, 'b, ()> {
+        CcrResumeAutoFollowPattern::new(&self.client, parts)
     }
-    pub fn resume_follow<'a>(&self, parts: CcrResumeFollowParts<'a>) -> CcrResumeFollow<'a, ()> {
-        CcrResumeFollow::new(self.client.clone(), parts)
+    pub fn resume_follow<'b>(
+        &'a self,
+        parts: CcrResumeFollowParts<'b>,
+    ) -> CcrResumeFollow<'a, 'b, ()> {
+        CcrResumeFollow::new(&self.client, parts)
     }
-    pub fn stats<'a>(&self) -> CcrStats<'a> {
-        CcrStats::new(self.client.clone())
+    pub fn stats<'b>(&'a self) -> CcrStats<'a, 'b> {
+        CcrStats::new(&self.client)
     }
-    pub fn unfollow<'a>(&self, parts: CcrUnfollowParts<'a>) -> CcrUnfollow<'a, ()> {
-        CcrUnfollow::new(self.client.clone(), parts)
+    pub fn unfollow<'b>(&'a self, parts: CcrUnfollowParts<'b>) -> CcrUnfollow<'a, 'b, ()> {
+        CcrUnfollow::new(&self.client, parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Cross Cluster Replication APIs"]
     pub fn ccr(&self) -> Ccr {
-        Ccr::new(self.clone())
+        Ccr::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/cluster.rs
+++ b/elasticsearch/src/generated/namespace_clients/cluster.rs
@@ -45,25 +45,25 @@ impl ClusterAllocationExplainParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Allocation Explain API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html). Provides explanations for shard allocations in the cluster."]
-pub struct ClusterAllocationExplain<'a, B> {
-    client: Elasticsearch,
+pub struct ClusterAllocationExplain<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: ClusterAllocationExplainParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     include_disk_info: Option<bool>,
     include_yes_decisions: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> ClusterAllocationExplain<'a, B>
+impl<'a, 'b, B> ClusterAllocationExplain<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [ClusterAllocationExplain]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         ClusterAllocationExplain {
             client,
             parts: ClusterAllocationExplainParts::None,
@@ -79,7 +79,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> ClusterAllocationExplain<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> ClusterAllocationExplain<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -103,7 +103,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -133,7 +133,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -148,14 +148,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "include_disk_info")]
@@ -165,7 +165,7 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -202,23 +202,23 @@ impl ClusterGetSettingsParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Get Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html). Returns cluster settings."]
-pub struct ClusterGetSettings<'a> {
-    client: Elasticsearch,
+pub struct ClusterGetSettings<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: ClusterGetSettingsParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     include_defaults: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> ClusterGetSettings<'a> {
+impl<'a, 'b> ClusterGetSettings<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterGetSettings]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         ClusterGetSettings {
             client,
             parts: ClusterGetSettingsParts::None,
@@ -240,7 +240,7 @@ impl<'a> ClusterGetSettings<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -265,7 +265,7 @@ impl<'a> ClusterGetSettings<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -275,12 +275,12 @@ impl<'a> ClusterGetSettings<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -292,14 +292,14 @@ impl<'a> ClusterGetSettings<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -307,13 +307,13 @@ impl<'a> ClusterGetSettings<'a> {
                 #[serde(rename = "include_defaults")]
                 include_defaults: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -338,13 +338,13 @@ impl<'a> ClusterGetSettings<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cluster Health API"]
-pub enum ClusterHealthParts<'a> {
+pub enum ClusterHealthParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> ClusterHealthParts<'a> {
+impl<'b> ClusterHealthParts<'b> {
     #[doc = "Builds a relative URL path to the Cluster Health API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -361,30 +361,30 @@ impl<'a> ClusterHealthParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Health API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html). Returns basic information about the health of the cluster."]
-pub struct ClusterHealth<'a> {
-    client: Elasticsearch,
-    parts: ClusterHealthParts<'a>,
+pub struct ClusterHealth<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: ClusterHealthParts<'b>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     level: Option<Level>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
     wait_for_events: Option<WaitForEvents>,
     wait_for_no_initializing_shards: Option<bool>,
     wait_for_no_relocating_shards: Option<bool>,
-    wait_for_nodes: Option<&'a str>,
+    wait_for_nodes: Option<&'b str>,
     wait_for_status: Option<WaitForStatus>,
 }
-impl<'a> ClusterHealth<'a> {
+impl<'a, 'b> ClusterHealth<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterHealth] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: ClusterHealthParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: ClusterHealthParts<'b>) -> Self {
         ClusterHealth {
             client,
             parts,
@@ -418,7 +418,7 @@ impl<'a> ClusterHealth<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -443,7 +443,7 @@ impl<'a> ClusterHealth<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -453,17 +453,17 @@ impl<'a> ClusterHealth<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Wait until the specified number of shards is active"]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -486,7 +486,7 @@ impl<'a> ClusterHealth<'a> {
         self
     }
     #[doc = "Wait until the specified number of nodes is available"]
-    pub fn wait_for_nodes(mut self, wait_for_nodes: &'a str) -> Self {
+    pub fn wait_for_nodes(mut self, wait_for_nodes: &'b str) -> Self {
         self.wait_for_nodes = Some(wait_for_nodes);
         self
     }
@@ -503,7 +503,7 @@ impl<'a> ClusterHealth<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "expand_wildcards")]
@@ -512,7 +512,7 @@ impl<'a> ClusterHealth<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "level")]
@@ -520,15 +520,15 @@ impl<'a> ClusterHealth<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
                 #[serde(rename = "wait_for_events")]
                 wait_for_events: Option<WaitForEvents>,
                 #[serde(rename = "wait_for_no_initializing_shards")]
@@ -536,7 +536,7 @@ impl<'a> ClusterHealth<'a> {
                 #[serde(rename = "wait_for_no_relocating_shards")]
                 wait_for_no_relocating_shards: Option<bool>,
                 #[serde(rename = "wait_for_nodes")]
-                wait_for_nodes: Option<&'a str>,
+                wait_for_nodes: Option<&'b str>,
                 #[serde(rename = "wait_for_status")]
                 wait_for_status: Option<WaitForStatus>,
             }
@@ -584,21 +584,21 @@ impl ClusterPendingTasksParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Pending Tasks API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html). Returns a list of any cluster-level changes (e.g. create index, update mapping,\nallocate or fail shard) which have not yet been executed."]
-pub struct ClusterPendingTasks<'a> {
-    client: Elasticsearch,
+pub struct ClusterPendingTasks<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: ClusterPendingTasksParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> ClusterPendingTasks<'a> {
+impl<'a, 'b> ClusterPendingTasks<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterPendingTasks]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         ClusterPendingTasks {
             client,
             parts: ClusterPendingTasksParts::None,
@@ -618,7 +618,7 @@ impl<'a> ClusterPendingTasks<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -638,7 +638,7 @@ impl<'a> ClusterPendingTasks<'a> {
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -648,7 +648,7 @@ impl<'a> ClusterPendingTasks<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -660,24 +660,24 @@ impl<'a> ClusterPendingTasks<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -714,26 +714,26 @@ impl ClusterPutSettingsParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Put Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html). Updates the cluster settings."]
-pub struct ClusterPutSettings<'a, B> {
-    client: Elasticsearch,
+pub struct ClusterPutSettings<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: ClusterPutSettingsParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> ClusterPutSettings<'a, B>
+impl<'a, 'b, B> ClusterPutSettings<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [ClusterPutSettings]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         ClusterPutSettings {
             client,
             parts: ClusterPutSettingsParts::None,
@@ -750,7 +750,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> ClusterPutSettings<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> ClusterPutSettings<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -775,7 +775,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -795,7 +795,7 @@ where
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -805,12 +805,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -822,26 +822,26 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -879,19 +879,19 @@ impl ClusterRemoteInfoParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Remote Info API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html). Returns the information about configured remote clusters."]
-pub struct ClusterRemoteInfo<'a> {
-    client: Elasticsearch,
+pub struct ClusterRemoteInfo<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: ClusterRemoteInfoParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> ClusterRemoteInfo<'a> {
+impl<'a, 'b> ClusterRemoteInfo<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterRemoteInfo]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         ClusterRemoteInfo {
             client,
             parts: ClusterRemoteInfoParts::None,
@@ -909,7 +909,7 @@ impl<'a> ClusterRemoteInfo<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -929,7 +929,7 @@ impl<'a> ClusterRemoteInfo<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -941,20 +941,20 @@ impl<'a> ClusterRemoteInfo<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -989,29 +989,29 @@ impl ClusterRerouteParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Reroute API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html). Allows to manually change the allocation of individual shards in the cluster."]
-pub struct ClusterReroute<'a, B> {
-    client: Elasticsearch,
+pub struct ClusterReroute<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: ClusterRerouteParts,
     body: Option<B>,
     dry_run: Option<bool>,
     error_trace: Option<bool>,
     explain: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
-    metric: Option<&'a [&'a str]>,
+    master_timeout: Option<&'b str>,
+    metric: Option<&'b [&'b str]>,
     pretty: Option<bool>,
     retry_failed: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> ClusterReroute<'a, B>
+impl<'a, 'b, B> ClusterReroute<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [ClusterReroute]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         ClusterReroute {
             client,
             parts: ClusterRerouteParts::None,
@@ -1031,7 +1031,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> ClusterReroute<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> ClusterReroute<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1069,7 +1069,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1084,12 +1084,12 @@ where
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
     #[doc = "Limit the information returned to the specified metrics. Defaults to all but metadata"]
-    pub fn metric(mut self, metric: &'a [&'a str]) -> Self {
+    pub fn metric(mut self, metric: &'b [&'b str]) -> Self {
         self.metric = Some(metric);
         self
     }
@@ -1104,12 +1104,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -1121,7 +1121,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "dry_run")]
                 dry_run: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -1132,21 +1132,21 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "metric", serialize_with = "crate::client::serialize_coll_qs")]
-                metric: Option<&'a [&'a str]>,
+                metric: Option<&'b [&'b str]>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "retry_failed")]
                 retry_failed: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 dry_run: self.dry_run,
@@ -1173,15 +1173,15 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cluster State API"]
-pub enum ClusterStateParts<'a> {
+pub enum ClusterStateParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Metric"]
-    Metric(&'a [&'a str]),
+    Metric(&'b [&'b str]),
     #[doc = "Metric and Index"]
-    MetricIndex(&'a [&'a str], &'a [&'a str]),
+    MetricIndex(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> ClusterStateParts<'a> {
+impl<'b> ClusterStateParts<'b> {
     #[doc = "Builds a relative URL path to the Cluster State API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1208,27 +1208,27 @@ impl<'a> ClusterStateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster State API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html). Returns a comprehensive information about the state of the cluster."]
-pub struct ClusterState<'a> {
-    client: Elasticsearch,
-    parts: ClusterStateParts<'a>,
+pub struct ClusterState<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: ClusterStateParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     wait_for_metadata_version: Option<i64>,
-    wait_for_timeout: Option<&'a str>,
+    wait_for_timeout: Option<&'b str>,
 }
-impl<'a> ClusterState<'a> {
+impl<'a, 'b> ClusterState<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterState] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: ClusterStateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: ClusterStateParts<'b>) -> Self {
         ClusterState {
             client,
             parts,
@@ -1264,7 +1264,7 @@ impl<'a> ClusterState<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1294,7 +1294,7 @@ impl<'a> ClusterState<'a> {
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1304,7 +1304,7 @@ impl<'a> ClusterState<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1314,7 +1314,7 @@ impl<'a> ClusterState<'a> {
         self
     }
     #[doc = "The maximum time to wait for wait_for_metadata_version before timing out"]
-    pub fn wait_for_timeout(mut self, wait_for_timeout: &'a str) -> Self {
+    pub fn wait_for_timeout(mut self, wait_for_timeout: &'b str) -> Self {
         self.wait_for_timeout = Some(wait_for_timeout);
         self
     }
@@ -1326,7 +1326,7 @@ impl<'a> ClusterState<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -1337,7 +1337,7 @@ impl<'a> ClusterState<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -1347,15 +1347,15 @@ impl<'a> ClusterState<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "wait_for_metadata_version")]
                 wait_for_metadata_version: Option<i64>,
                 #[serde(rename = "wait_for_timeout")]
-                wait_for_timeout: Option<&'a str>,
+                wait_for_timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -1384,13 +1384,13 @@ impl<'a> ClusterState<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Cluster Stats API"]
-pub enum ClusterStatsParts<'a> {
+pub enum ClusterStatsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "NodeId"]
-    NodeId(&'a [&'a str]),
+    NodeId(&'b [&'b str]),
 }
-impl<'a> ClusterStatsParts<'a> {
+impl<'b> ClusterStatsParts<'b> {
     #[doc = "Builds a relative URL path to the Cluster Stats API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1407,21 +1407,21 @@ impl<'a> ClusterStatsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html). Returns high-level overview of cluster statistics."]
-pub struct ClusterStats<'a> {
-    client: Elasticsearch,
-    parts: ClusterStatsParts<'a>,
+pub struct ClusterStats<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: ClusterStatsParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> ClusterStats<'a> {
+impl<'a, 'b> ClusterStats<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterStats] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: ClusterStatsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: ClusterStatsParts<'b>) -> Self {
         ClusterStats {
             client,
             parts,
@@ -1441,7 +1441,7 @@ impl<'a> ClusterStats<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1466,12 +1466,12 @@ impl<'a> ClusterStats<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -1483,14 +1483,14 @@ impl<'a> ClusterStats<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -1498,9 +1498,9 @@ impl<'a> ClusterStats<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1522,54 +1522,54 @@ impl<'a> ClusterStats<'a> {
     }
 }
 #[doc = "Namespace client for Cluster APIs"]
-pub struct Cluster {
-    client: Elasticsearch,
+pub struct Cluster<'a> {
+    client: &'a Elasticsearch,
 }
-impl Cluster {
+impl<'a> Cluster<'a> {
     #[doc = "Creates a new instance of [Cluster]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
     #[doc = "Provides explanations for shard allocations in the cluster."]
-    pub fn allocation_explain<'a>(&self) -> ClusterAllocationExplain<'a, ()> {
-        ClusterAllocationExplain::new(self.client.clone())
+    pub fn allocation_explain<'b>(&'a self) -> ClusterAllocationExplain<'a, 'b, ()> {
+        ClusterAllocationExplain::new(&self.client)
     }
     #[doc = "Returns cluster settings."]
-    pub fn get_settings<'a>(&self) -> ClusterGetSettings<'a> {
-        ClusterGetSettings::new(self.client.clone())
+    pub fn get_settings<'b>(&'a self) -> ClusterGetSettings<'a, 'b> {
+        ClusterGetSettings::new(&self.client)
     }
     #[doc = "Returns basic information about the health of the cluster."]
-    pub fn health<'a>(&self, parts: ClusterHealthParts<'a>) -> ClusterHealth<'a> {
-        ClusterHealth::new(self.client.clone(), parts)
+    pub fn health<'b>(&'a self, parts: ClusterHealthParts<'b>) -> ClusterHealth<'a, 'b> {
+        ClusterHealth::new(&self.client, parts)
     }
     #[doc = "Returns a list of any cluster-level changes (e.g. create index, update mapping,\nallocate or fail shard) which have not yet been executed."]
-    pub fn pending_tasks<'a>(&self) -> ClusterPendingTasks<'a> {
-        ClusterPendingTasks::new(self.client.clone())
+    pub fn pending_tasks<'b>(&'a self) -> ClusterPendingTasks<'a, 'b> {
+        ClusterPendingTasks::new(&self.client)
     }
     #[doc = "Updates the cluster settings."]
-    pub fn put_settings<'a>(&self) -> ClusterPutSettings<'a, ()> {
-        ClusterPutSettings::new(self.client.clone())
+    pub fn put_settings<'b>(&'a self) -> ClusterPutSettings<'a, 'b, ()> {
+        ClusterPutSettings::new(&self.client)
     }
     #[doc = "Returns the information about configured remote clusters."]
-    pub fn remote_info<'a>(&self) -> ClusterRemoteInfo<'a> {
-        ClusterRemoteInfo::new(self.client.clone())
+    pub fn remote_info<'b>(&'a self) -> ClusterRemoteInfo<'a, 'b> {
+        ClusterRemoteInfo::new(&self.client)
     }
     #[doc = "Allows to manually change the allocation of individual shards in the cluster."]
-    pub fn reroute<'a>(&self) -> ClusterReroute<'a, ()> {
-        ClusterReroute::new(self.client.clone())
+    pub fn reroute<'b>(&'a self) -> ClusterReroute<'a, 'b, ()> {
+        ClusterReroute::new(&self.client)
     }
     #[doc = "Returns a comprehensive information about the state of the cluster."]
-    pub fn state<'a>(&self, parts: ClusterStateParts<'a>) -> ClusterState<'a> {
-        ClusterState::new(self.client.clone(), parts)
+    pub fn state<'b>(&'a self, parts: ClusterStateParts<'b>) -> ClusterState<'a, 'b> {
+        ClusterState::new(&self.client, parts)
     }
     #[doc = "Returns high-level overview of cluster statistics."]
-    pub fn stats<'a>(&self, parts: ClusterStatsParts<'a>) -> ClusterStats<'a> {
-        ClusterStats::new(self.client.clone(), parts)
+    pub fn stats<'b>(&'a self, parts: ClusterStatsParts<'b>) -> ClusterStats<'a, 'b> {
+        ClusterStats::new(&self.client, parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Cluster APIs"]
     pub fn cluster(&self) -> Cluster {
-        Cluster::new(self.clone())
+        Cluster::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/enrich.rs
+++ b/elasticsearch/src/generated/namespace_clients/enrich.rs
@@ -31,11 +31,11 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Enrich Delete Policy API"]
-pub enum EnrichDeletePolicyParts<'a> {
+pub enum EnrichDeletePolicyParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> EnrichDeletePolicyParts<'a> {
+impl<'b> EnrichDeletePolicyParts<'b> {
     #[doc = "Builds a relative URL path to the Enrich Delete Policy API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -50,19 +50,19 @@ impl<'a> EnrichDeletePolicyParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Enrich Delete Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-delete-policy.html)."]
-pub struct EnrichDeletePolicy<'a> {
-    client: Elasticsearch,
-    parts: EnrichDeletePolicyParts<'a>,
+pub struct EnrichDeletePolicy<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: EnrichDeletePolicyParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> EnrichDeletePolicy<'a> {
+impl<'a, 'b> EnrichDeletePolicy<'a, 'b> {
     #[doc = "Creates a new instance of [EnrichDeletePolicy] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: EnrichDeletePolicyParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: EnrichDeletePolicyParts<'b>) -> Self {
         EnrichDeletePolicy {
             client,
             parts,
@@ -80,7 +80,7 @@ impl<'a> EnrichDeletePolicy<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -100,7 +100,7 @@ impl<'a> EnrichDeletePolicy<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -112,20 +112,20 @@ impl<'a> EnrichDeletePolicy<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -146,11 +146,11 @@ impl<'a> EnrichDeletePolicy<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Enrich Execute Policy API"]
-pub enum EnrichExecutePolicyParts<'a> {
+pub enum EnrichExecutePolicyParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> EnrichExecutePolicyParts<'a> {
+impl<'b> EnrichExecutePolicyParts<'b> {
     #[doc = "Builds a relative URL path to the Enrich Execute Policy API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -166,24 +166,24 @@ impl<'a> EnrichExecutePolicyParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Enrich Execute Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-execute-policy.html)."]
-pub struct EnrichExecutePolicy<'a, B> {
-    client: Elasticsearch,
-    parts: EnrichExecutePolicyParts<'a>,
+pub struct EnrichExecutePolicy<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: EnrichExecutePolicyParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     wait_for_completion: Option<bool>,
 }
-impl<'a, B> EnrichExecutePolicy<'a, B>
+impl<'a, 'b, B> EnrichExecutePolicy<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [EnrichExecutePolicy] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: EnrichExecutePolicyParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: EnrichExecutePolicyParts<'b>) -> Self {
         EnrichExecutePolicy {
             client,
             parts,
@@ -198,7 +198,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> EnrichExecutePolicy<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> EnrichExecutePolicy<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -221,7 +221,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -241,7 +241,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -258,20 +258,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "wait_for_completion")]
                 wait_for_completion: Option<bool>,
             }
@@ -295,13 +295,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Enrich Get Policy API"]
-pub enum EnrichGetPolicyParts<'a> {
+pub enum EnrichGetPolicyParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
     #[doc = "No parts"]
     None,
 }
-impl<'a> EnrichGetPolicyParts<'a> {
+impl<'b> EnrichGetPolicyParts<'b> {
     #[doc = "Builds a relative URL path to the Enrich Get Policy API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -317,19 +317,19 @@ impl<'a> EnrichGetPolicyParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Enrich Get Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-get-policy.html)."]
-pub struct EnrichGetPolicy<'a> {
-    client: Elasticsearch,
-    parts: EnrichGetPolicyParts<'a>,
+pub struct EnrichGetPolicy<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: EnrichGetPolicyParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> EnrichGetPolicy<'a> {
+impl<'a, 'b> EnrichGetPolicy<'a, 'b> {
     #[doc = "Creates a new instance of [EnrichGetPolicy] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: EnrichGetPolicyParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: EnrichGetPolicyParts<'b>) -> Self {
         EnrichGetPolicy {
             client,
             parts,
@@ -347,7 +347,7 @@ impl<'a> EnrichGetPolicy<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -367,7 +367,7 @@ impl<'a> EnrichGetPolicy<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -379,20 +379,20 @@ impl<'a> EnrichGetPolicy<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -413,11 +413,11 @@ impl<'a> EnrichGetPolicy<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Enrich Put Policy API"]
-pub enum EnrichPutPolicyParts<'a> {
+pub enum EnrichPutPolicyParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> EnrichPutPolicyParts<'a> {
+impl<'b> EnrichPutPolicyParts<'b> {
     #[doc = "Builds a relative URL path to the Enrich Put Policy API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -432,23 +432,23 @@ impl<'a> EnrichPutPolicyParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Enrich Put Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-put-policy.html)."]
-pub struct EnrichPutPolicy<'a, B> {
-    client: Elasticsearch,
-    parts: EnrichPutPolicyParts<'a>,
+pub struct EnrichPutPolicy<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: EnrichPutPolicyParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> EnrichPutPolicy<'a, B>
+impl<'a, 'b, B> EnrichPutPolicy<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [EnrichPutPolicy] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: EnrichPutPolicyParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: EnrichPutPolicyParts<'b>) -> Self {
         EnrichPutPolicy {
             client,
             parts,
@@ -462,7 +462,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> EnrichPutPolicy<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> EnrichPutPolicy<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -484,7 +484,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -504,7 +504,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -516,20 +516,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -564,19 +564,19 @@ impl EnrichStatsParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Enrich Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-stats.html)."]
-pub struct EnrichStats<'a> {
-    client: Elasticsearch,
+pub struct EnrichStats<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: EnrichStatsParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> EnrichStats<'a> {
+impl<'a, 'b> EnrichStats<'a, 'b> {
     #[doc = "Creates a new instance of [EnrichStats]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         EnrichStats {
             client,
             parts: EnrichStatsParts::None,
@@ -594,7 +594,7 @@ impl<'a> EnrichStats<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -614,7 +614,7 @@ impl<'a> EnrichStats<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -626,20 +626,20 @@ impl<'a> EnrichStats<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -659,36 +659,42 @@ impl<'a> EnrichStats<'a> {
     }
 }
 #[doc = "Namespace client for Enrich APIs"]
-pub struct Enrich {
-    client: Elasticsearch,
+pub struct Enrich<'a> {
+    client: &'a Elasticsearch,
 }
-impl Enrich {
+impl<'a> Enrich<'a> {
     #[doc = "Creates a new instance of [Enrich]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn delete_policy<'a>(&self, parts: EnrichDeletePolicyParts<'a>) -> EnrichDeletePolicy<'a> {
-        EnrichDeletePolicy::new(self.client.clone(), parts)
+    pub fn delete_policy<'b>(
+        &'a self,
+        parts: EnrichDeletePolicyParts<'b>,
+    ) -> EnrichDeletePolicy<'a, 'b> {
+        EnrichDeletePolicy::new(&self.client, parts)
     }
-    pub fn execute_policy<'a>(
-        &self,
-        parts: EnrichExecutePolicyParts<'a>,
-    ) -> EnrichExecutePolicy<'a, ()> {
-        EnrichExecutePolicy::new(self.client.clone(), parts)
+    pub fn execute_policy<'b>(
+        &'a self,
+        parts: EnrichExecutePolicyParts<'b>,
+    ) -> EnrichExecutePolicy<'a, 'b, ()> {
+        EnrichExecutePolicy::new(&self.client, parts)
     }
-    pub fn get_policy<'a>(&self, parts: EnrichGetPolicyParts<'a>) -> EnrichGetPolicy<'a> {
-        EnrichGetPolicy::new(self.client.clone(), parts)
+    pub fn get_policy<'b>(&'a self, parts: EnrichGetPolicyParts<'b>) -> EnrichGetPolicy<'a, 'b> {
+        EnrichGetPolicy::new(&self.client, parts)
     }
-    pub fn put_policy<'a>(&self, parts: EnrichPutPolicyParts<'a>) -> EnrichPutPolicy<'a, ()> {
-        EnrichPutPolicy::new(self.client.clone(), parts)
+    pub fn put_policy<'b>(
+        &'a self,
+        parts: EnrichPutPolicyParts<'b>,
+    ) -> EnrichPutPolicy<'a, 'b, ()> {
+        EnrichPutPolicy::new(&self.client, parts)
     }
-    pub fn stats<'a>(&self) -> EnrichStats<'a> {
-        EnrichStats::new(self.client.clone())
+    pub fn stats<'b>(&'a self) -> EnrichStats<'a, 'b> {
+        EnrichStats::new(&self.client)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Enrich APIs"]
     pub fn enrich(&self) -> Enrich {
-        Enrich::new(self.clone())
+        Enrich::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/graph.rs
+++ b/elasticsearch/src/generated/namespace_clients/graph.rs
@@ -31,13 +31,13 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Graph Explore API"]
-pub enum GraphExploreParts<'a> {
+pub enum GraphExploreParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> GraphExploreParts<'a> {
+impl<'b> GraphExploreParts<'b> {
     #[doc = "Builds a relative URL path to the Graph Explore API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -65,25 +65,25 @@ impl<'a> GraphExploreParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Graph Explore API](https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html)."]
-pub struct GraphExplore<'a, B> {
-    client: Elasticsearch,
-    parts: GraphExploreParts<'a>,
+pub struct GraphExplore<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: GraphExploreParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> GraphExplore<'a, B>
+impl<'a, 'b, B> GraphExplore<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [GraphExplore] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: GraphExploreParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: GraphExploreParts<'b>) -> Self {
         GraphExplore {
             client,
             parts,
@@ -99,7 +99,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> GraphExplore<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> GraphExplore<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -123,7 +123,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -143,17 +143,17 @@ where
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -168,24 +168,24 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -207,21 +207,21 @@ where
     }
 }
 #[doc = "Namespace client for Graph APIs"]
-pub struct Graph {
-    client: Elasticsearch,
+pub struct Graph<'a> {
+    client: &'a Elasticsearch,
 }
-impl Graph {
+impl<'a> Graph<'a> {
     #[doc = "Creates a new instance of [Graph]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn explore<'a>(&self, parts: GraphExploreParts<'a>) -> GraphExplore<'a, ()> {
-        GraphExplore::new(self.client.clone(), parts)
+    pub fn explore<'b>(&'a self, parts: GraphExploreParts<'b>) -> GraphExplore<'a, 'b, ()> {
+        GraphExplore::new(&self.client, parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Graph APIs"]
     pub fn graph(&self) -> Graph {
-        Graph::new(self.clone())
+        Graph::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/ilm.rs
+++ b/elasticsearch/src/generated/namespace_clients/ilm.rs
@@ -31,11 +31,11 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ilm Delete Lifecycle API"]
-pub enum IlmDeleteLifecycleParts<'a> {
+pub enum IlmDeleteLifecycleParts<'b> {
     #[doc = "Policy"]
-    Policy(&'a str),
+    Policy(&'b str),
 }
-impl<'a> IlmDeleteLifecycleParts<'a> {
+impl<'b> IlmDeleteLifecycleParts<'b> {
     #[doc = "Builds a relative URL path to the Ilm Delete Lifecycle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -50,19 +50,19 @@ impl<'a> IlmDeleteLifecycleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Delete Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html)."]
-pub struct IlmDeleteLifecycle<'a> {
-    client: Elasticsearch,
-    parts: IlmDeleteLifecycleParts<'a>,
+pub struct IlmDeleteLifecycle<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IlmDeleteLifecycleParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IlmDeleteLifecycle<'a> {
+impl<'a, 'b> IlmDeleteLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [IlmDeleteLifecycle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IlmDeleteLifecycleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IlmDeleteLifecycleParts<'b>) -> Self {
         IlmDeleteLifecycle {
             client,
             parts,
@@ -80,7 +80,7 @@ impl<'a> IlmDeleteLifecycle<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -100,7 +100,7 @@ impl<'a> IlmDeleteLifecycle<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -112,20 +112,20 @@ impl<'a> IlmDeleteLifecycle<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -146,11 +146,11 @@ impl<'a> IlmDeleteLifecycle<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ilm Explain Lifecycle API"]
-pub enum IlmExplainLifecycleParts<'a> {
+pub enum IlmExplainLifecycleParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> IlmExplainLifecycleParts<'a> {
+impl<'b> IlmExplainLifecycleParts<'b> {
     #[doc = "Builds a relative URL path to the Ilm Explain Lifecycle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -166,21 +166,21 @@ impl<'a> IlmExplainLifecycleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Explain Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html)."]
-pub struct IlmExplainLifecycle<'a> {
-    client: Elasticsearch,
-    parts: IlmExplainLifecycleParts<'a>,
+pub struct IlmExplainLifecycle<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IlmExplainLifecycleParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     only_errors: Option<bool>,
     only_managed: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IlmExplainLifecycle<'a> {
+impl<'a, 'b> IlmExplainLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [IlmExplainLifecycle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IlmExplainLifecycleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IlmExplainLifecycleParts<'b>) -> Self {
         IlmExplainLifecycle {
             client,
             parts,
@@ -200,7 +200,7 @@ impl<'a> IlmExplainLifecycle<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -230,7 +230,7 @@ impl<'a> IlmExplainLifecycle<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -242,14 +242,14 @@ impl<'a> IlmExplainLifecycle<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "only_errors")]
@@ -259,7 +259,7 @@ impl<'a> IlmExplainLifecycle<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -282,13 +282,13 @@ impl<'a> IlmExplainLifecycle<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ilm Get Lifecycle API"]
-pub enum IlmGetLifecycleParts<'a> {
+pub enum IlmGetLifecycleParts<'b> {
     #[doc = "Policy"]
-    Policy(&'a str),
+    Policy(&'b str),
     #[doc = "No parts"]
     None,
 }
-impl<'a> IlmGetLifecycleParts<'a> {
+impl<'b> IlmGetLifecycleParts<'b> {
     #[doc = "Builds a relative URL path to the Ilm Get Lifecycle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -304,19 +304,19 @@ impl<'a> IlmGetLifecycleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Get Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html)."]
-pub struct IlmGetLifecycle<'a> {
-    client: Elasticsearch,
-    parts: IlmGetLifecycleParts<'a>,
+pub struct IlmGetLifecycle<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IlmGetLifecycleParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IlmGetLifecycle<'a> {
+impl<'a, 'b> IlmGetLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [IlmGetLifecycle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IlmGetLifecycleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IlmGetLifecycleParts<'b>) -> Self {
         IlmGetLifecycle {
             client,
             parts,
@@ -334,7 +334,7 @@ impl<'a> IlmGetLifecycle<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -354,7 +354,7 @@ impl<'a> IlmGetLifecycle<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -366,20 +366,20 @@ impl<'a> IlmGetLifecycle<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -414,19 +414,19 @@ impl IlmGetStatusParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Get Status API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html)."]
-pub struct IlmGetStatus<'a> {
-    client: Elasticsearch,
+pub struct IlmGetStatus<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: IlmGetStatusParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IlmGetStatus<'a> {
+impl<'a, 'b> IlmGetStatus<'a, 'b> {
     #[doc = "Creates a new instance of [IlmGetStatus]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         IlmGetStatus {
             client,
             parts: IlmGetStatusParts::None,
@@ -444,7 +444,7 @@ impl<'a> IlmGetStatus<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -464,7 +464,7 @@ impl<'a> IlmGetStatus<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -476,20 +476,20 @@ impl<'a> IlmGetStatus<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -510,11 +510,11 @@ impl<'a> IlmGetStatus<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ilm Move To Step API"]
-pub enum IlmMoveToStepParts<'a> {
+pub enum IlmMoveToStepParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> IlmMoveToStepParts<'a> {
+impl<'b> IlmMoveToStepParts<'b> {
     #[doc = "Builds a relative URL path to the Ilm Move To Step API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -529,23 +529,23 @@ impl<'a> IlmMoveToStepParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Move To Step API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html)."]
-pub struct IlmMoveToStep<'a, B> {
-    client: Elasticsearch,
-    parts: IlmMoveToStepParts<'a>,
+pub struct IlmMoveToStep<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IlmMoveToStepParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IlmMoveToStep<'a, B>
+impl<'a, 'b, B> IlmMoveToStep<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmMoveToStep] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IlmMoveToStepParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IlmMoveToStepParts<'b>) -> Self {
         IlmMoveToStep {
             client,
             parts,
@@ -559,7 +559,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IlmMoveToStep<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IlmMoveToStep<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -581,7 +581,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -601,7 +601,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -613,20 +613,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -647,11 +647,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ilm Put Lifecycle API"]
-pub enum IlmPutLifecycleParts<'a> {
+pub enum IlmPutLifecycleParts<'b> {
     #[doc = "Policy"]
-    Policy(&'a str),
+    Policy(&'b str),
 }
-impl<'a> IlmPutLifecycleParts<'a> {
+impl<'b> IlmPutLifecycleParts<'b> {
     #[doc = "Builds a relative URL path to the Ilm Put Lifecycle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -666,23 +666,23 @@ impl<'a> IlmPutLifecycleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Put Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html)."]
-pub struct IlmPutLifecycle<'a, B> {
-    client: Elasticsearch,
-    parts: IlmPutLifecycleParts<'a>,
+pub struct IlmPutLifecycle<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IlmPutLifecycleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IlmPutLifecycle<'a, B>
+impl<'a, 'b, B> IlmPutLifecycle<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmPutLifecycle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IlmPutLifecycleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IlmPutLifecycleParts<'b>) -> Self {
         IlmPutLifecycle {
             client,
             parts,
@@ -696,7 +696,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IlmPutLifecycle<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IlmPutLifecycle<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -718,7 +718,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -738,7 +738,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -750,20 +750,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -784,11 +784,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ilm Remove Policy API"]
-pub enum IlmRemovePolicyParts<'a> {
+pub enum IlmRemovePolicyParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> IlmRemovePolicyParts<'a> {
+impl<'b> IlmRemovePolicyParts<'b> {
     #[doc = "Builds a relative URL path to the Ilm Remove Policy API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -804,23 +804,23 @@ impl<'a> IlmRemovePolicyParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Remove Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html)."]
-pub struct IlmRemovePolicy<'a, B> {
-    client: Elasticsearch,
-    parts: IlmRemovePolicyParts<'a>,
+pub struct IlmRemovePolicy<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IlmRemovePolicyParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IlmRemovePolicy<'a, B>
+impl<'a, 'b, B> IlmRemovePolicy<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmRemovePolicy] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IlmRemovePolicyParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IlmRemovePolicyParts<'b>) -> Self {
         IlmRemovePolicy {
             client,
             parts,
@@ -834,7 +834,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IlmRemovePolicy<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IlmRemovePolicy<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -856,7 +856,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -876,7 +876,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -888,20 +888,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -922,11 +922,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ilm Retry API"]
-pub enum IlmRetryParts<'a> {
+pub enum IlmRetryParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> IlmRetryParts<'a> {
+impl<'b> IlmRetryParts<'b> {
     #[doc = "Builds a relative URL path to the Ilm Retry API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -942,23 +942,23 @@ impl<'a> IlmRetryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Retry API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html)."]
-pub struct IlmRetry<'a, B> {
-    client: Elasticsearch,
-    parts: IlmRetryParts<'a>,
+pub struct IlmRetry<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IlmRetryParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IlmRetry<'a, B>
+impl<'a, 'b, B> IlmRetry<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmRetry] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IlmRetryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IlmRetryParts<'b>) -> Self {
         IlmRetry {
             client,
             parts,
@@ -972,7 +972,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IlmRetry<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IlmRetry<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -994,7 +994,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1014,7 +1014,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1026,20 +1026,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1074,23 +1074,23 @@ impl IlmStartParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Start API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html)."]
-pub struct IlmStart<'a, B> {
-    client: Elasticsearch,
+pub struct IlmStart<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: IlmStartParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IlmStart<'a, B>
+impl<'a, 'b, B> IlmStart<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmStart]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         IlmStart {
             client,
             parts: IlmStartParts::None,
@@ -1104,7 +1104,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IlmStart<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IlmStart<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1126,7 +1126,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1146,7 +1146,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1158,20 +1158,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1206,23 +1206,23 @@ impl IlmStopParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Stop API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html)."]
-pub struct IlmStop<'a, B> {
-    client: Elasticsearch,
+pub struct IlmStop<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: IlmStopParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IlmStop<'a, B>
+impl<'a, 'b, B> IlmStop<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmStop]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         IlmStop {
             client,
             parts: IlmStopParts::None,
@@ -1236,7 +1236,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IlmStop<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IlmStop<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1258,7 +1258,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1278,7 +1278,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1290,20 +1290,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1323,54 +1323,60 @@ where
     }
 }
 #[doc = "Namespace client for Index Lifecycle Management APIs"]
-pub struct Ilm {
-    client: Elasticsearch,
+pub struct Ilm<'a> {
+    client: &'a Elasticsearch,
 }
-impl Ilm {
+impl<'a> Ilm<'a> {
     #[doc = "Creates a new instance of [Ilm]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn delete_lifecycle<'a>(
-        &self,
-        parts: IlmDeleteLifecycleParts<'a>,
-    ) -> IlmDeleteLifecycle<'a> {
-        IlmDeleteLifecycle::new(self.client.clone(), parts)
+    pub fn delete_lifecycle<'b>(
+        &'a self,
+        parts: IlmDeleteLifecycleParts<'b>,
+    ) -> IlmDeleteLifecycle<'a, 'b> {
+        IlmDeleteLifecycle::new(&self.client, parts)
     }
-    pub fn explain_lifecycle<'a>(
-        &self,
-        parts: IlmExplainLifecycleParts<'a>,
-    ) -> IlmExplainLifecycle<'a> {
-        IlmExplainLifecycle::new(self.client.clone(), parts)
+    pub fn explain_lifecycle<'b>(
+        &'a self,
+        parts: IlmExplainLifecycleParts<'b>,
+    ) -> IlmExplainLifecycle<'a, 'b> {
+        IlmExplainLifecycle::new(&self.client, parts)
     }
-    pub fn get_lifecycle<'a>(&self, parts: IlmGetLifecycleParts<'a>) -> IlmGetLifecycle<'a> {
-        IlmGetLifecycle::new(self.client.clone(), parts)
+    pub fn get_lifecycle<'b>(&'a self, parts: IlmGetLifecycleParts<'b>) -> IlmGetLifecycle<'a, 'b> {
+        IlmGetLifecycle::new(&self.client, parts)
     }
-    pub fn get_status<'a>(&self) -> IlmGetStatus<'a> {
-        IlmGetStatus::new(self.client.clone())
+    pub fn get_status<'b>(&'a self) -> IlmGetStatus<'a, 'b> {
+        IlmGetStatus::new(&self.client)
     }
-    pub fn move_to_step<'a>(&self, parts: IlmMoveToStepParts<'a>) -> IlmMoveToStep<'a, ()> {
-        IlmMoveToStep::new(self.client.clone(), parts)
+    pub fn move_to_step<'b>(&'a self, parts: IlmMoveToStepParts<'b>) -> IlmMoveToStep<'a, 'b, ()> {
+        IlmMoveToStep::new(&self.client, parts)
     }
-    pub fn put_lifecycle<'a>(&self, parts: IlmPutLifecycleParts<'a>) -> IlmPutLifecycle<'a, ()> {
-        IlmPutLifecycle::new(self.client.clone(), parts)
+    pub fn put_lifecycle<'b>(
+        &'a self,
+        parts: IlmPutLifecycleParts<'b>,
+    ) -> IlmPutLifecycle<'a, 'b, ()> {
+        IlmPutLifecycle::new(&self.client, parts)
     }
-    pub fn remove_policy<'a>(&self, parts: IlmRemovePolicyParts<'a>) -> IlmRemovePolicy<'a, ()> {
-        IlmRemovePolicy::new(self.client.clone(), parts)
+    pub fn remove_policy<'b>(
+        &'a self,
+        parts: IlmRemovePolicyParts<'b>,
+    ) -> IlmRemovePolicy<'a, 'b, ()> {
+        IlmRemovePolicy::new(&self.client, parts)
     }
-    pub fn retry<'a>(&self, parts: IlmRetryParts<'a>) -> IlmRetry<'a, ()> {
-        IlmRetry::new(self.client.clone(), parts)
+    pub fn retry<'b>(&'a self, parts: IlmRetryParts<'b>) -> IlmRetry<'a, 'b, ()> {
+        IlmRetry::new(&self.client, parts)
     }
-    pub fn start<'a>(&self) -> IlmStart<'a, ()> {
-        IlmStart::new(self.client.clone())
+    pub fn start<'b>(&'a self) -> IlmStart<'a, 'b, ()> {
+        IlmStart::new(&self.client)
     }
-    pub fn stop<'a>(&self) -> IlmStop<'a, ()> {
-        IlmStop::new(self.client.clone())
+    pub fn stop<'b>(&'a self) -> IlmStop<'a, 'b, ()> {
+        IlmStop::new(&self.client)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Index Lifecycle Management APIs"]
     pub fn ilm(&self) -> Ilm {
-        Ilm::new(self.clone())
+        Ilm::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/indices.rs
+++ b/elasticsearch/src/generated/namespace_clients/indices.rs
@@ -31,13 +31,13 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Analyze API"]
-pub enum IndicesAnalyzeParts<'a> {
+pub enum IndicesAnalyzeParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> IndicesAnalyzeParts<'a> {
+impl<'b> IndicesAnalyzeParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Analyze API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -54,24 +54,24 @@ impl<'a> IndicesAnalyzeParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Analyze API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html). Performs the analysis process on a text and return the tokens breakdown of the text."]
-pub struct IndicesAnalyze<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesAnalyzeParts<'a>,
+pub struct IndicesAnalyze<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesAnalyzeParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    index: Option<&'a str>,
+    index: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IndicesAnalyze<'a, B>
+impl<'a, 'b, B> IndicesAnalyze<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesAnalyze] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesAnalyzeParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesAnalyzeParts<'b>) -> Self {
         IndicesAnalyze {
             client,
             parts,
@@ -86,7 +86,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesAnalyze<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesAnalyze<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -109,7 +109,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -124,7 +124,7 @@ where
         self
     }
     #[doc = "The name of the index to scope the operation"]
-    pub fn index(mut self, index: &'a str) -> Self {
+    pub fn index(mut self, index: &'b str) -> Self {
         self.index = Some(index);
         self
     }
@@ -134,7 +134,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -149,22 +149,22 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "index")]
-                index: Option<&'a str>,
+                index: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -186,13 +186,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Clear Cache API"]
-pub enum IndicesClearCacheParts<'a> {
+pub enum IndicesClearCacheParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesClearCacheParts<'a> {
+impl<'b> IndicesClearCacheParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Clear Cache API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -210,31 +210,31 @@ impl<'a> IndicesClearCacheParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Clear Cache API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html). Clears all or specific caches for one or more indices."]
-pub struct IndicesClearCache<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesClearCacheParts<'a>,
+pub struct IndicesClearCache<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesClearCacheParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
     fielddata: Option<bool>,
-    fields: Option<&'a [&'a str]>,
-    filter_path: Option<&'a [&'a str]>,
+    fields: Option<&'b [&'b str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
-    index: Option<&'a [&'a str]>,
+    index: Option<&'b [&'b str]>,
     pretty: Option<bool>,
     query: Option<bool>,
     request: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IndicesClearCache<'a, B>
+impl<'a, 'b, B> IndicesClearCache<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesClearCache] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesClearCacheParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesClearCacheParts<'b>) -> Self {
         IndicesClearCache {
             client,
             parts,
@@ -261,7 +261,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesClearCache<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesClearCache<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -301,12 +301,12 @@ where
         self
     }
     #[doc = "A comma-separated list of fields to clear when using the `fielddata` parameter (default: all)"]
-    pub fn fields(mut self, fields: &'a [&'a str]) -> Self {
+    pub fn fields(mut self, fields: &'b [&'b str]) -> Self {
         self.fields = Some(fields);
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -326,7 +326,7 @@ where
         self
     }
     #[doc = "A comma-separated list of index name to limit the operation"]
-    pub fn index(mut self, index: &'a [&'a str]) -> Self {
+    pub fn index(mut self, index: &'b [&'b str]) -> Self {
         self.index = Some(index);
         self
     }
@@ -346,7 +346,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -358,7 +358,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -368,18 +368,18 @@ where
                 #[serde(rename = "fielddata")]
                 fielddata: Option<bool>,
                 #[serde(rename = "fields", serialize_with = "crate::client::serialize_coll_qs")]
-                fields: Option<&'a [&'a str]>,
+                fields: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "index", serialize_with = "crate::client::serialize_coll_qs")]
-                index: Option<&'a [&'a str]>,
+                index: Option<&'b [&'b str]>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "query")]
@@ -387,7 +387,7 @@ where
                 #[serde(rename = "request")]
                 request: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -416,11 +416,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Clone API"]
-pub enum IndicesCloneParts<'a> {
+pub enum IndicesCloneParts<'b> {
     #[doc = "Index and Target"]
-    IndexTarget(&'a str, &'a str),
+    IndexTarget(&'b str, &'b str),
 }
-impl<'a> IndicesCloneParts<'a> {
+impl<'b> IndicesCloneParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Clone API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -437,26 +437,26 @@ impl<'a> IndicesCloneParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Clone API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html). Clones an index"]
-pub struct IndicesClone<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesCloneParts<'a>,
+pub struct IndicesClone<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesCloneParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> IndicesClone<'a, B>
+impl<'a, 'b, B> IndicesClone<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesClone] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesCloneParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesCloneParts<'b>) -> Self {
         IndicesClone {
             client,
             parts,
@@ -473,7 +473,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesClone<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesClone<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -498,7 +498,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -513,7 +513,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -523,17 +523,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Set the number of active shards to wait for on the cloned index before the operation returns."]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -545,26 +545,26 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -588,11 +588,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Close API"]
-pub enum IndicesCloseParts<'a> {
+pub enum IndicesCloseParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesCloseParts<'a> {
+impl<'b> IndicesCloseParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Close API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -609,29 +609,29 @@ impl<'a> IndicesCloseParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Close API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html). Closes an index."]
-pub struct IndicesClose<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesCloseParts<'a>,
+pub struct IndicesClose<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesCloseParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> IndicesClose<'a, B>
+impl<'a, 'b, B> IndicesClose<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesClose] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesCloseParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesCloseParts<'b>) -> Self {
         IndicesClose {
             client,
             parts,
@@ -656,7 +656,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesClose<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesClose<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -689,7 +689,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -709,7 +709,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -719,17 +719,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Sets the number of active shards to wait for before the operation returns."]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -741,7 +741,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -752,21 +752,21 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -793,11 +793,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Create API"]
-pub enum IndicesCreateParts<'a> {
+pub enum IndicesCreateParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> IndicesCreateParts<'a> {
+impl<'b> IndicesCreateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Create API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -812,27 +812,27 @@ impl<'a> IndicesCreateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Create API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html). Creates an index with optional settings and mappings."]
-pub struct IndicesCreate<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesCreateParts<'a>,
+pub struct IndicesCreate<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesCreateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     include_type_name: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> IndicesCreate<'a, B>
+impl<'a, 'b, B> IndicesCreate<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesCreate] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesCreateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesCreateParts<'b>) -> Self {
         IndicesCreate {
             client,
             parts,
@@ -850,7 +850,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesCreate<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesCreate<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -876,7 +876,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -896,7 +896,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -906,17 +906,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Set the number of active shards to wait for before the operation returns."]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -928,28 +928,28 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "include_type_name")]
                 include_type_name: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -974,11 +974,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Delete API"]
-pub enum IndicesDeleteParts<'a> {
+pub enum IndicesDeleteParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesDeleteParts<'a> {
+impl<'b> IndicesDeleteParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Delete API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -994,24 +994,24 @@ impl<'a> IndicesDeleteParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html). Deletes an index."]
-pub struct IndicesDelete<'a> {
-    client: Elasticsearch,
-    parts: IndicesDeleteParts<'a>,
+pub struct IndicesDelete<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesDeleteParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> IndicesDelete<'a> {
+impl<'a, 'b> IndicesDelete<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesDelete] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesDeleteParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesDeleteParts<'b>) -> Self {
         IndicesDelete {
             client,
             parts,
@@ -1044,7 +1044,7 @@ impl<'a> IndicesDelete<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1064,7 +1064,7 @@ impl<'a> IndicesDelete<'a> {
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1074,12 +1074,12 @@ impl<'a> IndicesDelete<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -1091,7 +1091,7 @@ impl<'a> IndicesDelete<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -1102,19 +1102,19 @@ impl<'a> IndicesDelete<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -1140,11 +1140,11 @@ impl<'a> IndicesDelete<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Delete Alias API"]
-pub enum IndicesDeleteAliasParts<'a> {
+pub enum IndicesDeleteAliasParts<'b> {
     #[doc = "Index and Name"]
-    IndexName(&'a [&'a str], &'a [&'a str]),
+    IndexName(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> IndicesDeleteAliasParts<'a> {
+impl<'b> IndicesDeleteAliasParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Delete Alias API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1163,21 +1163,21 @@ impl<'a> IndicesDeleteAliasParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Delete Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html). Deletes an alias."]
-pub struct IndicesDeleteAlias<'a> {
-    client: Elasticsearch,
-    parts: IndicesDeleteAliasParts<'a>,
+pub struct IndicesDeleteAlias<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesDeleteAliasParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> IndicesDeleteAlias<'a> {
+impl<'a, 'b> IndicesDeleteAlias<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesDeleteAlias] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesDeleteAliasParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesDeleteAliasParts<'b>) -> Self {
         IndicesDeleteAlias {
             client,
             parts,
@@ -1197,7 +1197,7 @@ impl<'a> IndicesDeleteAlias<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1212,7 +1212,7 @@ impl<'a> IndicesDeleteAlias<'a> {
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1222,12 +1222,12 @@ impl<'a> IndicesDeleteAlias<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit timestamp for the document"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -1239,24 +1239,24 @@ impl<'a> IndicesDeleteAlias<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1279,11 +1279,11 @@ impl<'a> IndicesDeleteAlias<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Delete Template API"]
-pub enum IndicesDeleteTemplateParts<'a> {
+pub enum IndicesDeleteTemplateParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> IndicesDeleteTemplateParts<'a> {
+impl<'b> IndicesDeleteTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Delete Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1298,21 +1298,21 @@ impl<'a> IndicesDeleteTemplateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Delete Template API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html). Deletes an index template."]
-pub struct IndicesDeleteTemplate<'a> {
-    client: Elasticsearch,
-    parts: IndicesDeleteTemplateParts<'a>,
+pub struct IndicesDeleteTemplate<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesDeleteTemplateParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> IndicesDeleteTemplate<'a> {
+impl<'a, 'b> IndicesDeleteTemplate<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesDeleteTemplate] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesDeleteTemplateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesDeleteTemplateParts<'b>) -> Self {
         IndicesDeleteTemplate {
             client,
             parts,
@@ -1332,7 +1332,7 @@ impl<'a> IndicesDeleteTemplate<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1347,7 +1347,7 @@ impl<'a> IndicesDeleteTemplate<'a> {
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1357,12 +1357,12 @@ impl<'a> IndicesDeleteTemplate<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -1374,24 +1374,24 @@ impl<'a> IndicesDeleteTemplate<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1414,11 +1414,11 @@ impl<'a> IndicesDeleteTemplate<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Exists API"]
-pub enum IndicesExistsParts<'a> {
+pub enum IndicesExistsParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesExistsParts<'a> {
+impl<'b> IndicesExistsParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Exists API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1434,13 +1434,13 @@ impl<'a> IndicesExistsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Exists API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html). Returns information about whether a particular index exists."]
-pub struct IndicesExists<'a> {
-    client: Elasticsearch,
-    parts: IndicesExistsParts<'a>,
+pub struct IndicesExists<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesExistsParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
@@ -1448,11 +1448,11 @@ pub struct IndicesExists<'a> {
     include_defaults: Option<bool>,
     local: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesExists<'a> {
+impl<'a, 'b> IndicesExists<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExists] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesExistsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesExistsParts<'b>) -> Self {
         IndicesExists {
             client,
             parts,
@@ -1486,7 +1486,7 @@ impl<'a> IndicesExists<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1526,7 +1526,7 @@ impl<'a> IndicesExists<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1538,7 +1538,7 @@ impl<'a> IndicesExists<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -1549,7 +1549,7 @@ impl<'a> IndicesExists<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -1563,7 +1563,7 @@ impl<'a> IndicesExists<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -1590,13 +1590,13 @@ impl<'a> IndicesExists<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Exists Alias API"]
-pub enum IndicesExistsAliasParts<'a> {
+pub enum IndicesExistsAliasParts<'b> {
     #[doc = "Name"]
-    Name(&'a [&'a str]),
+    Name(&'b [&'b str]),
     #[doc = "Index and Name"]
-    IndexName(&'a [&'a str], &'a [&'a str]),
+    IndexName(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> IndicesExistsAliasParts<'a> {
+impl<'b> IndicesExistsAliasParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Exists Alias API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1622,23 +1622,23 @@ impl<'a> IndicesExistsAliasParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Exists Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html). Returns information about whether a particular alias exists."]
-pub struct IndicesExistsAlias<'a> {
-    client: Elasticsearch,
-    parts: IndicesExistsAliasParts<'a>,
+pub struct IndicesExistsAlias<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesExistsAliasParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     local: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesExistsAlias<'a> {
+impl<'a, 'b> IndicesExistsAlias<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExistsAlias] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesExistsAliasParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesExistsAliasParts<'b>) -> Self {
         IndicesExistsAlias {
             client,
             parts,
@@ -1670,7 +1670,7 @@ impl<'a> IndicesExistsAlias<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1700,7 +1700,7 @@ impl<'a> IndicesExistsAlias<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1712,7 +1712,7 @@ impl<'a> IndicesExistsAlias<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -1723,7 +1723,7 @@ impl<'a> IndicesExistsAlias<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -1733,7 +1733,7 @@ impl<'a> IndicesExistsAlias<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -1758,11 +1758,11 @@ impl<'a> IndicesExistsAlias<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Exists Template API"]
-pub enum IndicesExistsTemplateParts<'a> {
+pub enum IndicesExistsTemplateParts<'b> {
     #[doc = "Name"]
-    Name(&'a [&'a str]),
+    Name(&'b [&'b str]),
 }
-impl<'a> IndicesExistsTemplateParts<'a> {
+impl<'b> IndicesExistsTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Exists Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1778,22 +1778,22 @@ impl<'a> IndicesExistsTemplateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Exists Template API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html). Returns information about whether a particular index template exists."]
-pub struct IndicesExistsTemplate<'a> {
-    client: Elasticsearch,
-    parts: IndicesExistsTemplateParts<'a>,
+pub struct IndicesExistsTemplate<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesExistsTemplateParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesExistsTemplate<'a> {
+impl<'a, 'b> IndicesExistsTemplate<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExistsTemplate] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesExistsTemplateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesExistsTemplateParts<'b>) -> Self {
         IndicesExistsTemplate {
             client,
             parts,
@@ -1814,7 +1814,7 @@ impl<'a> IndicesExistsTemplate<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1839,7 +1839,7 @@ impl<'a> IndicesExistsTemplate<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1849,7 +1849,7 @@ impl<'a> IndicesExistsTemplate<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1861,14 +1861,14 @@ impl<'a> IndicesExistsTemplate<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -1876,11 +1876,11 @@ impl<'a> IndicesExistsTemplate<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1904,11 +1904,11 @@ impl<'a> IndicesExistsTemplate<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Exists Type API"]
-pub enum IndicesExistsTypeParts<'a> {
+pub enum IndicesExistsTypeParts<'b> {
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> IndicesExistsTypeParts<'a> {
+impl<'b> IndicesExistsTypeParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Exists Type API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1927,23 +1927,23 @@ impl<'a> IndicesExistsTypeParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Exists Type API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html). Returns information about whether a particular document type exists. (DEPRECATED)"]
-pub struct IndicesExistsType<'a> {
-    client: Elasticsearch,
-    parts: IndicesExistsTypeParts<'a>,
+pub struct IndicesExistsType<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesExistsTypeParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     local: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesExistsType<'a> {
+impl<'a, 'b> IndicesExistsType<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExistsType] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesExistsTypeParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesExistsTypeParts<'b>) -> Self {
         IndicesExistsType {
             client,
             parts,
@@ -1975,7 +1975,7 @@ impl<'a> IndicesExistsType<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2005,7 +2005,7 @@ impl<'a> IndicesExistsType<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2017,7 +2017,7 @@ impl<'a> IndicesExistsType<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -2028,7 +2028,7 @@ impl<'a> IndicesExistsType<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -2038,7 +2038,7 @@ impl<'a> IndicesExistsType<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -2063,13 +2063,13 @@ impl<'a> IndicesExistsType<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Flush API"]
-pub enum IndicesFlushParts<'a> {
+pub enum IndicesFlushParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesFlushParts<'a> {
+impl<'b> IndicesFlushParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Flush API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2087,28 +2087,28 @@ impl<'a> IndicesFlushParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Flush API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html). Performs the flush operation on one or more indices."]
-pub struct IndicesFlush<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesFlushParts<'a>,
+pub struct IndicesFlush<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesFlushParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     force: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     wait_if_ongoing: Option<bool>,
 }
-impl<'a, B> IndicesFlush<'a, B>
+impl<'a, 'b, B> IndicesFlush<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesFlush] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesFlushParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesFlushParts<'b>) -> Self {
         IndicesFlush {
             client,
             parts,
@@ -2132,7 +2132,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesFlush<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesFlush<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2164,7 +2164,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2194,7 +2194,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2214,7 +2214,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -2225,7 +2225,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "force")]
                 force: Option<bool>,
                 #[serde(rename = "human")]
@@ -2235,7 +2235,7 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "wait_if_ongoing")]
                 wait_if_ongoing: Option<bool>,
             }
@@ -2263,13 +2263,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Flush Synced API"]
-pub enum IndicesFlushSyncedParts<'a> {
+pub enum IndicesFlushSyncedParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesFlushSyncedParts<'a> {
+impl<'b> IndicesFlushSyncedParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Flush Synced API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2287,26 +2287,26 @@ impl<'a> IndicesFlushSyncedParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Flush Synced API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush-api.html). Performs a synced flush operation on one or more indices."]
-pub struct IndicesFlushSynced<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesFlushSyncedParts<'a>,
+pub struct IndicesFlushSynced<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesFlushSyncedParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IndicesFlushSynced<'a, B>
+impl<'a, 'b, B> IndicesFlushSynced<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesFlushSynced] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesFlushSyncedParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesFlushSyncedParts<'b>) -> Self {
         IndicesFlushSynced {
             client,
             parts,
@@ -2328,7 +2328,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesFlushSynced<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesFlushSynced<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2358,7 +2358,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2383,7 +2383,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2398,7 +2398,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -2409,7 +2409,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -2417,7 +2417,7 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -2441,13 +2441,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Forcemerge API"]
-pub enum IndicesForcemergeParts<'a> {
+pub enum IndicesForcemergeParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesForcemergeParts<'a> {
+impl<'b> IndicesForcemergeParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Forcemerge API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2465,14 +2465,14 @@ impl<'a> IndicesForcemergeParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Forcemerge API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html). Performs the force merge operation on one or more indices."]
-pub struct IndicesForcemerge<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesForcemergeParts<'a>,
+pub struct IndicesForcemerge<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesForcemergeParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flush: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
@@ -2480,14 +2480,14 @@ pub struct IndicesForcemerge<'a, B> {
     max_num_segments: Option<i64>,
     only_expunge_deletes: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IndicesForcemerge<'a, B>
+impl<'a, 'b, B> IndicesForcemerge<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesForcemerge] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesForcemergeParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesForcemergeParts<'b>) -> Self {
         IndicesForcemerge {
             client,
             parts,
@@ -2512,7 +2512,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesForcemerge<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesForcemerge<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2545,7 +2545,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2585,7 +2585,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2597,7 +2597,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -2608,7 +2608,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flush")]
                 flush: Option<bool>,
                 #[serde(rename = "human")]
@@ -2622,7 +2622,7 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -2649,11 +2649,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Freeze API"]
-pub enum IndicesFreezeParts<'a> {
+pub enum IndicesFreezeParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> IndicesFreezeParts<'a> {
+impl<'b> IndicesFreezeParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Freeze API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2669,29 +2669,29 @@ impl<'a> IndicesFreezeParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Freeze API](https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html)."]
-pub struct IndicesFreeze<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesFreezeParts<'a>,
+pub struct IndicesFreeze<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesFreezeParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> IndicesFreeze<'a, B>
+impl<'a, 'b, B> IndicesFreeze<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesFreeze] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesFreezeParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesFreezeParts<'b>) -> Self {
         IndicesFreeze {
             client,
             parts,
@@ -2716,7 +2716,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesFreeze<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesFreeze<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2749,7 +2749,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2769,7 +2769,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -2779,17 +2779,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Sets the number of active shards to wait for before the operation returns."]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -2801,7 +2801,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -2812,21 +2812,21 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -2853,11 +2853,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Get API"]
-pub enum IndicesGetParts<'a> {
+pub enum IndicesGetParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesGetParts<'a> {
+impl<'b> IndicesGetParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Get API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2873,13 +2873,13 @@ impl<'a> IndicesGetParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html). Returns information about one or more indices."]
-pub struct IndicesGet<'a> {
-    client: Elasticsearch,
-    parts: IndicesGetParts<'a>,
+pub struct IndicesGet<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesGetParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
@@ -2887,13 +2887,13 @@ pub struct IndicesGet<'a> {
     include_defaults: Option<bool>,
     include_type_name: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesGet<'a> {
+impl<'a, 'b> IndicesGet<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGet] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesGetParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesGetParts<'b>) -> Self {
         IndicesGet {
             client,
             parts,
@@ -2929,7 +2929,7 @@ impl<'a> IndicesGet<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2969,7 +2969,7 @@ impl<'a> IndicesGet<'a> {
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -2979,7 +2979,7 @@ impl<'a> IndicesGet<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2991,7 +2991,7 @@ impl<'a> IndicesGet<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -3002,7 +3002,7 @@ impl<'a> IndicesGet<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -3016,11 +3016,11 @@ impl<'a> IndicesGet<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -3049,17 +3049,17 @@ impl<'a> IndicesGet<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Get Alias API"]
-pub enum IndicesGetAliasParts<'a> {
+pub enum IndicesGetAliasParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Name"]
-    Name(&'a [&'a str]),
+    Name(&'b [&'b str]),
     #[doc = "Index and Name"]
-    IndexName(&'a [&'a str], &'a [&'a str]),
+    IndexName(&'b [&'b str], &'b [&'b str]),
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesGetAliasParts<'a> {
+impl<'b> IndicesGetAliasParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Get Alias API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3094,23 +3094,23 @@ impl<'a> IndicesGetAliasParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html). Returns an alias."]
-pub struct IndicesGetAlias<'a> {
-    client: Elasticsearch,
-    parts: IndicesGetAliasParts<'a>,
+pub struct IndicesGetAlias<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesGetAliasParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     local: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesGetAlias<'a> {
+impl<'a, 'b> IndicesGetAlias<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetAlias] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesGetAliasParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesGetAliasParts<'b>) -> Self {
         IndicesGetAlias {
             client,
             parts,
@@ -3142,7 +3142,7 @@ impl<'a> IndicesGetAlias<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3172,7 +3172,7 @@ impl<'a> IndicesGetAlias<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3184,7 +3184,7 @@ impl<'a> IndicesGetAlias<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -3195,7 +3195,7 @@ impl<'a> IndicesGetAlias<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -3205,7 +3205,7 @@ impl<'a> IndicesGetAlias<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -3230,17 +3230,17 @@ impl<'a> IndicesGetAlias<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Get Field Mapping API"]
-pub enum IndicesGetFieldMappingParts<'a> {
+pub enum IndicesGetFieldMappingParts<'b> {
     #[doc = "Fields"]
-    Fields(&'a [&'a str]),
+    Fields(&'b [&'b str]),
     #[doc = "Index and Fields"]
-    IndexFields(&'a [&'a str], &'a [&'a str]),
+    IndexFields(&'b [&'b str], &'b [&'b str]),
     #[doc = "Type and Fields"]
-    TypeFields(&'a [&'a str], &'a [&'a str]),
+    TypeFields(&'b [&'b str], &'b [&'b str]),
     #[doc = "Index, Type and Fields"]
-    IndexTypeFields(&'a [&'a str], &'a [&'a str], &'a [&'a str]),
+    IndexTypeFields(&'b [&'b str], &'b [&'b str], &'b [&'b str]),
 }
-impl<'a> IndicesGetFieldMappingParts<'a> {
+impl<'b> IndicesGetFieldMappingParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Get Field Mapping API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3291,13 +3291,13 @@ impl<'a> IndicesGetFieldMappingParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Field Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html). Returns mapping for one or more fields."]
-pub struct IndicesGetFieldMapping<'a> {
-    client: Elasticsearch,
-    parts: IndicesGetFieldMappingParts<'a>,
+pub struct IndicesGetFieldMapping<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesGetFieldMappingParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
@@ -3305,11 +3305,11 @@ pub struct IndicesGetFieldMapping<'a> {
     include_type_name: Option<bool>,
     local: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesGetFieldMapping<'a> {
+impl<'a, 'b> IndicesGetFieldMapping<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetFieldMapping] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesGetFieldMappingParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesGetFieldMappingParts<'b>) -> Self {
         IndicesGetFieldMapping {
             client,
             parts,
@@ -3343,7 +3343,7 @@ impl<'a> IndicesGetFieldMapping<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3383,7 +3383,7 @@ impl<'a> IndicesGetFieldMapping<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3395,7 +3395,7 @@ impl<'a> IndicesGetFieldMapping<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -3406,7 +3406,7 @@ impl<'a> IndicesGetFieldMapping<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -3420,7 +3420,7 @@ impl<'a> IndicesGetFieldMapping<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -3447,17 +3447,17 @@ impl<'a> IndicesGetFieldMapping<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Get Mapping API"]
-pub enum IndicesGetMappingParts<'a> {
+pub enum IndicesGetMappingParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Type"]
-    Type(&'a [&'a str]),
+    Type(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> IndicesGetMappingParts<'a> {
+impl<'b> IndicesGetMappingParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Get Mapping API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3492,25 +3492,25 @@ impl<'a> IndicesGetMappingParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html). Returns mappings for one or more indices."]
-pub struct IndicesGetMapping<'a> {
-    client: Elasticsearch,
-    parts: IndicesGetMappingParts<'a>,
+pub struct IndicesGetMapping<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesGetMappingParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     include_type_name: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesGetMapping<'a> {
+impl<'a, 'b> IndicesGetMapping<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetMapping] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesGetMappingParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesGetMappingParts<'b>) -> Self {
         IndicesGetMapping {
             client,
             parts,
@@ -3544,7 +3544,7 @@ impl<'a> IndicesGetMapping<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3574,7 +3574,7 @@ impl<'a> IndicesGetMapping<'a> {
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -3584,7 +3584,7 @@ impl<'a> IndicesGetMapping<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3596,7 +3596,7 @@ impl<'a> IndicesGetMapping<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -3607,7 +3607,7 @@ impl<'a> IndicesGetMapping<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -3617,11 +3617,11 @@ impl<'a> IndicesGetMapping<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -3648,17 +3648,17 @@ impl<'a> IndicesGetMapping<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Get Settings API"]
-pub enum IndicesGetSettingsParts<'a> {
+pub enum IndicesGetSettingsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Name"]
-    IndexName(&'a [&'a str], &'a [&'a str]),
+    IndexName(&'b [&'b str], &'b [&'b str]),
     #[doc = "Name"]
-    Name(&'a [&'a str]),
+    Name(&'b [&'b str]),
 }
-impl<'a> IndicesGetSettingsParts<'a> {
+impl<'b> IndicesGetSettingsParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Get Settings API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3693,26 +3693,26 @@ impl<'a> IndicesGetSettingsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html). Returns settings for one or more indices."]
-pub struct IndicesGetSettings<'a> {
-    client: Elasticsearch,
-    parts: IndicesGetSettingsParts<'a>,
+pub struct IndicesGetSettings<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesGetSettingsParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     include_defaults: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesGetSettings<'a> {
+impl<'a, 'b> IndicesGetSettings<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetSettings] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesGetSettingsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesGetSettingsParts<'b>) -> Self {
         IndicesGetSettings {
             client,
             parts,
@@ -3747,7 +3747,7 @@ impl<'a> IndicesGetSettings<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3782,7 +3782,7 @@ impl<'a> IndicesGetSettings<'a> {
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -3792,7 +3792,7 @@ impl<'a> IndicesGetSettings<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3804,7 +3804,7 @@ impl<'a> IndicesGetSettings<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -3815,7 +3815,7 @@ impl<'a> IndicesGetSettings<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -3827,11 +3827,11 @@ impl<'a> IndicesGetSettings<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -3859,13 +3859,13 @@ impl<'a> IndicesGetSettings<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Get Template API"]
-pub enum IndicesGetTemplateParts<'a> {
+pub enum IndicesGetTemplateParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Name"]
-    Name(&'a [&'a str]),
+    Name(&'b [&'b str]),
 }
-impl<'a> IndicesGetTemplateParts<'a> {
+impl<'b> IndicesGetTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Get Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3882,23 +3882,23 @@ impl<'a> IndicesGetTemplateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Template API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html). Returns an index template."]
-pub struct IndicesGetTemplate<'a> {
-    client: Elasticsearch,
-    parts: IndicesGetTemplateParts<'a>,
+pub struct IndicesGetTemplate<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesGetTemplateParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     include_type_name: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesGetTemplate<'a> {
+impl<'a, 'b> IndicesGetTemplate<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetTemplate] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesGetTemplateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesGetTemplateParts<'b>) -> Self {
         IndicesGetTemplate {
             client,
             parts,
@@ -3920,7 +3920,7 @@ impl<'a> IndicesGetTemplate<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3950,7 +3950,7 @@ impl<'a> IndicesGetTemplate<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -3960,7 +3960,7 @@ impl<'a> IndicesGetTemplate<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3972,14 +3972,14 @@ impl<'a> IndicesGetTemplate<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -3989,11 +3989,11 @@ impl<'a> IndicesGetTemplate<'a> {
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -4018,13 +4018,13 @@ impl<'a> IndicesGetTemplate<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Get Upgrade API"]
-pub enum IndicesGetUpgradeParts<'a> {
+pub enum IndicesGetUpgradeParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesGetUpgradeParts<'a> {
+impl<'b> IndicesGetUpgradeParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Get Upgrade API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4042,22 +4042,22 @@ impl<'a> IndicesGetUpgradeParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Upgrade API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html). The _upgrade API is no longer useful and will be removed."]
-pub struct IndicesGetUpgrade<'a> {
-    client: Elasticsearch,
-    parts: IndicesGetUpgradeParts<'a>,
+pub struct IndicesGetUpgrade<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesGetUpgradeParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesGetUpgrade<'a> {
+impl<'a, 'b> IndicesGetUpgrade<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetUpgrade] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesGetUpgradeParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesGetUpgradeParts<'b>) -> Self {
         IndicesGetUpgrade {
             client,
             parts,
@@ -4088,7 +4088,7 @@ impl<'a> IndicesGetUpgrade<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4113,7 +4113,7 @@ impl<'a> IndicesGetUpgrade<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4125,7 +4125,7 @@ impl<'a> IndicesGetUpgrade<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -4136,7 +4136,7 @@ impl<'a> IndicesGetUpgrade<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -4144,7 +4144,7 @@ impl<'a> IndicesGetUpgrade<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -4168,11 +4168,11 @@ impl<'a> IndicesGetUpgrade<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Open API"]
-pub enum IndicesOpenParts<'a> {
+pub enum IndicesOpenParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesOpenParts<'a> {
+impl<'b> IndicesOpenParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Open API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4189,29 +4189,29 @@ impl<'a> IndicesOpenParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Open API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html). Opens an index."]
-pub struct IndicesOpen<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesOpenParts<'a>,
+pub struct IndicesOpen<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesOpenParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> IndicesOpen<'a, B>
+impl<'a, 'b, B> IndicesOpen<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesOpen] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesOpenParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesOpenParts<'b>) -> Self {
         IndicesOpen {
             client,
             parts,
@@ -4236,7 +4236,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesOpen<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesOpen<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4269,7 +4269,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4289,7 +4289,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -4299,17 +4299,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Sets the number of active shards to wait for before the operation returns."]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -4321,7 +4321,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -4332,21 +4332,21 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -4373,11 +4373,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Put Alias API"]
-pub enum IndicesPutAliasParts<'a> {
+pub enum IndicesPutAliasParts<'b> {
     #[doc = "Index and Name"]
-    IndexName(&'a [&'a str], &'a str),
+    IndexName(&'b [&'b str], &'b str),
 }
-impl<'a> IndicesPutAliasParts<'a> {
+impl<'b> IndicesPutAliasParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Put Alias API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4395,25 +4395,25 @@ impl<'a> IndicesPutAliasParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Put Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html). Creates or updates an alias."]
-pub struct IndicesPutAlias<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesPutAliasParts<'a>,
+pub struct IndicesPutAlias<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesPutAliasParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> IndicesPutAlias<'a, B>
+impl<'a, 'b, B> IndicesPutAlias<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesPutAlias] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesPutAliasParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesPutAliasParts<'b>) -> Self {
         IndicesPutAlias {
             client,
             parts,
@@ -4429,7 +4429,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesPutAlias<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesPutAlias<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4453,7 +4453,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4468,7 +4468,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -4478,12 +4478,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit timestamp for the document"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -4495,24 +4495,24 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -4535,15 +4535,15 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Put Mapping API"]
-pub enum IndicesPutMappingParts<'a> {
+pub enum IndicesPutMappingParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a str),
+    IndexType(&'b [&'b str], &'b str),
     #[doc = "Type"]
-    Type(&'a str),
+    Type(&'b str),
 }
-impl<'a> IndicesPutMappingParts<'a> {
+impl<'b> IndicesPutMappingParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Put Mapping API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4576,29 +4576,29 @@ impl<'a> IndicesPutMappingParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Put Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html). Updates the index mappings."]
-pub struct IndicesPutMapping<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesPutMappingParts<'a>,
+pub struct IndicesPutMapping<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesPutMappingParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     include_type_name: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> IndicesPutMapping<'a, B>
+impl<'a, 'b, B> IndicesPutMapping<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesPutMapping] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesPutMappingParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesPutMappingParts<'b>) -> Self {
         IndicesPutMapping {
             client,
             parts,
@@ -4623,7 +4623,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesPutMapping<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesPutMapping<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4656,7 +4656,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4681,7 +4681,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -4691,12 +4691,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -4708,7 +4708,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -4719,7 +4719,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -4727,13 +4727,13 @@ where
                 #[serde(rename = "include_type_name")]
                 include_type_name: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -4760,13 +4760,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Put Settings API"]
-pub enum IndicesPutSettingsParts<'a> {
+pub enum IndicesPutSettingsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesPutSettingsParts<'a> {
+impl<'b> IndicesPutSettingsParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Put Settings API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4784,30 +4784,30 @@ impl<'a> IndicesPutSettingsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Put Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html). Updates the index settings."]
-pub struct IndicesPutSettings<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesPutSettingsParts<'a>,
+pub struct IndicesPutSettings<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesPutSettingsParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     preserve_existing: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> IndicesPutSettings<'a, B>
+impl<'a, 'b, B> IndicesPutSettings<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesPutSettings] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesPutSettingsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesPutSettingsParts<'b>) -> Self {
         IndicesPutSettings {
             client,
             parts,
@@ -4833,7 +4833,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesPutSettings<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesPutSettings<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4867,7 +4867,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4892,7 +4892,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -4907,12 +4907,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -4924,7 +4924,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -4935,7 +4935,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -4943,15 +4943,15 @@ where
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "preserve_existing")]
                 preserve_existing: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -4979,11 +4979,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Put Template API"]
-pub enum IndicesPutTemplateParts<'a> {
+pub enum IndicesPutTemplateParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> IndicesPutTemplateParts<'a> {
+impl<'b> IndicesPutTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Put Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4998,29 +4998,29 @@ impl<'a> IndicesPutTemplateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Put Template API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html). Creates or updates an index template."]
-pub struct IndicesPutTemplate<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesPutTemplateParts<'a>,
+pub struct IndicesPutTemplate<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesPutTemplateParts<'b>,
     body: Option<B>,
     create: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     include_type_name: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     order: Option<i64>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> IndicesPutTemplate<'a, B>
+impl<'a, 'b, B> IndicesPutTemplate<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesPutTemplate] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesPutTemplateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesPutTemplateParts<'b>) -> Self {
         IndicesPutTemplate {
             client,
             parts,
@@ -5040,7 +5040,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesPutTemplate<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesPutTemplate<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5073,7 +5073,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5098,7 +5098,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -5113,12 +5113,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -5130,7 +5130,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "create")]
                 create: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -5139,7 +5139,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -5147,15 +5147,15 @@ where
                 #[serde(rename = "include_type_name")]
                 include_type_name: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "order")]
                 order: Option<i64>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 create: self.create,
@@ -5182,13 +5182,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Recovery API"]
-pub enum IndicesRecoveryParts<'a> {
+pub enum IndicesRecoveryParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesRecoveryParts<'a> {
+impl<'b> IndicesRecoveryParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Recovery API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5206,21 +5206,21 @@ impl<'a> IndicesRecoveryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Recovery API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html). Returns information about ongoing index shard recoveries."]
-pub struct IndicesRecovery<'a> {
-    client: Elasticsearch,
-    parts: IndicesRecoveryParts<'a>,
+pub struct IndicesRecovery<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesRecoveryParts<'b>,
     active_only: Option<bool>,
     detailed: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IndicesRecovery<'a> {
+impl<'a, 'b> IndicesRecovery<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesRecovery] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesRecoveryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesRecoveryParts<'b>) -> Self {
         IndicesRecovery {
             client,
             parts,
@@ -5250,7 +5250,7 @@ impl<'a> IndicesRecovery<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5270,7 +5270,7 @@ impl<'a> IndicesRecovery<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -5282,7 +5282,7 @@ impl<'a> IndicesRecovery<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "active_only")]
                 active_only: Option<bool>,
                 #[serde(rename = "detailed")]
@@ -5293,13 +5293,13 @@ impl<'a> IndicesRecovery<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 active_only: self.active_only,
@@ -5322,13 +5322,13 @@ impl<'a> IndicesRecovery<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Refresh API"]
-pub enum IndicesRefreshParts<'a> {
+pub enum IndicesRefreshParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesRefreshParts<'a> {
+impl<'b> IndicesRefreshParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Refresh API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5346,26 +5346,26 @@ impl<'a> IndicesRefreshParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Refresh API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html). Performs the refresh operation in one or more indices."]
-pub struct IndicesRefresh<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesRefreshParts<'a>,
+pub struct IndicesRefresh<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesRefreshParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IndicesRefresh<'a, B>
+impl<'a, 'b, B> IndicesRefresh<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesRefresh] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesRefreshParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesRefreshParts<'b>) -> Self {
         IndicesRefresh {
             client,
             parts,
@@ -5387,7 +5387,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesRefresh<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesRefresh<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5417,7 +5417,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5442,7 +5442,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -5457,7 +5457,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -5468,7 +5468,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -5476,7 +5476,7 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -5500,13 +5500,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Rollover API"]
-pub enum IndicesRolloverParts<'a> {
+pub enum IndicesRolloverParts<'b> {
     #[doc = "Alias"]
-    Alias(&'a str),
+    Alias(&'b str),
     #[doc = "Alias and NewIndex"]
-    AliasNewIndex(&'a str, &'a str),
+    AliasNewIndex(&'b str, &'b str),
 }
-impl<'a> IndicesRolloverParts<'a> {
+impl<'b> IndicesRolloverParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Rollover API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5530,28 +5530,28 @@ impl<'a> IndicesRolloverParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Rollover API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html). Updates an alias to point to a new index when the existing index\nis considered to be too large or too old."]
-pub struct IndicesRollover<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesRolloverParts<'a>,
+pub struct IndicesRollover<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesRolloverParts<'b>,
     body: Option<B>,
     dry_run: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     include_type_name: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> IndicesRollover<'a, B>
+impl<'a, 'b, B> IndicesRollover<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesRollover] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesRolloverParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesRolloverParts<'b>) -> Self {
         IndicesRollover {
             client,
             parts,
@@ -5570,7 +5570,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesRollover<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesRollover<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5602,7 +5602,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5622,7 +5622,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -5632,17 +5632,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Set the number of active shards to wait for on the newly created rollover index before the operation returns."]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -5654,7 +5654,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "dry_run")]
                 dry_run: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -5663,21 +5663,21 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "include_type_name")]
                 include_type_name: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 dry_run: self.dry_run,
@@ -5703,13 +5703,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Segments API"]
-pub enum IndicesSegmentsParts<'a> {
+pub enum IndicesSegmentsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesSegmentsParts<'a> {
+impl<'b> IndicesSegmentsParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Segments API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5727,23 +5727,23 @@ impl<'a> IndicesSegmentsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Segments API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html). Provides low-level information about segments in a Lucene index."]
-pub struct IndicesSegments<'a> {
-    client: Elasticsearch,
-    parts: IndicesSegmentsParts<'a>,
+pub struct IndicesSegments<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesSegmentsParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     verbose: Option<bool>,
 }
-impl<'a> IndicesSegments<'a> {
+impl<'a, 'b> IndicesSegments<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesSegments] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesSegmentsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesSegmentsParts<'b>) -> Self {
         IndicesSegments {
             client,
             parts,
@@ -5775,7 +5775,7 @@ impl<'a> IndicesSegments<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5800,7 +5800,7 @@ impl<'a> IndicesSegments<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -5817,7 +5817,7 @@ impl<'a> IndicesSegments<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -5828,7 +5828,7 @@ impl<'a> IndicesSegments<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -5836,7 +5836,7 @@ impl<'a> IndicesSegments<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "verbose")]
                 verbose: Option<bool>,
             }
@@ -5863,13 +5863,13 @@ impl<'a> IndicesSegments<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Shard Stores API"]
-pub enum IndicesShardStoresParts<'a> {
+pub enum IndicesShardStoresParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesShardStoresParts<'a> {
+impl<'b> IndicesShardStoresParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Shard Stores API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5887,23 +5887,23 @@ impl<'a> IndicesShardStoresParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Shard Stores API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html). Provides store information for shard copies of indices."]
-pub struct IndicesShardStores<'a> {
-    client: Elasticsearch,
-    parts: IndicesShardStoresParts<'a>,
+pub struct IndicesShardStores<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesShardStoresParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    status: Option<&'a [&'a str]>,
+    source: Option<&'b str>,
+    status: Option<&'b [&'b str]>,
 }
-impl<'a> IndicesShardStores<'a> {
+impl<'a, 'b> IndicesShardStores<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesShardStores] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesShardStoresParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesShardStoresParts<'b>) -> Self {
         IndicesShardStores {
             client,
             parts,
@@ -5935,7 +5935,7 @@ impl<'a> IndicesShardStores<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5960,12 +5960,12 @@ impl<'a> IndicesShardStores<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "A comma-separated list of statuses used to filter on shards to get store information for"]
-    pub fn status(mut self, status: &'a [&'a str]) -> Self {
+    pub fn status(mut self, status: &'b [&'b str]) -> Self {
         self.status = Some(status);
         self
     }
@@ -5977,7 +5977,7 @@ impl<'a> IndicesShardStores<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -5988,7 +5988,7 @@ impl<'a> IndicesShardStores<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -5996,9 +5996,9 @@ impl<'a> IndicesShardStores<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "status", serialize_with = "crate::client::serialize_coll_qs")]
-                status: Option<&'a [&'a str]>,
+                status: Option<&'b [&'b str]>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -6023,11 +6023,11 @@ impl<'a> IndicesShardStores<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Shrink API"]
-pub enum IndicesShrinkParts<'a> {
+pub enum IndicesShrinkParts<'b> {
     #[doc = "Index and Target"]
-    IndexTarget(&'a str, &'a str),
+    IndexTarget(&'b str, &'b str),
 }
-impl<'a> IndicesShrinkParts<'a> {
+impl<'b> IndicesShrinkParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Shrink API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -6044,27 +6044,27 @@ impl<'a> IndicesShrinkParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Shrink API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html). Allow to shrink an existing index into a new index with fewer primary shards."]
-pub struct IndicesShrink<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesShrinkParts<'a>,
+pub struct IndicesShrink<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesShrinkParts<'b>,
     body: Option<B>,
     copy_settings: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> IndicesShrink<'a, B>
+impl<'a, 'b, B> IndicesShrink<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesShrink] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesShrinkParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesShrinkParts<'b>) -> Self {
         IndicesShrink {
             client,
             parts,
@@ -6082,7 +6082,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesShrink<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesShrink<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6113,7 +6113,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6128,7 +6128,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -6138,17 +6138,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Set the number of active shards to wait for on the shrunken index before the operation returns."]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -6160,7 +6160,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "copy_settings")]
                 copy_settings: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -6169,19 +6169,19 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 copy_settings: self.copy_settings,
@@ -6206,11 +6206,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Split API"]
-pub enum IndicesSplitParts<'a> {
+pub enum IndicesSplitParts<'b> {
     #[doc = "Index and Target"]
-    IndexTarget(&'a str, &'a str),
+    IndexTarget(&'b str, &'b str),
 }
-impl<'a> IndicesSplitParts<'a> {
+impl<'b> IndicesSplitParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Split API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -6227,27 +6227,27 @@ impl<'a> IndicesSplitParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Split API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html). Allows you to split an existing index into a new index with more primary shards."]
-pub struct IndicesSplit<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesSplitParts<'a>,
+pub struct IndicesSplit<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesSplitParts<'b>,
     body: Option<B>,
     copy_settings: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> IndicesSplit<'a, B>
+impl<'a, 'b, B> IndicesSplit<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesSplit] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesSplitParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesSplitParts<'b>) -> Self {
         IndicesSplit {
             client,
             parts,
@@ -6265,7 +6265,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesSplit<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesSplit<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6296,7 +6296,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6311,7 +6311,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -6321,17 +6321,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Set the number of active shards to wait for on the shrunken index before the operation returns."]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -6343,7 +6343,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "copy_settings")]
                 copy_settings: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -6352,19 +6352,19 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 copy_settings: self.copy_settings,
@@ -6389,17 +6389,17 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Stats API"]
-pub enum IndicesStatsParts<'a> {
+pub enum IndicesStatsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Metric"]
-    Metric(&'a [&'a str]),
+    Metric(&'b [&'b str]),
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Metric"]
-    IndexMetric(&'a [&'a str], &'a [&'a str]),
+    IndexMetric(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> IndicesStatsParts<'a> {
+impl<'b> IndicesStatsParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Stats API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -6434,29 +6434,29 @@ impl<'a> IndicesStatsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html). Provides statistics on operations happening in an index."]
-pub struct IndicesStats<'a> {
-    client: Elasticsearch,
-    parts: IndicesStatsParts<'a>,
-    completion_fields: Option<&'a [&'a str]>,
+pub struct IndicesStats<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IndicesStatsParts<'b>,
+    completion_fields: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    fielddata_fields: Option<&'a [&'a str]>,
-    fields: Option<&'a [&'a str]>,
-    filter_path: Option<&'a [&'a str]>,
+    fielddata_fields: Option<&'b [&'b str]>,
+    fields: Option<&'b [&'b str]>,
+    filter_path: Option<&'b [&'b str]>,
     forbid_closed_indices: Option<bool>,
-    groups: Option<&'a [&'a str]>,
+    groups: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     include_segment_file_sizes: Option<bool>,
     include_unloaded_segments: Option<bool>,
     level: Option<Level>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    types: Option<&'a [&'a str]>,
+    source: Option<&'b str>,
+    types: Option<&'b [&'b str]>,
 }
-impl<'a> IndicesStats<'a> {
+impl<'a, 'b> IndicesStats<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesStats] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesStatsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesStatsParts<'b>) -> Self {
         IndicesStats {
             client,
             parts,
@@ -6479,7 +6479,7 @@ impl<'a> IndicesStats<'a> {
         }
     }
     #[doc = "A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)"]
-    pub fn completion_fields(mut self, completion_fields: &'a [&'a str]) -> Self {
+    pub fn completion_fields(mut self, completion_fields: &'b [&'b str]) -> Self {
         self.completion_fields = Some(completion_fields);
         self
     }
@@ -6494,17 +6494,17 @@ impl<'a> IndicesStats<'a> {
         self
     }
     #[doc = "A comma-separated list of fields for `fielddata` index metric (supports wildcards)"]
-    pub fn fielddata_fields(mut self, fielddata_fields: &'a [&'a str]) -> Self {
+    pub fn fielddata_fields(mut self, fielddata_fields: &'b [&'b str]) -> Self {
         self.fielddata_fields = Some(fielddata_fields);
         self
     }
     #[doc = "A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)"]
-    pub fn fields(mut self, fields: &'a [&'a str]) -> Self {
+    pub fn fields(mut self, fields: &'b [&'b str]) -> Self {
         self.fields = Some(fields);
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6514,7 +6514,7 @@ impl<'a> IndicesStats<'a> {
         self
     }
     #[doc = "A comma-separated list of search groups for `search` index metric"]
-    pub fn groups(mut self, groups: &'a [&'a str]) -> Self {
+    pub fn groups(mut self, groups: &'b [&'b str]) -> Self {
         self.groups = Some(groups);
         self
     }
@@ -6549,12 +6549,12 @@ impl<'a> IndicesStats<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "A comma-separated list of document types for the `indexing` index metric"]
-    pub fn types(mut self, types: &'a [&'a str]) -> Self {
+    pub fn types(mut self, types: &'b [&'b str]) -> Self {
         self.types = Some(types);
         self
     }
@@ -6566,12 +6566,12 @@ impl<'a> IndicesStats<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "completion_fields",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                completion_fields: Option<&'a [&'a str]>,
+                completion_fields: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "expand_wildcards")]
@@ -6580,18 +6580,18 @@ impl<'a> IndicesStats<'a> {
                     rename = "fielddata_fields",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                fielddata_fields: Option<&'a [&'a str]>,
+                fielddata_fields: Option<&'b [&'b str]>,
                 #[serde(rename = "fields", serialize_with = "crate::client::serialize_coll_qs")]
-                fields: Option<&'a [&'a str]>,
+                fields: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "forbid_closed_indices")]
                 forbid_closed_indices: Option<bool>,
                 #[serde(rename = "groups", serialize_with = "crate::client::serialize_coll_qs")]
-                groups: Option<&'a [&'a str]>,
+                groups: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "include_segment_file_sizes")]
@@ -6603,9 +6603,9 @@ impl<'a> IndicesStats<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "types", serialize_with = "crate::client::serialize_coll_qs")]
-                types: Option<&'a [&'a str]>,
+                types: Option<&'b [&'b str]>,
             }
             let query_params = QueryParams {
                 completion_fields: self.completion_fields,
@@ -6636,11 +6636,11 @@ impl<'a> IndicesStats<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Unfreeze API"]
-pub enum IndicesUnfreezeParts<'a> {
+pub enum IndicesUnfreezeParts<'b> {
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> IndicesUnfreezeParts<'a> {
+impl<'b> IndicesUnfreezeParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Unfreeze API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -6656,29 +6656,29 @@ impl<'a> IndicesUnfreezeParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Unfreeze API](https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html)."]
-pub struct IndicesUnfreeze<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesUnfreezeParts<'a>,
+pub struct IndicesUnfreeze<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesUnfreezeParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> IndicesUnfreeze<'a, B>
+impl<'a, 'b, B> IndicesUnfreeze<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesUnfreeze] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesUnfreezeParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesUnfreezeParts<'b>) -> Self {
         IndicesUnfreeze {
             client,
             parts,
@@ -6703,7 +6703,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesUnfreeze<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesUnfreeze<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6736,7 +6736,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6756,7 +6756,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -6766,17 +6766,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Sets the number of active shards to wait for before the operation returns."]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -6788,7 +6788,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -6799,21 +6799,21 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -6854,25 +6854,25 @@ impl IndicesUpdateAliasesParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Update Aliases API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html). Updates index aliases."]
-pub struct IndicesUpdateAliases<'a, B> {
-    client: Elasticsearch,
+pub struct IndicesUpdateAliases<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: IndicesUpdateAliasesParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> IndicesUpdateAliases<'a, B>
+impl<'a, 'b, B> IndicesUpdateAliases<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesUpdateAliases]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         IndicesUpdateAliases {
             client,
             parts: IndicesUpdateAliasesParts::None,
@@ -6888,7 +6888,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesUpdateAliases<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesUpdateAliases<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6912,7 +6912,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6927,7 +6927,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -6937,12 +6937,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Request timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -6954,24 +6954,24 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -6994,13 +6994,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Upgrade API"]
-pub enum IndicesUpgradeParts<'a> {
+pub enum IndicesUpgradeParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> IndicesUpgradeParts<'a> {
+impl<'b> IndicesUpgradeParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Upgrade API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -7018,28 +7018,28 @@ impl<'a> IndicesUpgradeParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Upgrade API](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html). The _upgrade API is no longer useful and will be removed."]
-pub struct IndicesUpgrade<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesUpgradeParts<'a>,
+pub struct IndicesUpgrade<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesUpgradeParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     only_ancient_segments: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     wait_for_completion: Option<bool>,
 }
-impl<'a, B> IndicesUpgrade<'a, B>
+impl<'a, 'b, B> IndicesUpgrade<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesUpgrade] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesUpgradeParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesUpgradeParts<'b>) -> Self {
         IndicesUpgrade {
             client,
             parts,
@@ -7063,7 +7063,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesUpgrade<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesUpgrade<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -7095,7 +7095,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -7125,7 +7125,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -7142,7 +7142,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -7153,7 +7153,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -7163,7 +7163,7 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "wait_for_completion")]
                 wait_for_completion: Option<bool>,
             }
@@ -7191,15 +7191,15 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Indices Validate Query API"]
-pub enum IndicesValidateQueryParts<'a> {
+pub enum IndicesValidateQueryParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> IndicesValidateQueryParts<'a> {
+impl<'b> IndicesValidateQueryParts<'b> {
     #[doc = "Builds a relative URL path to the Indices Validate Query API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -7228,35 +7228,35 @@ impl<'a> IndicesValidateQueryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Validate Query API](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html). Allows a user to validate a potentially expensive query without executing it."]
-pub struct IndicesValidateQuery<'a, B> {
-    client: Elasticsearch,
-    parts: IndicesValidateQueryParts<'a>,
+pub struct IndicesValidateQuery<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndicesValidateQueryParts<'b>,
     all_shards: Option<bool>,
     allow_no_indices: Option<bool>,
     analyze_wildcard: Option<bool>,
-    analyzer: Option<&'a str>,
+    analyzer: Option<&'b str>,
     body: Option<B>,
     default_operator: Option<DefaultOperator>,
-    df: Option<&'a str>,
+    df: Option<&'b str>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
     explain: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     lenient: Option<bool>,
     pretty: Option<bool>,
-    q: Option<&'a str>,
+    q: Option<&'b str>,
     rewrite: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> IndicesValidateQuery<'a, B>
+impl<'a, 'b, B> IndicesValidateQuery<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesValidateQuery] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndicesValidateQueryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndicesValidateQueryParts<'b>) -> Self {
         IndicesValidateQuery {
             client,
             parts,
@@ -7297,12 +7297,12 @@ where
         self
     }
     #[doc = "The analyzer to use for the query string"]
-    pub fn analyzer(mut self, analyzer: &'a str) -> Self {
+    pub fn analyzer(mut self, analyzer: &'b str) -> Self {
         self.analyzer = Some(analyzer);
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesValidateQuery<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IndicesValidateQuery<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -7336,7 +7336,7 @@ where
         self
     }
     #[doc = "The field to use as default where no field prefix is given in the query string"]
-    pub fn df(mut self, df: &'a str) -> Self {
+    pub fn df(mut self, df: &'b str) -> Self {
         self.df = Some(df);
         self
     }
@@ -7356,7 +7356,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -7386,7 +7386,7 @@ where
         self
     }
     #[doc = "Query in the Lucene query string syntax"]
-    pub fn q(mut self, q: &'a str) -> Self {
+    pub fn q(mut self, q: &'b str) -> Self {
         self.q = Some(q);
         self
     }
@@ -7396,7 +7396,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -7411,7 +7411,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "all_shards")]
                 all_shards: Option<bool>,
                 #[serde(rename = "allow_no_indices")]
@@ -7419,11 +7419,11 @@ where
                 #[serde(rename = "analyze_wildcard")]
                 analyze_wildcard: Option<bool>,
                 #[serde(rename = "analyzer")]
-                analyzer: Option<&'a str>,
+                analyzer: Option<&'b str>,
                 #[serde(rename = "default_operator")]
                 default_operator: Option<DefaultOperator>,
                 #[serde(rename = "df")]
-                df: Option<&'a str>,
+                df: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "expand_wildcards")]
@@ -7434,7 +7434,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -7444,11 +7444,11 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "q")]
-                q: Option<&'a str>,
+                q: Option<&'b str>,
                 #[serde(rename = "rewrite")]
                 rewrite: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 all_shards: self.all_shards,
@@ -7480,197 +7480,230 @@ where
     }
 }
 #[doc = "Namespace client for Indices APIs"]
-pub struct Indices {
-    client: Elasticsearch,
+pub struct Indices<'a> {
+    client: &'a Elasticsearch,
 }
-impl Indices {
+impl<'a> Indices<'a> {
     #[doc = "Creates a new instance of [Indices]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
     #[doc = "Performs the analysis process on a text and return the tokens breakdown of the text."]
-    pub fn analyze<'a>(&self, parts: IndicesAnalyzeParts<'a>) -> IndicesAnalyze<'a, ()> {
-        IndicesAnalyze::new(self.client.clone(), parts)
+    pub fn analyze<'b>(&'a self, parts: IndicesAnalyzeParts<'b>) -> IndicesAnalyze<'a, 'b, ()> {
+        IndicesAnalyze::new(&self.client, parts)
     }
     #[doc = "Clears all or specific caches for one or more indices."]
-    pub fn clear_cache<'a>(&self, parts: IndicesClearCacheParts<'a>) -> IndicesClearCache<'a, ()> {
-        IndicesClearCache::new(self.client.clone(), parts)
+    pub fn clear_cache<'b>(
+        &'a self,
+        parts: IndicesClearCacheParts<'b>,
+    ) -> IndicesClearCache<'a, 'b, ()> {
+        IndicesClearCache::new(&self.client, parts)
     }
     #[doc = "Clones an index"]
-    pub fn clone<'a>(&self, parts: IndicesCloneParts<'a>) -> IndicesClone<'a, ()> {
-        IndicesClone::new(self.client.clone(), parts)
+    pub fn clone<'b>(&'a self, parts: IndicesCloneParts<'b>) -> IndicesClone<'a, 'b, ()> {
+        IndicesClone::new(&self.client, parts)
     }
     #[doc = "Closes an index."]
-    pub fn close<'a>(&self, parts: IndicesCloseParts<'a>) -> IndicesClose<'a, ()> {
-        IndicesClose::new(self.client.clone(), parts)
+    pub fn close<'b>(&'a self, parts: IndicesCloseParts<'b>) -> IndicesClose<'a, 'b, ()> {
+        IndicesClose::new(&self.client, parts)
     }
     #[doc = "Creates an index with optional settings and mappings."]
-    pub fn create<'a>(&self, parts: IndicesCreateParts<'a>) -> IndicesCreate<'a, ()> {
-        IndicesCreate::new(self.client.clone(), parts)
+    pub fn create<'b>(&'a self, parts: IndicesCreateParts<'b>) -> IndicesCreate<'a, 'b, ()> {
+        IndicesCreate::new(&self.client, parts)
     }
     #[doc = "Deletes an index."]
-    pub fn delete<'a>(&self, parts: IndicesDeleteParts<'a>) -> IndicesDelete<'a> {
-        IndicesDelete::new(self.client.clone(), parts)
+    pub fn delete<'b>(&'a self, parts: IndicesDeleteParts<'b>) -> IndicesDelete<'a, 'b> {
+        IndicesDelete::new(&self.client, parts)
     }
     #[doc = "Deletes an alias."]
-    pub fn delete_alias<'a>(&self, parts: IndicesDeleteAliasParts<'a>) -> IndicesDeleteAlias<'a> {
-        IndicesDeleteAlias::new(self.client.clone(), parts)
+    pub fn delete_alias<'b>(
+        &'a self,
+        parts: IndicesDeleteAliasParts<'b>,
+    ) -> IndicesDeleteAlias<'a, 'b> {
+        IndicesDeleteAlias::new(&self.client, parts)
     }
     #[doc = "Deletes an index template."]
-    pub fn delete_template<'a>(
-        &self,
-        parts: IndicesDeleteTemplateParts<'a>,
-    ) -> IndicesDeleteTemplate<'a> {
-        IndicesDeleteTemplate::new(self.client.clone(), parts)
+    pub fn delete_template<'b>(
+        &'a self,
+        parts: IndicesDeleteTemplateParts<'b>,
+    ) -> IndicesDeleteTemplate<'a, 'b> {
+        IndicesDeleteTemplate::new(&self.client, parts)
     }
     #[doc = "Returns information about whether a particular index exists."]
-    pub fn exists<'a>(&self, parts: IndicesExistsParts<'a>) -> IndicesExists<'a> {
-        IndicesExists::new(self.client.clone(), parts)
+    pub fn exists<'b>(&'a self, parts: IndicesExistsParts<'b>) -> IndicesExists<'a, 'b> {
+        IndicesExists::new(&self.client, parts)
     }
     #[doc = "Returns information about whether a particular alias exists."]
-    pub fn exists_alias<'a>(&self, parts: IndicesExistsAliasParts<'a>) -> IndicesExistsAlias<'a> {
-        IndicesExistsAlias::new(self.client.clone(), parts)
+    pub fn exists_alias<'b>(
+        &'a self,
+        parts: IndicesExistsAliasParts<'b>,
+    ) -> IndicesExistsAlias<'a, 'b> {
+        IndicesExistsAlias::new(&self.client, parts)
     }
     #[doc = "Returns information about whether a particular index template exists."]
-    pub fn exists_template<'a>(
-        &self,
-        parts: IndicesExistsTemplateParts<'a>,
-    ) -> IndicesExistsTemplate<'a> {
-        IndicesExistsTemplate::new(self.client.clone(), parts)
+    pub fn exists_template<'b>(
+        &'a self,
+        parts: IndicesExistsTemplateParts<'b>,
+    ) -> IndicesExistsTemplate<'a, 'b> {
+        IndicesExistsTemplate::new(&self.client, parts)
     }
     #[doc = "Returns information about whether a particular document type exists. (DEPRECATED)"]
-    pub fn exists_type<'a>(&self, parts: IndicesExistsTypeParts<'a>) -> IndicesExistsType<'a> {
-        IndicesExistsType::new(self.client.clone(), parts)
+    pub fn exists_type<'b>(
+        &'a self,
+        parts: IndicesExistsTypeParts<'b>,
+    ) -> IndicesExistsType<'a, 'b> {
+        IndicesExistsType::new(&self.client, parts)
     }
     #[doc = "Performs the flush operation on one or more indices."]
-    pub fn flush<'a>(&self, parts: IndicesFlushParts<'a>) -> IndicesFlush<'a, ()> {
-        IndicesFlush::new(self.client.clone(), parts)
+    pub fn flush<'b>(&'a self, parts: IndicesFlushParts<'b>) -> IndicesFlush<'a, 'b, ()> {
+        IndicesFlush::new(&self.client, parts)
     }
     #[doc = "Performs a synced flush operation on one or more indices."]
-    pub fn flush_synced<'a>(
-        &self,
-        parts: IndicesFlushSyncedParts<'a>,
-    ) -> IndicesFlushSynced<'a, ()> {
-        IndicesFlushSynced::new(self.client.clone(), parts)
+    pub fn flush_synced<'b>(
+        &'a self,
+        parts: IndicesFlushSyncedParts<'b>,
+    ) -> IndicesFlushSynced<'a, 'b, ()> {
+        IndicesFlushSynced::new(&self.client, parts)
     }
     #[doc = "Performs the force merge operation on one or more indices."]
-    pub fn forcemerge<'a>(&self, parts: IndicesForcemergeParts<'a>) -> IndicesForcemerge<'a, ()> {
-        IndicesForcemerge::new(self.client.clone(), parts)
+    pub fn forcemerge<'b>(
+        &'a self,
+        parts: IndicesForcemergeParts<'b>,
+    ) -> IndicesForcemerge<'a, 'b, ()> {
+        IndicesForcemerge::new(&self.client, parts)
     }
-    pub fn freeze<'a>(&self, parts: IndicesFreezeParts<'a>) -> IndicesFreeze<'a, ()> {
-        IndicesFreeze::new(self.client.clone(), parts)
+    pub fn freeze<'b>(&'a self, parts: IndicesFreezeParts<'b>) -> IndicesFreeze<'a, 'b, ()> {
+        IndicesFreeze::new(&self.client, parts)
     }
     #[doc = "Returns information about one or more indices."]
-    pub fn get<'a>(&self, parts: IndicesGetParts<'a>) -> IndicesGet<'a> {
-        IndicesGet::new(self.client.clone(), parts)
+    pub fn get<'b>(&'a self, parts: IndicesGetParts<'b>) -> IndicesGet<'a, 'b> {
+        IndicesGet::new(&self.client, parts)
     }
     #[doc = "Returns an alias."]
-    pub fn get_alias<'a>(&self, parts: IndicesGetAliasParts<'a>) -> IndicesGetAlias<'a> {
-        IndicesGetAlias::new(self.client.clone(), parts)
+    pub fn get_alias<'b>(&'a self, parts: IndicesGetAliasParts<'b>) -> IndicesGetAlias<'a, 'b> {
+        IndicesGetAlias::new(&self.client, parts)
     }
     #[doc = "Returns mapping for one or more fields."]
-    pub fn get_field_mapping<'a>(
-        &self,
-        parts: IndicesGetFieldMappingParts<'a>,
-    ) -> IndicesGetFieldMapping<'a> {
-        IndicesGetFieldMapping::new(self.client.clone(), parts)
+    pub fn get_field_mapping<'b>(
+        &'a self,
+        parts: IndicesGetFieldMappingParts<'b>,
+    ) -> IndicesGetFieldMapping<'a, 'b> {
+        IndicesGetFieldMapping::new(&self.client, parts)
     }
     #[doc = "Returns mappings for one or more indices."]
-    pub fn get_mapping<'a>(&self, parts: IndicesGetMappingParts<'a>) -> IndicesGetMapping<'a> {
-        IndicesGetMapping::new(self.client.clone(), parts)
+    pub fn get_mapping<'b>(
+        &'a self,
+        parts: IndicesGetMappingParts<'b>,
+    ) -> IndicesGetMapping<'a, 'b> {
+        IndicesGetMapping::new(&self.client, parts)
     }
     #[doc = "Returns settings for one or more indices."]
-    pub fn get_settings<'a>(&self, parts: IndicesGetSettingsParts<'a>) -> IndicesGetSettings<'a> {
-        IndicesGetSettings::new(self.client.clone(), parts)
+    pub fn get_settings<'b>(
+        &'a self,
+        parts: IndicesGetSettingsParts<'b>,
+    ) -> IndicesGetSettings<'a, 'b> {
+        IndicesGetSettings::new(&self.client, parts)
     }
     #[doc = "Returns an index template."]
-    pub fn get_template<'a>(&self, parts: IndicesGetTemplateParts<'a>) -> IndicesGetTemplate<'a> {
-        IndicesGetTemplate::new(self.client.clone(), parts)
+    pub fn get_template<'b>(
+        &'a self,
+        parts: IndicesGetTemplateParts<'b>,
+    ) -> IndicesGetTemplate<'a, 'b> {
+        IndicesGetTemplate::new(&self.client, parts)
     }
     #[doc = "The _upgrade API is no longer useful and will be removed."]
-    pub fn get_upgrade<'a>(&self, parts: IndicesGetUpgradeParts<'a>) -> IndicesGetUpgrade<'a> {
-        IndicesGetUpgrade::new(self.client.clone(), parts)
+    pub fn get_upgrade<'b>(
+        &'a self,
+        parts: IndicesGetUpgradeParts<'b>,
+    ) -> IndicesGetUpgrade<'a, 'b> {
+        IndicesGetUpgrade::new(&self.client, parts)
     }
     #[doc = "Opens an index."]
-    pub fn open<'a>(&self, parts: IndicesOpenParts<'a>) -> IndicesOpen<'a, ()> {
-        IndicesOpen::new(self.client.clone(), parts)
+    pub fn open<'b>(&'a self, parts: IndicesOpenParts<'b>) -> IndicesOpen<'a, 'b, ()> {
+        IndicesOpen::new(&self.client, parts)
     }
     #[doc = "Creates or updates an alias."]
-    pub fn put_alias<'a>(&self, parts: IndicesPutAliasParts<'a>) -> IndicesPutAlias<'a, ()> {
-        IndicesPutAlias::new(self.client.clone(), parts)
+    pub fn put_alias<'b>(&'a self, parts: IndicesPutAliasParts<'b>) -> IndicesPutAlias<'a, 'b, ()> {
+        IndicesPutAlias::new(&self.client, parts)
     }
     #[doc = "Updates the index mappings."]
-    pub fn put_mapping<'a>(&self, parts: IndicesPutMappingParts<'a>) -> IndicesPutMapping<'a, ()> {
-        IndicesPutMapping::new(self.client.clone(), parts)
+    pub fn put_mapping<'b>(
+        &'a self,
+        parts: IndicesPutMappingParts<'b>,
+    ) -> IndicesPutMapping<'a, 'b, ()> {
+        IndicesPutMapping::new(&self.client, parts)
     }
     #[doc = "Updates the index settings."]
-    pub fn put_settings<'a>(
-        &self,
-        parts: IndicesPutSettingsParts<'a>,
-    ) -> IndicesPutSettings<'a, ()> {
-        IndicesPutSettings::new(self.client.clone(), parts)
+    pub fn put_settings<'b>(
+        &'a self,
+        parts: IndicesPutSettingsParts<'b>,
+    ) -> IndicesPutSettings<'a, 'b, ()> {
+        IndicesPutSettings::new(&self.client, parts)
     }
     #[doc = "Creates or updates an index template."]
-    pub fn put_template<'a>(
-        &self,
-        parts: IndicesPutTemplateParts<'a>,
-    ) -> IndicesPutTemplate<'a, ()> {
-        IndicesPutTemplate::new(self.client.clone(), parts)
+    pub fn put_template<'b>(
+        &'a self,
+        parts: IndicesPutTemplateParts<'b>,
+    ) -> IndicesPutTemplate<'a, 'b, ()> {
+        IndicesPutTemplate::new(&self.client, parts)
     }
     #[doc = "Returns information about ongoing index shard recoveries."]
-    pub fn recovery<'a>(&self, parts: IndicesRecoveryParts<'a>) -> IndicesRecovery<'a> {
-        IndicesRecovery::new(self.client.clone(), parts)
+    pub fn recovery<'b>(&'a self, parts: IndicesRecoveryParts<'b>) -> IndicesRecovery<'a, 'b> {
+        IndicesRecovery::new(&self.client, parts)
     }
     #[doc = "Performs the refresh operation in one or more indices."]
-    pub fn refresh<'a>(&self, parts: IndicesRefreshParts<'a>) -> IndicesRefresh<'a, ()> {
-        IndicesRefresh::new(self.client.clone(), parts)
+    pub fn refresh<'b>(&'a self, parts: IndicesRefreshParts<'b>) -> IndicesRefresh<'a, 'b, ()> {
+        IndicesRefresh::new(&self.client, parts)
     }
     #[doc = "Updates an alias to point to a new index when the existing index\nis considered to be too large or too old."]
-    pub fn rollover<'a>(&self, parts: IndicesRolloverParts<'a>) -> IndicesRollover<'a, ()> {
-        IndicesRollover::new(self.client.clone(), parts)
+    pub fn rollover<'b>(&'a self, parts: IndicesRolloverParts<'b>) -> IndicesRollover<'a, 'b, ()> {
+        IndicesRollover::new(&self.client, parts)
     }
     #[doc = "Provides low-level information about segments in a Lucene index."]
-    pub fn segments<'a>(&self, parts: IndicesSegmentsParts<'a>) -> IndicesSegments<'a> {
-        IndicesSegments::new(self.client.clone(), parts)
+    pub fn segments<'b>(&'a self, parts: IndicesSegmentsParts<'b>) -> IndicesSegments<'a, 'b> {
+        IndicesSegments::new(&self.client, parts)
     }
     #[doc = "Provides store information for shard copies of indices."]
-    pub fn shard_stores<'a>(&self, parts: IndicesShardStoresParts<'a>) -> IndicesShardStores<'a> {
-        IndicesShardStores::new(self.client.clone(), parts)
+    pub fn shard_stores<'b>(
+        &'a self,
+        parts: IndicesShardStoresParts<'b>,
+    ) -> IndicesShardStores<'a, 'b> {
+        IndicesShardStores::new(&self.client, parts)
     }
     #[doc = "Allow to shrink an existing index into a new index with fewer primary shards."]
-    pub fn shrink<'a>(&self, parts: IndicesShrinkParts<'a>) -> IndicesShrink<'a, ()> {
-        IndicesShrink::new(self.client.clone(), parts)
+    pub fn shrink<'b>(&'a self, parts: IndicesShrinkParts<'b>) -> IndicesShrink<'a, 'b, ()> {
+        IndicesShrink::new(&self.client, parts)
     }
     #[doc = "Allows you to split an existing index into a new index with more primary shards."]
-    pub fn split<'a>(&self, parts: IndicesSplitParts<'a>) -> IndicesSplit<'a, ()> {
-        IndicesSplit::new(self.client.clone(), parts)
+    pub fn split<'b>(&'a self, parts: IndicesSplitParts<'b>) -> IndicesSplit<'a, 'b, ()> {
+        IndicesSplit::new(&self.client, parts)
     }
     #[doc = "Provides statistics on operations happening in an index."]
-    pub fn stats<'a>(&self, parts: IndicesStatsParts<'a>) -> IndicesStats<'a> {
-        IndicesStats::new(self.client.clone(), parts)
+    pub fn stats<'b>(&'a self, parts: IndicesStatsParts<'b>) -> IndicesStats<'a, 'b> {
+        IndicesStats::new(&self.client, parts)
     }
-    pub fn unfreeze<'a>(&self, parts: IndicesUnfreezeParts<'a>) -> IndicesUnfreeze<'a, ()> {
-        IndicesUnfreeze::new(self.client.clone(), parts)
+    pub fn unfreeze<'b>(&'a self, parts: IndicesUnfreezeParts<'b>) -> IndicesUnfreeze<'a, 'b, ()> {
+        IndicesUnfreeze::new(&self.client, parts)
     }
     #[doc = "Updates index aliases."]
-    pub fn update_aliases<'a>(&self) -> IndicesUpdateAliases<'a, ()> {
-        IndicesUpdateAliases::new(self.client.clone())
+    pub fn update_aliases<'b>(&'a self) -> IndicesUpdateAliases<'a, 'b, ()> {
+        IndicesUpdateAliases::new(&self.client)
     }
     #[doc = "The _upgrade API is no longer useful and will be removed."]
-    pub fn upgrade<'a>(&self, parts: IndicesUpgradeParts<'a>) -> IndicesUpgrade<'a, ()> {
-        IndicesUpgrade::new(self.client.clone(), parts)
+    pub fn upgrade<'b>(&'a self, parts: IndicesUpgradeParts<'b>) -> IndicesUpgrade<'a, 'b, ()> {
+        IndicesUpgrade::new(&self.client, parts)
     }
     #[doc = "Allows a user to validate a potentially expensive query without executing it."]
-    pub fn validate_query<'a>(
-        &self,
-        parts: IndicesValidateQueryParts<'a>,
-    ) -> IndicesValidateQuery<'a, ()> {
-        IndicesValidateQuery::new(self.client.clone(), parts)
+    pub fn validate_query<'b>(
+        &'a self,
+        parts: IndicesValidateQueryParts<'b>,
+    ) -> IndicesValidateQuery<'a, 'b, ()> {
+        IndicesValidateQuery::new(&self.client, parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Indices APIs"]
     pub fn indices(&self) -> Indices {
-        Indices::new(self.clone())
+        Indices::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/ingest.rs
+++ b/elasticsearch/src/generated/namespace_clients/ingest.rs
@@ -31,11 +31,11 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ingest Delete Pipeline API"]
-pub enum IngestDeletePipelineParts<'a> {
+pub enum IngestDeletePipelineParts<'b> {
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
 }
-impl<'a> IngestDeletePipelineParts<'a> {
+impl<'b> IngestDeletePipelineParts<'b> {
     #[doc = "Builds a relative URL path to the Ingest Delete Pipeline API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -50,21 +50,21 @@ impl<'a> IngestDeletePipelineParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ingest Delete Pipeline API](https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html). Deletes a pipeline."]
-pub struct IngestDeletePipeline<'a> {
-    client: Elasticsearch,
-    parts: IngestDeletePipelineParts<'a>,
+pub struct IngestDeletePipeline<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IngestDeletePipelineParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> IngestDeletePipeline<'a> {
+impl<'a, 'b> IngestDeletePipeline<'a, 'b> {
     #[doc = "Creates a new instance of [IngestDeletePipeline] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IngestDeletePipelineParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IngestDeletePipelineParts<'b>) -> Self {
         IngestDeletePipeline {
             client,
             parts,
@@ -84,7 +84,7 @@ impl<'a> IngestDeletePipeline<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -99,7 +99,7 @@ impl<'a> IngestDeletePipeline<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -109,12 +109,12 @@ impl<'a> IngestDeletePipeline<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -126,24 +126,24 @@ impl<'a> IngestDeletePipeline<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -166,13 +166,13 @@ impl<'a> IngestDeletePipeline<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ingest Get Pipeline API"]
-pub enum IngestGetPipelineParts<'a> {
+pub enum IngestGetPipelineParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
 }
-impl<'a> IngestGetPipelineParts<'a> {
+impl<'b> IngestGetPipelineParts<'b> {
     #[doc = "Builds a relative URL path to the Ingest Get Pipeline API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -188,20 +188,20 @@ impl<'a> IngestGetPipelineParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ingest Get Pipeline API](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html). Returns a pipeline."]
-pub struct IngestGetPipeline<'a> {
-    client: Elasticsearch,
-    parts: IngestGetPipelineParts<'a>,
+pub struct IngestGetPipeline<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: IngestGetPipelineParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IngestGetPipeline<'a> {
+impl<'a, 'b> IngestGetPipeline<'a, 'b> {
     #[doc = "Creates a new instance of [IngestGetPipeline] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IngestGetPipelineParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IngestGetPipelineParts<'b>) -> Self {
         IngestGetPipeline {
             client,
             parts,
@@ -220,7 +220,7 @@ impl<'a> IngestGetPipeline<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -235,7 +235,7 @@ impl<'a> IngestGetPipeline<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -245,7 +245,7 @@ impl<'a> IngestGetPipeline<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -257,22 +257,22 @@ impl<'a> IngestGetPipeline<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -308,19 +308,19 @@ impl IngestProcessorGrokParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ingest Processor Grok API](https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get). Returns a list of the built-in patterns."]
-pub struct IngestProcessorGrok<'a> {
-    client: Elasticsearch,
+pub struct IngestProcessorGrok<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: IngestProcessorGrokParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> IngestProcessorGrok<'a> {
+impl<'a, 'b> IngestProcessorGrok<'a, 'b> {
     #[doc = "Creates a new instance of [IngestProcessorGrok]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         IngestProcessorGrok {
             client,
             parts: IngestProcessorGrokParts::None,
@@ -338,7 +338,7 @@ impl<'a> IngestProcessorGrok<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -358,7 +358,7 @@ impl<'a> IngestProcessorGrok<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -370,20 +370,20 @@ impl<'a> IngestProcessorGrok<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -404,11 +404,11 @@ impl<'a> IngestProcessorGrok<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ingest Put Pipeline API"]
-pub enum IngestPutPipelineParts<'a> {
+pub enum IngestPutPipelineParts<'b> {
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
 }
-impl<'a> IngestPutPipelineParts<'a> {
+impl<'b> IngestPutPipelineParts<'b> {
     #[doc = "Builds a relative URL path to the Ingest Put Pipeline API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -423,25 +423,25 @@ impl<'a> IngestPutPipelineParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ingest Put Pipeline API](https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html). Creates or updates a pipeline."]
-pub struct IngestPutPipeline<'a, B> {
-    client: Elasticsearch,
-    parts: IngestPutPipelineParts<'a>,
+pub struct IngestPutPipeline<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IngestPutPipelineParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> IngestPutPipeline<'a, B>
+impl<'a, 'b, B> IngestPutPipeline<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IngestPutPipeline] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IngestPutPipelineParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IngestPutPipelineParts<'b>) -> Self {
         IngestPutPipeline {
             client,
             parts,
@@ -457,7 +457,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IngestPutPipeline<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IngestPutPipeline<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -481,7 +481,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -496,7 +496,7 @@ where
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -506,12 +506,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -523,24 +523,24 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -563,13 +563,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ingest Simulate API"]
-pub enum IngestSimulateParts<'a> {
+pub enum IngestSimulateParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
 }
-impl<'a> IngestSimulateParts<'a> {
+impl<'b> IngestSimulateParts<'b> {
     #[doc = "Builds a relative URL path to the Ingest Simulate API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -586,24 +586,24 @@ impl<'a> IngestSimulateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ingest Simulate API](https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html). Allows to simulate a pipeline with example documents."]
-pub struct IngestSimulate<'a, B> {
-    client: Elasticsearch,
-    parts: IngestSimulateParts<'a>,
+pub struct IngestSimulate<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IngestSimulateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     verbose: Option<bool>,
 }
-impl<'a, B> IngestSimulate<'a, B>
+impl<'a, 'b, B> IngestSimulate<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [IngestSimulate] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IngestSimulateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IngestSimulateParts<'b>) -> Self {
         IngestSimulate {
             client,
             parts,
@@ -618,7 +618,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IngestSimulate<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> IngestSimulate<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -641,7 +641,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -661,7 +661,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -681,20 +681,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "verbose")]
                 verbose: Option<bool>,
             }
@@ -717,41 +717,47 @@ where
     }
 }
 #[doc = "Namespace client for Ingest APIs"]
-pub struct Ingest {
-    client: Elasticsearch,
+pub struct Ingest<'a> {
+    client: &'a Elasticsearch,
 }
-impl Ingest {
+impl<'a> Ingest<'a> {
     #[doc = "Creates a new instance of [Ingest]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
     #[doc = "Deletes a pipeline."]
-    pub fn delete_pipeline<'a>(
-        &self,
-        parts: IngestDeletePipelineParts<'a>,
-    ) -> IngestDeletePipeline<'a> {
-        IngestDeletePipeline::new(self.client.clone(), parts)
+    pub fn delete_pipeline<'b>(
+        &'a self,
+        parts: IngestDeletePipelineParts<'b>,
+    ) -> IngestDeletePipeline<'a, 'b> {
+        IngestDeletePipeline::new(&self.client, parts)
     }
     #[doc = "Returns a pipeline."]
-    pub fn get_pipeline<'a>(&self, parts: IngestGetPipelineParts<'a>) -> IngestGetPipeline<'a> {
-        IngestGetPipeline::new(self.client.clone(), parts)
+    pub fn get_pipeline<'b>(
+        &'a self,
+        parts: IngestGetPipelineParts<'b>,
+    ) -> IngestGetPipeline<'a, 'b> {
+        IngestGetPipeline::new(&self.client, parts)
     }
     #[doc = "Returns a list of the built-in patterns."]
-    pub fn processor_grok<'a>(&self) -> IngestProcessorGrok<'a> {
-        IngestProcessorGrok::new(self.client.clone())
+    pub fn processor_grok<'b>(&'a self) -> IngestProcessorGrok<'a, 'b> {
+        IngestProcessorGrok::new(&self.client)
     }
     #[doc = "Creates or updates a pipeline."]
-    pub fn put_pipeline<'a>(&self, parts: IngestPutPipelineParts<'a>) -> IngestPutPipeline<'a, ()> {
-        IngestPutPipeline::new(self.client.clone(), parts)
+    pub fn put_pipeline<'b>(
+        &'a self,
+        parts: IngestPutPipelineParts<'b>,
+    ) -> IngestPutPipeline<'a, 'b, ()> {
+        IngestPutPipeline::new(&self.client, parts)
     }
     #[doc = "Allows to simulate a pipeline with example documents."]
-    pub fn simulate<'a>(&self, parts: IngestSimulateParts<'a>) -> IngestSimulate<'a, ()> {
-        IngestSimulate::new(self.client.clone(), parts)
+    pub fn simulate<'b>(&'a self, parts: IngestSimulateParts<'b>) -> IngestSimulate<'a, 'b, ()> {
+        IngestSimulate::new(&self.client, parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Ingest APIs"]
     pub fn ingest(&self) -> Ingest {
-        Ingest::new(self.clone())
+        Ingest::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/license.rs
+++ b/elasticsearch/src/generated/namespace_clients/license.rs
@@ -45,19 +45,19 @@ impl LicenseDeleteParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html)."]
-pub struct LicenseDelete<'a> {
-    client: Elasticsearch,
+pub struct LicenseDelete<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: LicenseDeleteParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> LicenseDelete<'a> {
+impl<'a, 'b> LicenseDelete<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseDelete]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         LicenseDelete {
             client,
             parts: LicenseDeleteParts::None,
@@ -75,7 +75,7 @@ impl<'a> LicenseDelete<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -95,7 +95,7 @@ impl<'a> LicenseDelete<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -107,20 +107,20 @@ impl<'a> LicenseDelete<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -155,20 +155,20 @@ impl LicenseGetParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Get API](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html)."]
-pub struct LicenseGet<'a> {
-    client: Elasticsearch,
+pub struct LicenseGet<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: LicenseGetParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     local: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> LicenseGet<'a> {
+impl<'a, 'b> LicenseGet<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseGet]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         LicenseGet {
             client,
             parts: LicenseGetParts::None,
@@ -187,7 +187,7 @@ impl<'a> LicenseGet<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -212,7 +212,7 @@ impl<'a> LicenseGet<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -224,14 +224,14 @@ impl<'a> LicenseGet<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "local")]
@@ -239,7 +239,7 @@ impl<'a> LicenseGet<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -275,19 +275,19 @@ impl LicenseGetBasicStatusParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Get Basic Status API](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html)."]
-pub struct LicenseGetBasicStatus<'a> {
-    client: Elasticsearch,
+pub struct LicenseGetBasicStatus<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: LicenseGetBasicStatusParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> LicenseGetBasicStatus<'a> {
+impl<'a, 'b> LicenseGetBasicStatus<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseGetBasicStatus]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         LicenseGetBasicStatus {
             client,
             parts: LicenseGetBasicStatusParts::None,
@@ -305,7 +305,7 @@ impl<'a> LicenseGetBasicStatus<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -325,7 +325,7 @@ impl<'a> LicenseGetBasicStatus<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -337,20 +337,20 @@ impl<'a> LicenseGetBasicStatus<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -385,19 +385,19 @@ impl LicenseGetTrialStatusParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Get Trial Status API](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html)."]
-pub struct LicenseGetTrialStatus<'a> {
-    client: Elasticsearch,
+pub struct LicenseGetTrialStatus<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: LicenseGetTrialStatusParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> LicenseGetTrialStatus<'a> {
+impl<'a, 'b> LicenseGetTrialStatus<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseGetTrialStatus]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         LicenseGetTrialStatus {
             client,
             parts: LicenseGetTrialStatusParts::None,
@@ -415,7 +415,7 @@ impl<'a> LicenseGetTrialStatus<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -435,7 +435,7 @@ impl<'a> LicenseGetTrialStatus<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -447,20 +447,20 @@ impl<'a> LicenseGetTrialStatus<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -495,24 +495,24 @@ impl LicensePostParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Post API](https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html)."]
-pub struct LicensePost<'a, B> {
-    client: Elasticsearch,
+pub struct LicensePost<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: LicensePostParts,
     acknowledge: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> LicensePost<'a, B>
+impl<'a, 'b, B> LicensePost<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [LicensePost]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         LicensePost {
             client,
             parts: LicensePostParts::None,
@@ -532,7 +532,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> LicensePost<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> LicensePost<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -555,7 +555,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -575,7 +575,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -587,7 +587,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "acknowledge")]
                 acknowledge: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -596,13 +596,13 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 acknowledge: self.acknowledge,
@@ -638,24 +638,24 @@ impl LicensePostStartBasicParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Post Start Basic API](https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html)."]
-pub struct LicensePostStartBasic<'a, B> {
-    client: Elasticsearch,
+pub struct LicensePostStartBasic<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: LicensePostStartBasicParts,
     acknowledge: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> LicensePostStartBasic<'a, B>
+impl<'a, 'b, B> LicensePostStartBasic<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [LicensePostStartBasic]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         LicensePostStartBasic {
             client,
             parts: LicensePostStartBasicParts::None,
@@ -675,7 +675,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> LicensePostStartBasic<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> LicensePostStartBasic<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -698,7 +698,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -718,7 +718,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -730,7 +730,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "acknowledge")]
                 acknowledge: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -739,13 +739,13 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 acknowledge: self.acknowledge,
@@ -781,25 +781,25 @@ impl LicensePostStartTrialParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Post Start Trial API](https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html)."]
-pub struct LicensePostStartTrial<'a, B> {
-    client: Elasticsearch,
+pub struct LicensePostStartTrial<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: LicensePostStartTrialParts,
     acknowledge: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    ty: Option<&'a str>,
+    source: Option<&'b str>,
+    ty: Option<&'b str>,
 }
-impl<'a, B> LicensePostStartTrial<'a, B>
+impl<'a, 'b, B> LicensePostStartTrial<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [LicensePostStartTrial]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         LicensePostStartTrial {
             client,
             parts: LicensePostStartTrialParts::None,
@@ -820,7 +820,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> LicensePostStartTrial<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> LicensePostStartTrial<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -844,7 +844,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -864,12 +864,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "The type of trial license to generate (default: \"trial\")"]
-    pub fn ty(mut self, ty: &'a str) -> Self {
+    pub fn ty(mut self, ty: &'b str) -> Self {
         self.ty = Some(ty);
         self
     }
@@ -881,7 +881,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "acknowledge")]
                 acknowledge: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -890,15 +890,15 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "type")]
-                ty: Option<&'a str>,
+                ty: Option<&'b str>,
             }
             let query_params = QueryParams {
                 acknowledge: self.acknowledge,
@@ -920,39 +920,39 @@ where
     }
 }
 #[doc = "Namespace client for License APIs"]
-pub struct License {
-    client: Elasticsearch,
+pub struct License<'a> {
+    client: &'a Elasticsearch,
 }
-impl License {
+impl<'a> License<'a> {
     #[doc = "Creates a new instance of [License]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn delete<'a>(&self) -> LicenseDelete<'a> {
-        LicenseDelete::new(self.client.clone())
+    pub fn delete<'b>(&'a self) -> LicenseDelete<'a, 'b> {
+        LicenseDelete::new(&self.client)
     }
-    pub fn get<'a>(&self) -> LicenseGet<'a> {
-        LicenseGet::new(self.client.clone())
+    pub fn get<'b>(&'a self) -> LicenseGet<'a, 'b> {
+        LicenseGet::new(&self.client)
     }
-    pub fn get_basic_status<'a>(&self) -> LicenseGetBasicStatus<'a> {
-        LicenseGetBasicStatus::new(self.client.clone())
+    pub fn get_basic_status<'b>(&'a self) -> LicenseGetBasicStatus<'a, 'b> {
+        LicenseGetBasicStatus::new(&self.client)
     }
-    pub fn get_trial_status<'a>(&self) -> LicenseGetTrialStatus<'a> {
-        LicenseGetTrialStatus::new(self.client.clone())
+    pub fn get_trial_status<'b>(&'a self) -> LicenseGetTrialStatus<'a, 'b> {
+        LicenseGetTrialStatus::new(&self.client)
     }
-    pub fn post<'a>(&self) -> LicensePost<'a, ()> {
-        LicensePost::new(self.client.clone())
+    pub fn post<'b>(&'a self) -> LicensePost<'a, 'b, ()> {
+        LicensePost::new(&self.client)
     }
-    pub fn post_start_basic<'a>(&self) -> LicensePostStartBasic<'a, ()> {
-        LicensePostStartBasic::new(self.client.clone())
+    pub fn post_start_basic<'b>(&'a self) -> LicensePostStartBasic<'a, 'b, ()> {
+        LicensePostStartBasic::new(&self.client)
     }
-    pub fn post_start_trial<'a>(&self) -> LicensePostStartTrial<'a, ()> {
-        LicensePostStartTrial::new(self.client.clone())
+    pub fn post_start_trial<'b>(&'a self) -> LicensePostStartTrial<'a, 'b, ()> {
+        LicensePostStartTrial::new(&self.client)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for License APIs"]
     pub fn license(&self) -> License {
-        License::new(self.clone())
+        License::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/migration.rs
+++ b/elasticsearch/src/generated/namespace_clients/migration.rs
@@ -31,13 +31,13 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Migration Deprecations API"]
-pub enum MigrationDeprecationsParts<'a> {
+pub enum MigrationDeprecationsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
 }
-impl<'a> MigrationDeprecationsParts<'a> {
+impl<'b> MigrationDeprecationsParts<'b> {
     #[doc = "Builds a relative URL path to the Migration Deprecations API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -54,19 +54,19 @@ impl<'a> MigrationDeprecationsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Migration Deprecations API](http://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-deprecation.html)."]
-pub struct MigrationDeprecations<'a> {
-    client: Elasticsearch,
-    parts: MigrationDeprecationsParts<'a>,
+pub struct MigrationDeprecations<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MigrationDeprecationsParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MigrationDeprecations<'a> {
+impl<'a, 'b> MigrationDeprecations<'a, 'b> {
     #[doc = "Creates a new instance of [MigrationDeprecations] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MigrationDeprecationsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MigrationDeprecationsParts<'b>) -> Self {
         MigrationDeprecations {
             client,
             parts,
@@ -84,7 +84,7 @@ impl<'a> MigrationDeprecations<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -104,7 +104,7 @@ impl<'a> MigrationDeprecations<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -116,20 +116,20 @@ impl<'a> MigrationDeprecations<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -149,24 +149,24 @@ impl<'a> MigrationDeprecations<'a> {
     }
 }
 #[doc = "Namespace client for Migration APIs"]
-pub struct Migration {
-    client: Elasticsearch,
+pub struct Migration<'a> {
+    client: &'a Elasticsearch,
 }
-impl Migration {
+impl<'a> Migration<'a> {
     #[doc = "Creates a new instance of [Migration]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn deprecations<'a>(
-        &self,
-        parts: MigrationDeprecationsParts<'a>,
-    ) -> MigrationDeprecations<'a> {
-        MigrationDeprecations::new(self.client.clone(), parts)
+    pub fn deprecations<'b>(
+        &'a self,
+        parts: MigrationDeprecationsParts<'b>,
+    ) -> MigrationDeprecations<'a, 'b> {
+        MigrationDeprecations::new(&self.client, parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Migration APIs"]
     pub fn migration(&self) -> Migration {
-        Migration::new(self.clone())
+        Migration::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/ml.rs
+++ b/elasticsearch/src/generated/namespace_clients/ml.rs
@@ -31,11 +31,11 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Close Job API"]
-pub enum MlCloseJobParts<'a> {
+pub enum MlCloseJobParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlCloseJobParts<'a> {
+impl<'b> MlCloseJobParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Close Job API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -51,26 +51,26 @@ impl<'a> MlCloseJobParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Close Job API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html)."]
-pub struct MlCloseJob<'a, B> {
-    client: Elasticsearch,
-    parts: MlCloseJobParts<'a>,
+pub struct MlCloseJob<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlCloseJobParts<'b>,
     allow_no_jobs: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     force: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> MlCloseJob<'a, B>
+impl<'a, 'b, B> MlCloseJob<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlCloseJob] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlCloseJobParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlCloseJobParts<'b>) -> Self {
         MlCloseJob {
             client,
             parts,
@@ -92,7 +92,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlCloseJob<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlCloseJob<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -117,7 +117,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -142,12 +142,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Controls the time to wait until a job has closed. Default to 30 minutes"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -159,7 +159,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_jobs")]
                 allow_no_jobs: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -168,7 +168,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "force")]
                 force: Option<bool>,
                 #[serde(rename = "human")]
@@ -176,9 +176,9 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_jobs: self.allow_no_jobs,
@@ -202,11 +202,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Delete Calendar API"]
-pub enum MlDeleteCalendarParts<'a> {
+pub enum MlDeleteCalendarParts<'b> {
     #[doc = "CalendarId"]
-    CalendarId(&'a str),
+    CalendarId(&'b str),
 }
-impl<'a> MlDeleteCalendarParts<'a> {
+impl<'b> MlDeleteCalendarParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Delete Calendar API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -221,19 +221,19 @@ impl<'a> MlDeleteCalendarParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Delete Calendar API"]
-pub struct MlDeleteCalendar<'a> {
-    client: Elasticsearch,
-    parts: MlDeleteCalendarParts<'a>,
+pub struct MlDeleteCalendar<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlDeleteCalendarParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlDeleteCalendar<'a> {
+impl<'a, 'b> MlDeleteCalendar<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteCalendar] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlDeleteCalendarParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlDeleteCalendarParts<'b>) -> Self {
         MlDeleteCalendar {
             client,
             parts,
@@ -251,7 +251,7 @@ impl<'a> MlDeleteCalendar<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -271,7 +271,7 @@ impl<'a> MlDeleteCalendar<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -283,20 +283,20 @@ impl<'a> MlDeleteCalendar<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -317,11 +317,11 @@ impl<'a> MlDeleteCalendar<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Delete Calendar Event API"]
-pub enum MlDeleteCalendarEventParts<'a> {
+pub enum MlDeleteCalendarEventParts<'b> {
     #[doc = "CalendarId and EventId"]
-    CalendarIdEventId(&'a str, &'a str),
+    CalendarIdEventId(&'b str, &'b str),
 }
-impl<'a> MlDeleteCalendarEventParts<'a> {
+impl<'b> MlDeleteCalendarEventParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Delete Calendar Event API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -338,19 +338,19 @@ impl<'a> MlDeleteCalendarEventParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Delete Calendar Event API"]
-pub struct MlDeleteCalendarEvent<'a> {
-    client: Elasticsearch,
-    parts: MlDeleteCalendarEventParts<'a>,
+pub struct MlDeleteCalendarEvent<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlDeleteCalendarEventParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlDeleteCalendarEvent<'a> {
+impl<'a, 'b> MlDeleteCalendarEvent<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteCalendarEvent] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlDeleteCalendarEventParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlDeleteCalendarEventParts<'b>) -> Self {
         MlDeleteCalendarEvent {
             client,
             parts,
@@ -368,7 +368,7 @@ impl<'a> MlDeleteCalendarEvent<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -388,7 +388,7 @@ impl<'a> MlDeleteCalendarEvent<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -400,20 +400,20 @@ impl<'a> MlDeleteCalendarEvent<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -434,11 +434,11 @@ impl<'a> MlDeleteCalendarEvent<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Delete Calendar Job API"]
-pub enum MlDeleteCalendarJobParts<'a> {
+pub enum MlDeleteCalendarJobParts<'b> {
     #[doc = "CalendarId and JobId"]
-    CalendarIdJobId(&'a str, &'a str),
+    CalendarIdJobId(&'b str, &'b str),
 }
-impl<'a> MlDeleteCalendarJobParts<'a> {
+impl<'b> MlDeleteCalendarJobParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Delete Calendar Job API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -455,19 +455,19 @@ impl<'a> MlDeleteCalendarJobParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Delete Calendar Job API"]
-pub struct MlDeleteCalendarJob<'a> {
-    client: Elasticsearch,
-    parts: MlDeleteCalendarJobParts<'a>,
+pub struct MlDeleteCalendarJob<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlDeleteCalendarJobParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlDeleteCalendarJob<'a> {
+impl<'a, 'b> MlDeleteCalendarJob<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteCalendarJob] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlDeleteCalendarJobParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlDeleteCalendarJobParts<'b>) -> Self {
         MlDeleteCalendarJob {
             client,
             parts,
@@ -485,7 +485,7 @@ impl<'a> MlDeleteCalendarJob<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -505,7 +505,7 @@ impl<'a> MlDeleteCalendarJob<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -517,20 +517,20 @@ impl<'a> MlDeleteCalendarJob<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -551,11 +551,11 @@ impl<'a> MlDeleteCalendarJob<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Delete Datafeed API"]
-pub enum MlDeleteDatafeedParts<'a> {
+pub enum MlDeleteDatafeedParts<'b> {
     #[doc = "DatafeedId"]
-    DatafeedId(&'a str),
+    DatafeedId(&'b str),
 }
-impl<'a> MlDeleteDatafeedParts<'a> {
+impl<'b> MlDeleteDatafeedParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Delete Datafeed API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -570,20 +570,20 @@ impl<'a> MlDeleteDatafeedParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Datafeed API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html)."]
-pub struct MlDeleteDatafeed<'a> {
-    client: Elasticsearch,
-    parts: MlDeleteDatafeedParts<'a>,
+pub struct MlDeleteDatafeed<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlDeleteDatafeedParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     force: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlDeleteDatafeed<'a> {
+impl<'a, 'b> MlDeleteDatafeed<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteDatafeed] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlDeleteDatafeedParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlDeleteDatafeedParts<'b>) -> Self {
         MlDeleteDatafeed {
             client,
             parts,
@@ -602,7 +602,7 @@ impl<'a> MlDeleteDatafeed<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -627,7 +627,7 @@ impl<'a> MlDeleteDatafeed<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -639,14 +639,14 @@ impl<'a> MlDeleteDatafeed<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "force")]
                 force: Option<bool>,
                 #[serde(rename = "human")]
@@ -654,7 +654,7 @@ impl<'a> MlDeleteDatafeed<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -690,19 +690,19 @@ impl MlDeleteExpiredDataParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Delete Expired Data API"]
-pub struct MlDeleteExpiredData<'a> {
-    client: Elasticsearch,
+pub struct MlDeleteExpiredData<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: MlDeleteExpiredDataParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlDeleteExpiredData<'a> {
+impl<'a, 'b> MlDeleteExpiredData<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteExpiredData]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         MlDeleteExpiredData {
             client,
             parts: MlDeleteExpiredDataParts::None,
@@ -720,7 +720,7 @@ impl<'a> MlDeleteExpiredData<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -740,7 +740,7 @@ impl<'a> MlDeleteExpiredData<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -752,20 +752,20 @@ impl<'a> MlDeleteExpiredData<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -786,11 +786,11 @@ impl<'a> MlDeleteExpiredData<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Delete Filter API"]
-pub enum MlDeleteFilterParts<'a> {
+pub enum MlDeleteFilterParts<'b> {
     #[doc = "FilterId"]
-    FilterId(&'a str),
+    FilterId(&'b str),
 }
-impl<'a> MlDeleteFilterParts<'a> {
+impl<'b> MlDeleteFilterParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Delete Filter API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -805,19 +805,19 @@ impl<'a> MlDeleteFilterParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Delete Filter API"]
-pub struct MlDeleteFilter<'a> {
-    client: Elasticsearch,
-    parts: MlDeleteFilterParts<'a>,
+pub struct MlDeleteFilter<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlDeleteFilterParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlDeleteFilter<'a> {
+impl<'a, 'b> MlDeleteFilter<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteFilter] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlDeleteFilterParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlDeleteFilterParts<'b>) -> Self {
         MlDeleteFilter {
             client,
             parts,
@@ -835,7 +835,7 @@ impl<'a> MlDeleteFilter<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -855,7 +855,7 @@ impl<'a> MlDeleteFilter<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -867,20 +867,20 @@ impl<'a> MlDeleteFilter<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -901,13 +901,13 @@ impl<'a> MlDeleteFilter<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Delete Forecast API"]
-pub enum MlDeleteForecastParts<'a> {
+pub enum MlDeleteForecastParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
     #[doc = "JobId and ForecastId"]
-    JobIdForecastId(&'a str, &'a str),
+    JobIdForecastId(&'b str, &'b str),
 }
-impl<'a> MlDeleteForecastParts<'a> {
+impl<'b> MlDeleteForecastParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Delete Forecast API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -931,21 +931,21 @@ impl<'a> MlDeleteForecastParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Forecast API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html)."]
-pub struct MlDeleteForecast<'a> {
-    client: Elasticsearch,
-    parts: MlDeleteForecastParts<'a>,
+pub struct MlDeleteForecast<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlDeleteForecastParts<'b>,
     allow_no_forecasts: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> MlDeleteForecast<'a> {
+impl<'a, 'b> MlDeleteForecast<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteForecast] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlDeleteForecastParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlDeleteForecastParts<'b>) -> Self {
         MlDeleteForecast {
             client,
             parts,
@@ -970,7 +970,7 @@ impl<'a> MlDeleteForecast<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -990,12 +990,12 @@ impl<'a> MlDeleteForecast<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Controls the time to wait until the forecast(s) are deleted. Default to 30 seconds"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -1007,7 +1007,7 @@ impl<'a> MlDeleteForecast<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_forecasts")]
                 allow_no_forecasts: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -1016,15 +1016,15 @@ impl<'a> MlDeleteForecast<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_forecasts: self.allow_no_forecasts,
@@ -1047,11 +1047,11 @@ impl<'a> MlDeleteForecast<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Delete Job API"]
-pub enum MlDeleteJobParts<'a> {
+pub enum MlDeleteJobParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlDeleteJobParts<'a> {
+impl<'b> MlDeleteJobParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Delete Job API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1066,21 +1066,21 @@ impl<'a> MlDeleteJobParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Job API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html)."]
-pub struct MlDeleteJob<'a> {
-    client: Elasticsearch,
-    parts: MlDeleteJobParts<'a>,
+pub struct MlDeleteJob<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlDeleteJobParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     force: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     wait_for_completion: Option<bool>,
 }
-impl<'a> MlDeleteJob<'a> {
+impl<'a, 'b> MlDeleteJob<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteJob] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlDeleteJobParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlDeleteJobParts<'b>) -> Self {
         MlDeleteJob {
             client,
             parts,
@@ -1100,7 +1100,7 @@ impl<'a> MlDeleteJob<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1125,7 +1125,7 @@ impl<'a> MlDeleteJob<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1142,14 +1142,14 @@ impl<'a> MlDeleteJob<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "force")]
                 force: Option<bool>,
                 #[serde(rename = "human")]
@@ -1157,7 +1157,7 @@ impl<'a> MlDeleteJob<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "wait_for_completion")]
                 wait_for_completion: Option<bool>,
             }
@@ -1182,11 +1182,11 @@ impl<'a> MlDeleteJob<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Delete Model Snapshot API"]
-pub enum MlDeleteModelSnapshotParts<'a> {
+pub enum MlDeleteModelSnapshotParts<'b> {
     #[doc = "JobId and SnapshotId"]
-    JobIdSnapshotId(&'a str, &'a str),
+    JobIdSnapshotId(&'b str, &'b str),
 }
-impl<'a> MlDeleteModelSnapshotParts<'a> {
+impl<'b> MlDeleteModelSnapshotParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Delete Model Snapshot API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1203,19 +1203,19 @@ impl<'a> MlDeleteModelSnapshotParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Model Snapshot API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html)."]
-pub struct MlDeleteModelSnapshot<'a> {
-    client: Elasticsearch,
-    parts: MlDeleteModelSnapshotParts<'a>,
+pub struct MlDeleteModelSnapshot<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlDeleteModelSnapshotParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlDeleteModelSnapshot<'a> {
+impl<'a, 'b> MlDeleteModelSnapshot<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteModelSnapshot] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlDeleteModelSnapshotParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlDeleteModelSnapshotParts<'b>) -> Self {
         MlDeleteModelSnapshot {
             client,
             parts,
@@ -1233,7 +1233,7 @@ impl<'a> MlDeleteModelSnapshot<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1253,7 +1253,7 @@ impl<'a> MlDeleteModelSnapshot<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1265,20 +1265,20 @@ impl<'a> MlDeleteModelSnapshot<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1299,11 +1299,11 @@ impl<'a> MlDeleteModelSnapshot<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Flush Job API"]
-pub enum MlFlushJobParts<'a> {
+pub enum MlFlushJobParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlFlushJobParts<'a> {
+impl<'b> MlFlushJobParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Flush Job API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1319,28 +1319,28 @@ impl<'a> MlFlushJobParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Flush Job API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html)."]
-pub struct MlFlushJob<'a, B> {
-    client: Elasticsearch,
-    parts: MlFlushJobParts<'a>,
-    advance_time: Option<&'a str>,
+pub struct MlFlushJob<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlFlushJobParts<'b>,
+    advance_time: Option<&'b str>,
     body: Option<B>,
     calc_interim: Option<bool>,
-    end: Option<&'a str>,
+    end: Option<&'b str>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    skip_time: Option<&'a str>,
-    source: Option<&'a str>,
-    start: Option<&'a str>,
+    skip_time: Option<&'b str>,
+    source: Option<&'b str>,
+    start: Option<&'b str>,
 }
-impl<'a, B> MlFlushJob<'a, B>
+impl<'a, 'b, B> MlFlushJob<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlFlushJob] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlFlushJobParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlFlushJobParts<'b>) -> Self {
         MlFlushJob {
             client,
             parts,
@@ -1359,12 +1359,12 @@ where
         }
     }
     #[doc = "Advances time to the given value generating results and updating the model for the advanced interval"]
-    pub fn advance_time(mut self, advance_time: &'a str) -> Self {
+    pub fn advance_time(mut self, advance_time: &'b str) -> Self {
         self.advance_time = Some(advance_time);
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlFlushJob<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlFlushJob<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1391,7 +1391,7 @@ where
         self
     }
     #[doc = "When used in conjunction with calc_interim, specifies the range of buckets on which to calculate interim results"]
-    pub fn end(mut self, end: &'a str) -> Self {
+    pub fn end(mut self, end: &'b str) -> Self {
         self.end = Some(end);
         self
     }
@@ -1401,7 +1401,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1421,17 +1421,17 @@ where
         self
     }
     #[doc = "Skips time to the given value without generating results or updating the model for the skipped interval"]
-    pub fn skip_time(mut self, skip_time: &'a str) -> Self {
+    pub fn skip_time(mut self, skip_time: &'b str) -> Self {
         self.skip_time = Some(skip_time);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "When used in conjunction with calc_interim, specifies the range of buckets on which to calculate interim results"]
-    pub fn start(mut self, start: &'a str) -> Self {
+    pub fn start(mut self, start: &'b str) -> Self {
         self.start = Some(start);
         self
     }
@@ -1443,30 +1443,30 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "advance_time")]
-                advance_time: Option<&'a str>,
+                advance_time: Option<&'b str>,
                 #[serde(rename = "calc_interim")]
                 calc_interim: Option<bool>,
                 #[serde(rename = "end")]
-                end: Option<&'a str>,
+                end: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "skip_time")]
-                skip_time: Option<&'a str>,
+                skip_time: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "start")]
-                start: Option<&'a str>,
+                start: Option<&'b str>,
             }
             let query_params = QueryParams {
                 advance_time: self.advance_time,
@@ -1492,11 +1492,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Forecast API"]
-pub enum MlForecastParts<'a> {
+pub enum MlForecastParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlForecastParts<'a> {
+impl<'b> MlForecastParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Forecast API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1512,25 +1512,25 @@ impl<'a> MlForecastParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Forecast API"]
-pub struct MlForecast<'a, B> {
-    client: Elasticsearch,
-    parts: MlForecastParts<'a>,
+pub struct MlForecast<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlForecastParts<'b>,
     body: Option<B>,
-    duration: Option<&'a str>,
+    duration: Option<&'b str>,
     error_trace: Option<bool>,
-    expires_in: Option<&'a str>,
-    filter_path: Option<&'a [&'a str]>,
+    expires_in: Option<&'b str>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlForecast<'a, B>
+impl<'a, 'b, B> MlForecast<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlForecast] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlForecastParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlForecastParts<'b>) -> Self {
         MlForecast {
             client,
             parts,
@@ -1546,7 +1546,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlForecast<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlForecast<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1565,7 +1565,7 @@ where
         }
     }
     #[doc = "The duration of the forecast"]
-    pub fn duration(mut self, duration: &'a str) -> Self {
+    pub fn duration(mut self, duration: &'b str) -> Self {
         self.duration = Some(duration);
         self
     }
@@ -1575,12 +1575,12 @@ where
         self
     }
     #[doc = "The time interval after which the forecast expires. Expired forecasts will be deleted at the first opportunity."]
-    pub fn expires_in(mut self, expires_in: &'a str) -> Self {
+    pub fn expires_in(mut self, expires_in: &'b str) -> Self {
         self.expires_in = Some(expires_in);
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1600,7 +1600,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1612,24 +1612,24 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "duration")]
-                duration: Option<&'a str>,
+                duration: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "expires_in")]
-                expires_in: Option<&'a str>,
+                expires_in: Option<&'b str>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 duration: self.duration,
@@ -1652,13 +1652,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Buckets API"]
-pub enum MlGetBucketsParts<'a> {
+pub enum MlGetBucketsParts<'b> {
     #[doc = "JobId and Timestamp"]
-    JobIdTimestamp(&'a str, &'a str),
+    JobIdTimestamp(&'b str, &'b str),
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlGetBucketsParts<'a> {
+impl<'b> MlGetBucketsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Buckets API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1682,32 +1682,32 @@ impl<'a> MlGetBucketsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Buckets API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html)."]
-pub struct MlGetBuckets<'a, B> {
-    client: Elasticsearch,
-    parts: MlGetBucketsParts<'a>,
+pub struct MlGetBuckets<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlGetBucketsParts<'b>,
     anomaly_score: Option<f64>,
     body: Option<B>,
     desc: Option<bool>,
-    end: Option<&'a str>,
+    end: Option<&'b str>,
     error_trace: Option<bool>,
     exclude_interim: Option<bool>,
     expand: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i32>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     size: Option<i32>,
-    sort: Option<&'a str>,
-    source: Option<&'a str>,
-    start: Option<&'a str>,
+    sort: Option<&'b str>,
+    source: Option<&'b str>,
+    start: Option<&'b str>,
 }
-impl<'a, B> MlGetBuckets<'a, B>
+impl<'a, 'b, B> MlGetBuckets<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetBuckets] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetBucketsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetBucketsParts<'b>) -> Self {
         MlGetBuckets {
             client,
             parts,
@@ -1735,7 +1735,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlGetBuckets<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlGetBuckets<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1766,7 +1766,7 @@ where
         self
     }
     #[doc = "End time filter for buckets"]
-    pub fn end(mut self, end: &'a str) -> Self {
+    pub fn end(mut self, end: &'b str) -> Self {
         self.end = Some(end);
         self
     }
@@ -1786,7 +1786,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1816,17 +1816,17 @@ where
         self
     }
     #[doc = "Sort buckets by a particular field"]
-    pub fn sort(mut self, sort: &'a str) -> Self {
+    pub fn sort(mut self, sort: &'b str) -> Self {
         self.sort = Some(sort);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Start time filter for buckets"]
-    pub fn start(mut self, start: &'a str) -> Self {
+    pub fn start(mut self, start: &'b str) -> Self {
         self.start = Some(start);
         self
     }
@@ -1841,13 +1841,13 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "anomaly_score")]
                 anomaly_score: Option<f64>,
                 #[serde(rename = "desc")]
                 desc: Option<bool>,
                 #[serde(rename = "end")]
-                end: Option<&'a str>,
+                end: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "exclude_interim")]
@@ -1858,7 +1858,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i32>,
                 #[serde(rename = "human")]
@@ -1868,11 +1868,11 @@ where
                 #[serde(rename = "size")]
                 size: Option<i32>,
                 #[serde(rename = "sort")]
-                sort: Option<&'a str>,
+                sort: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "start")]
-                start: Option<&'a str>,
+                start: Option<&'b str>,
             }
             let query_params = QueryParams {
                 anomaly_score: self.anomaly_score,
@@ -1902,11 +1902,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Calendar Events API"]
-pub enum MlGetCalendarEventsParts<'a> {
+pub enum MlGetCalendarEventsParts<'b> {
     #[doc = "CalendarId"]
-    CalendarId(&'a str),
+    CalendarId(&'b str),
 }
-impl<'a> MlGetCalendarEventsParts<'a> {
+impl<'b> MlGetCalendarEventsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Calendar Events API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1922,24 +1922,24 @@ impl<'a> MlGetCalendarEventsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Get Calendar Events API"]
-pub struct MlGetCalendarEvents<'a> {
-    client: Elasticsearch,
-    parts: MlGetCalendarEventsParts<'a>,
-    end: Option<&'a str>,
+pub struct MlGetCalendarEvents<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlGetCalendarEventsParts<'b>,
+    end: Option<&'b str>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i32>,
     headers: HeaderMap,
     human: Option<bool>,
-    job_id: Option<&'a str>,
+    job_id: Option<&'b str>,
     pretty: Option<bool>,
     size: Option<i32>,
-    source: Option<&'a str>,
-    start: Option<&'a str>,
+    source: Option<&'b str>,
+    start: Option<&'b str>,
 }
-impl<'a> MlGetCalendarEvents<'a> {
+impl<'a, 'b> MlGetCalendarEvents<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetCalendarEvents] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetCalendarEventsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetCalendarEventsParts<'b>) -> Self {
         MlGetCalendarEvents {
             client,
             parts,
@@ -1957,7 +1957,7 @@ impl<'a> MlGetCalendarEvents<'a> {
         }
     }
     #[doc = "Get events before this time"]
-    pub fn end(mut self, end: &'a str) -> Self {
+    pub fn end(mut self, end: &'b str) -> Self {
         self.end = Some(end);
         self
     }
@@ -1967,7 +1967,7 @@ impl<'a> MlGetCalendarEvents<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1987,7 +1987,7 @@ impl<'a> MlGetCalendarEvents<'a> {
         self
     }
     #[doc = "Get events for the job. When this option is used calendar_id must be '_all'"]
-    pub fn job_id(mut self, job_id: &'a str) -> Self {
+    pub fn job_id(mut self, job_id: &'b str) -> Self {
         self.job_id = Some(job_id);
         self
     }
@@ -2002,12 +2002,12 @@ impl<'a> MlGetCalendarEvents<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Get events after this time"]
-    pub fn start(mut self, start: &'a str) -> Self {
+    pub fn start(mut self, start: &'b str) -> Self {
         self.start = Some(start);
         self
     }
@@ -2019,30 +2019,30 @@ impl<'a> MlGetCalendarEvents<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "end")]
-                end: Option<&'a str>,
+                end: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i32>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "job_id")]
-                job_id: Option<&'a str>,
+                job_id: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "size")]
                 size: Option<i32>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "start")]
-                start: Option<&'a str>,
+                start: Option<&'b str>,
             }
             let query_params = QueryParams {
                 end: self.end,
@@ -2068,13 +2068,13 @@ impl<'a> MlGetCalendarEvents<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Calendars API"]
-pub enum MlGetCalendarsParts<'a> {
+pub enum MlGetCalendarsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "CalendarId"]
-    CalendarId(&'a str),
+    CalendarId(&'b str),
 }
-impl<'a> MlGetCalendarsParts<'a> {
+impl<'b> MlGetCalendarsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Calendars API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2090,25 +2090,25 @@ impl<'a> MlGetCalendarsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Get Calendars API"]
-pub struct MlGetCalendars<'a, B> {
-    client: Elasticsearch,
-    parts: MlGetCalendarsParts<'a>,
+pub struct MlGetCalendars<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlGetCalendarsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i32>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     size: Option<i32>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlGetCalendars<'a, B>
+impl<'a, 'b, B> MlGetCalendars<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetCalendars] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetCalendarsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetCalendarsParts<'b>) -> Self {
         MlGetCalendars {
             client,
             parts,
@@ -2124,7 +2124,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlGetCalendars<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlGetCalendars<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2148,7 +2148,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2178,7 +2178,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2193,14 +2193,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i32>,
                 #[serde(rename = "human")]
@@ -2210,7 +2210,7 @@ where
                 #[serde(rename = "size")]
                 size: Option<i32>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2233,13 +2233,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Categories API"]
-pub enum MlGetCategoriesParts<'a> {
+pub enum MlGetCategoriesParts<'b> {
     #[doc = "JobId and CategoryId"]
-    JobIdCategoryId(&'a str, i64),
+    JobIdCategoryId(&'b str, i64),
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlGetCategoriesParts<'a> {
+impl<'b> MlGetCategoriesParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Categories API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2264,25 +2264,25 @@ impl<'a> MlGetCategoriesParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Categories API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html)."]
-pub struct MlGetCategories<'a, B> {
-    client: Elasticsearch,
-    parts: MlGetCategoriesParts<'a>,
+pub struct MlGetCategories<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlGetCategoriesParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i32>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     size: Option<i32>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlGetCategories<'a, B>
+impl<'a, 'b, B> MlGetCategories<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetCategories] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetCategoriesParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetCategoriesParts<'b>) -> Self {
         MlGetCategories {
             client,
             parts,
@@ -2298,7 +2298,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlGetCategories<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlGetCategories<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2322,7 +2322,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2352,7 +2352,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2367,14 +2367,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i32>,
                 #[serde(rename = "human")]
@@ -2384,7 +2384,7 @@ where
                 #[serde(rename = "size")]
                 size: Option<i32>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2407,13 +2407,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Datafeed Stats API"]
-pub enum MlGetDatafeedStatsParts<'a> {
+pub enum MlGetDatafeedStatsParts<'b> {
     #[doc = "DatafeedId"]
-    DatafeedId(&'a str),
+    DatafeedId(&'b str),
     #[doc = "No parts"]
     None,
 }
-impl<'a> MlGetDatafeedStatsParts<'a> {
+impl<'b> MlGetDatafeedStatsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Datafeed Stats API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2430,20 +2430,20 @@ impl<'a> MlGetDatafeedStatsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Datafeed Stats API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html)."]
-pub struct MlGetDatafeedStats<'a> {
-    client: Elasticsearch,
-    parts: MlGetDatafeedStatsParts<'a>,
+pub struct MlGetDatafeedStats<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlGetDatafeedStatsParts<'b>,
     allow_no_datafeeds: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlGetDatafeedStats<'a> {
+impl<'a, 'b> MlGetDatafeedStats<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetDatafeedStats] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetDatafeedStatsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetDatafeedStatsParts<'b>) -> Self {
         MlGetDatafeedStats {
             client,
             parts,
@@ -2467,7 +2467,7 @@ impl<'a> MlGetDatafeedStats<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2487,7 +2487,7 @@ impl<'a> MlGetDatafeedStats<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2499,7 +2499,7 @@ impl<'a> MlGetDatafeedStats<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_datafeeds")]
                 allow_no_datafeeds: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -2508,13 +2508,13 @@ impl<'a> MlGetDatafeedStats<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_datafeeds: self.allow_no_datafeeds,
@@ -2536,13 +2536,13 @@ impl<'a> MlGetDatafeedStats<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Datafeeds API"]
-pub enum MlGetDatafeedsParts<'a> {
+pub enum MlGetDatafeedsParts<'b> {
     #[doc = "DatafeedId"]
-    DatafeedId(&'a str),
+    DatafeedId(&'b str),
     #[doc = "No parts"]
     None,
 }
-impl<'a> MlGetDatafeedsParts<'a> {
+impl<'b> MlGetDatafeedsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Datafeeds API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2558,20 +2558,20 @@ impl<'a> MlGetDatafeedsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Datafeeds API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html)."]
-pub struct MlGetDatafeeds<'a> {
-    client: Elasticsearch,
-    parts: MlGetDatafeedsParts<'a>,
+pub struct MlGetDatafeeds<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlGetDatafeedsParts<'b>,
     allow_no_datafeeds: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlGetDatafeeds<'a> {
+impl<'a, 'b> MlGetDatafeeds<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetDatafeeds] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetDatafeedsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetDatafeedsParts<'b>) -> Self {
         MlGetDatafeeds {
             client,
             parts,
@@ -2595,7 +2595,7 @@ impl<'a> MlGetDatafeeds<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2615,7 +2615,7 @@ impl<'a> MlGetDatafeeds<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2627,7 +2627,7 @@ impl<'a> MlGetDatafeeds<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_datafeeds")]
                 allow_no_datafeeds: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -2636,13 +2636,13 @@ impl<'a> MlGetDatafeeds<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_datafeeds: self.allow_no_datafeeds,
@@ -2664,13 +2664,13 @@ impl<'a> MlGetDatafeeds<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Filters API"]
-pub enum MlGetFiltersParts<'a> {
+pub enum MlGetFiltersParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "FilterId"]
-    FilterId(&'a str),
+    FilterId(&'b str),
 }
-impl<'a> MlGetFiltersParts<'a> {
+impl<'b> MlGetFiltersParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Filters API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2686,21 +2686,21 @@ impl<'a> MlGetFiltersParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Get Filters API"]
-pub struct MlGetFilters<'a> {
-    client: Elasticsearch,
-    parts: MlGetFiltersParts<'a>,
+pub struct MlGetFilters<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlGetFiltersParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i32>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     size: Option<i32>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlGetFilters<'a> {
+impl<'a, 'b> MlGetFilters<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetFilters] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetFiltersParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetFiltersParts<'b>) -> Self {
         MlGetFilters {
             client,
             parts,
@@ -2720,7 +2720,7 @@ impl<'a> MlGetFilters<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2750,7 +2750,7 @@ impl<'a> MlGetFilters<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2762,14 +2762,14 @@ impl<'a> MlGetFilters<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i32>,
                 #[serde(rename = "human")]
@@ -2779,7 +2779,7 @@ impl<'a> MlGetFilters<'a> {
                 #[serde(rename = "size")]
                 size: Option<i32>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2802,11 +2802,11 @@ impl<'a> MlGetFilters<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Influencers API"]
-pub enum MlGetInfluencersParts<'a> {
+pub enum MlGetInfluencersParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlGetInfluencersParts<'a> {
+impl<'b> MlGetInfluencersParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Influencers API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2822,31 +2822,31 @@ impl<'a> MlGetInfluencersParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Influencers API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html)."]
-pub struct MlGetInfluencers<'a, B> {
-    client: Elasticsearch,
-    parts: MlGetInfluencersParts<'a>,
+pub struct MlGetInfluencers<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlGetInfluencersParts<'b>,
     body: Option<B>,
     desc: Option<bool>,
-    end: Option<&'a str>,
+    end: Option<&'b str>,
     error_trace: Option<bool>,
     exclude_interim: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i32>,
     headers: HeaderMap,
     human: Option<bool>,
     influencer_score: Option<f64>,
     pretty: Option<bool>,
     size: Option<i32>,
-    sort: Option<&'a str>,
-    source: Option<&'a str>,
-    start: Option<&'a str>,
+    sort: Option<&'b str>,
+    source: Option<&'b str>,
+    start: Option<&'b str>,
 }
-impl<'a, B> MlGetInfluencers<'a, B>
+impl<'a, 'b, B> MlGetInfluencers<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetInfluencers] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetInfluencersParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetInfluencersParts<'b>) -> Self {
         MlGetInfluencers {
             client,
             parts,
@@ -2868,7 +2868,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlGetInfluencers<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlGetInfluencers<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2898,7 +2898,7 @@ where
         self
     }
     #[doc = "end timestamp for the requested influencers"]
-    pub fn end(mut self, end: &'a str) -> Self {
+    pub fn end(mut self, end: &'b str) -> Self {
         self.end = Some(end);
         self
     }
@@ -2913,7 +2913,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2948,17 +2948,17 @@ where
         self
     }
     #[doc = "sort field for the requested influencers"]
-    pub fn sort(mut self, sort: &'a str) -> Self {
+    pub fn sort(mut self, sort: &'b str) -> Self {
         self.sort = Some(sort);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "start timestamp for the requested influencers"]
-    pub fn start(mut self, start: &'a str) -> Self {
+    pub fn start(mut self, start: &'b str) -> Self {
         self.start = Some(start);
         self
     }
@@ -2973,11 +2973,11 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "desc")]
                 desc: Option<bool>,
                 #[serde(rename = "end")]
-                end: Option<&'a str>,
+                end: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "exclude_interim")]
@@ -2986,7 +2986,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i32>,
                 #[serde(rename = "human")]
@@ -2998,11 +2998,11 @@ where
                 #[serde(rename = "size")]
                 size: Option<i32>,
                 #[serde(rename = "sort")]
-                sort: Option<&'a str>,
+                sort: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "start")]
-                start: Option<&'a str>,
+                start: Option<&'b str>,
             }
             let query_params = QueryParams {
                 desc: self.desc,
@@ -3031,13 +3031,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Job Stats API"]
-pub enum MlGetJobStatsParts<'a> {
+pub enum MlGetJobStatsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlGetJobStatsParts<'a> {
+impl<'b> MlGetJobStatsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Job Stats API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3054,20 +3054,20 @@ impl<'a> MlGetJobStatsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Job Stats API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html)."]
-pub struct MlGetJobStats<'a> {
-    client: Elasticsearch,
-    parts: MlGetJobStatsParts<'a>,
+pub struct MlGetJobStats<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlGetJobStatsParts<'b>,
     allow_no_jobs: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlGetJobStats<'a> {
+impl<'a, 'b> MlGetJobStats<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetJobStats] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetJobStatsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetJobStatsParts<'b>) -> Self {
         MlGetJobStats {
             client,
             parts,
@@ -3091,7 +3091,7 @@ impl<'a> MlGetJobStats<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3111,7 +3111,7 @@ impl<'a> MlGetJobStats<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3123,7 +3123,7 @@ impl<'a> MlGetJobStats<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_jobs")]
                 allow_no_jobs: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -3132,13 +3132,13 @@ impl<'a> MlGetJobStats<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_jobs: self.allow_no_jobs,
@@ -3160,13 +3160,13 @@ impl<'a> MlGetJobStats<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Jobs API"]
-pub enum MlGetJobsParts<'a> {
+pub enum MlGetJobsParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
     #[doc = "No parts"]
     None,
 }
-impl<'a> MlGetJobsParts<'a> {
+impl<'b> MlGetJobsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Jobs API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3182,20 +3182,20 @@ impl<'a> MlGetJobsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Jobs API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html)."]
-pub struct MlGetJobs<'a> {
-    client: Elasticsearch,
-    parts: MlGetJobsParts<'a>,
+pub struct MlGetJobs<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlGetJobsParts<'b>,
     allow_no_jobs: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlGetJobs<'a> {
+impl<'a, 'b> MlGetJobs<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetJobs] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetJobsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetJobsParts<'b>) -> Self {
         MlGetJobs {
             client,
             parts,
@@ -3219,7 +3219,7 @@ impl<'a> MlGetJobs<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3239,7 +3239,7 @@ impl<'a> MlGetJobs<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3251,7 +3251,7 @@ impl<'a> MlGetJobs<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_jobs")]
                 allow_no_jobs: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -3260,13 +3260,13 @@ impl<'a> MlGetJobs<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_jobs: self.allow_no_jobs,
@@ -3288,13 +3288,13 @@ impl<'a> MlGetJobs<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Model Snapshots API"]
-pub enum MlGetModelSnapshotsParts<'a> {
+pub enum MlGetModelSnapshotsParts<'b> {
     #[doc = "JobId and SnapshotId"]
-    JobIdSnapshotId(&'a str, &'a str),
+    JobIdSnapshotId(&'b str, &'b str),
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlGetModelSnapshotsParts<'a> {
+impl<'b> MlGetModelSnapshotsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Model Snapshots API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3318,29 +3318,29 @@ impl<'a> MlGetModelSnapshotsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Model Snapshots API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html)."]
-pub struct MlGetModelSnapshots<'a, B> {
-    client: Elasticsearch,
-    parts: MlGetModelSnapshotsParts<'a>,
+pub struct MlGetModelSnapshots<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlGetModelSnapshotsParts<'b>,
     body: Option<B>,
     desc: Option<bool>,
-    end: Option<&'a str>,
+    end: Option<&'b str>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i32>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     size: Option<i32>,
-    sort: Option<&'a str>,
-    source: Option<&'a str>,
-    start: Option<&'a str>,
+    sort: Option<&'b str>,
+    source: Option<&'b str>,
+    start: Option<&'b str>,
 }
-impl<'a, B> MlGetModelSnapshots<'a, B>
+impl<'a, 'b, B> MlGetModelSnapshots<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetModelSnapshots] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetModelSnapshotsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetModelSnapshotsParts<'b>) -> Self {
         MlGetModelSnapshots {
             client,
             parts,
@@ -3360,7 +3360,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlGetModelSnapshots<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlGetModelSnapshots<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -3388,7 +3388,7 @@ where
         self
     }
     #[doc = "The filter 'end' query parameter"]
-    pub fn end(mut self, end: &'a str) -> Self {
+    pub fn end(mut self, end: &'b str) -> Self {
         self.end = Some(end);
         self
     }
@@ -3398,7 +3398,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3428,17 +3428,17 @@ where
         self
     }
     #[doc = "Name of the field to sort on"]
-    pub fn sort(mut self, sort: &'a str) -> Self {
+    pub fn sort(mut self, sort: &'b str) -> Self {
         self.sort = Some(sort);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "The filter 'start' query parameter"]
-    pub fn start(mut self, start: &'a str) -> Self {
+    pub fn start(mut self, start: &'b str) -> Self {
         self.start = Some(start);
         self
     }
@@ -3453,18 +3453,18 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "desc")]
                 desc: Option<bool>,
                 #[serde(rename = "end")]
-                end: Option<&'a str>,
+                end: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i32>,
                 #[serde(rename = "human")]
@@ -3474,11 +3474,11 @@ where
                 #[serde(rename = "size")]
                 size: Option<i32>,
                 #[serde(rename = "sort")]
-                sort: Option<&'a str>,
+                sort: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "start")]
-                start: Option<&'a str>,
+                start: Option<&'b str>,
             }
             let query_params = QueryParams {
                 desc: self.desc,
@@ -3505,11 +3505,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Overall Buckets API"]
-pub enum MlGetOverallBucketsParts<'a> {
+pub enum MlGetOverallBucketsParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlGetOverallBucketsParts<'a> {
+impl<'b> MlGetOverallBucketsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Overall Buckets API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3525,30 +3525,30 @@ impl<'a> MlGetOverallBucketsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Overall Buckets API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html)."]
-pub struct MlGetOverallBuckets<'a, B> {
-    client: Elasticsearch,
-    parts: MlGetOverallBucketsParts<'a>,
+pub struct MlGetOverallBuckets<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlGetOverallBucketsParts<'b>,
     allow_no_jobs: Option<bool>,
     body: Option<B>,
-    bucket_span: Option<&'a str>,
-    end: Option<&'a str>,
+    bucket_span: Option<&'b str>,
+    end: Option<&'b str>,
     error_trace: Option<bool>,
     exclude_interim: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     overall_score: Option<f64>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    start: Option<&'a str>,
+    source: Option<&'b str>,
+    start: Option<&'b str>,
     top_n: Option<i32>,
 }
-impl<'a, B> MlGetOverallBuckets<'a, B>
+impl<'a, 'b, B> MlGetOverallBuckets<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetOverallBuckets] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetOverallBucketsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetOverallBucketsParts<'b>) -> Self {
         MlGetOverallBuckets {
             client,
             parts,
@@ -3574,7 +3574,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlGetOverallBuckets<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlGetOverallBuckets<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -3598,12 +3598,12 @@ where
         }
     }
     #[doc = "The span of the overall buckets. Defaults to the longest job bucket_span"]
-    pub fn bucket_span(mut self, bucket_span: &'a str) -> Self {
+    pub fn bucket_span(mut self, bucket_span: &'b str) -> Self {
         self.bucket_span = Some(bucket_span);
         self
     }
     #[doc = "Returns overall buckets with timestamps earlier than this time"]
-    pub fn end(mut self, end: &'a str) -> Self {
+    pub fn end(mut self, end: &'b str) -> Self {
         self.end = Some(end);
         self
     }
@@ -3618,7 +3618,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3643,12 +3643,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Returns overall buckets with timestamps after this time"]
-    pub fn start(mut self, start: &'a str) -> Self {
+    pub fn start(mut self, start: &'b str) -> Self {
         self.start = Some(start);
         self
     }
@@ -3668,13 +3668,13 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_jobs")]
                 allow_no_jobs: Option<bool>,
                 #[serde(rename = "bucket_span")]
-                bucket_span: Option<&'a str>,
+                bucket_span: Option<&'b str>,
                 #[serde(rename = "end")]
-                end: Option<&'a str>,
+                end: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "exclude_interim")]
@@ -3683,7 +3683,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "overall_score")]
@@ -3691,9 +3691,9 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "start")]
-                start: Option<&'a str>,
+                start: Option<&'b str>,
                 #[serde(rename = "top_n")]
                 top_n: Option<i32>,
             }
@@ -3723,11 +3723,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Get Records API"]
-pub enum MlGetRecordsParts<'a> {
+pub enum MlGetRecordsParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlGetRecordsParts<'a> {
+impl<'b> MlGetRecordsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Get Records API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3743,31 +3743,31 @@ impl<'a> MlGetRecordsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Records API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html)."]
-pub struct MlGetRecords<'a, B> {
-    client: Elasticsearch,
-    parts: MlGetRecordsParts<'a>,
+pub struct MlGetRecords<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlGetRecordsParts<'b>,
     body: Option<B>,
     desc: Option<bool>,
-    end: Option<&'a str>,
+    end: Option<&'b str>,
     error_trace: Option<bool>,
     exclude_interim: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i32>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     record_score: Option<f64>,
     size: Option<i32>,
-    sort: Option<&'a str>,
-    source: Option<&'a str>,
-    start: Option<&'a str>,
+    sort: Option<&'b str>,
+    source: Option<&'b str>,
+    start: Option<&'b str>,
 }
-impl<'a, B> MlGetRecords<'a, B>
+impl<'a, 'b, B> MlGetRecords<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetRecords] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlGetRecordsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlGetRecordsParts<'b>) -> Self {
         MlGetRecords {
             client,
             parts,
@@ -3789,7 +3789,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlGetRecords<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlGetRecords<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -3819,7 +3819,7 @@ where
         self
     }
     #[doc = "End time filter for records"]
-    pub fn end(mut self, end: &'a str) -> Self {
+    pub fn end(mut self, end: &'b str) -> Self {
         self.end = Some(end);
         self
     }
@@ -3834,7 +3834,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3868,17 +3868,17 @@ where
         self
     }
     #[doc = "Sort records by a particular field"]
-    pub fn sort(mut self, sort: &'a str) -> Self {
+    pub fn sort(mut self, sort: &'b str) -> Self {
         self.sort = Some(sort);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Start time filter for records"]
-    pub fn start(mut self, start: &'a str) -> Self {
+    pub fn start(mut self, start: &'b str) -> Self {
         self.start = Some(start);
         self
     }
@@ -3893,11 +3893,11 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "desc")]
                 desc: Option<bool>,
                 #[serde(rename = "end")]
-                end: Option<&'a str>,
+                end: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "exclude_interim")]
@@ -3906,7 +3906,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i32>,
                 #[serde(rename = "human")]
@@ -3918,11 +3918,11 @@ where
                 #[serde(rename = "size")]
                 size: Option<i32>,
                 #[serde(rename = "sort")]
-                sort: Option<&'a str>,
+                sort: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "start")]
-                start: Option<&'a str>,
+                start: Option<&'b str>,
             }
             let query_params = QueryParams {
                 desc: self.desc,
@@ -3965,19 +3965,19 @@ impl MlInfoParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Info API"]
-pub struct MlInfo<'a> {
-    client: Elasticsearch,
+pub struct MlInfo<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: MlInfoParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlInfo<'a> {
+impl<'a, 'b> MlInfo<'a, 'b> {
     #[doc = "Creates a new instance of [MlInfo]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         MlInfo {
             client,
             parts: MlInfoParts::None,
@@ -3995,7 +3995,7 @@ impl<'a> MlInfo<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4015,7 +4015,7 @@ impl<'a> MlInfo<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4027,20 +4027,20 @@ impl<'a> MlInfo<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -4061,11 +4061,11 @@ impl<'a> MlInfo<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Open Job API"]
-pub enum MlOpenJobParts<'a> {
+pub enum MlOpenJobParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlOpenJobParts<'a> {
+impl<'b> MlOpenJobParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Open Job API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4081,23 +4081,23 @@ impl<'a> MlOpenJobParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Open Job API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html)."]
-pub struct MlOpenJob<'a, B> {
-    client: Elasticsearch,
-    parts: MlOpenJobParts<'a>,
+pub struct MlOpenJob<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlOpenJobParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlOpenJob<'a, B>
+impl<'a, 'b, B> MlOpenJob<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlOpenJob] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlOpenJobParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlOpenJobParts<'b>) -> Self {
         MlOpenJob {
             client,
             parts,
@@ -4111,7 +4111,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlOpenJob<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlOpenJob<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4133,7 +4133,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4153,7 +4153,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4165,20 +4165,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -4199,11 +4199,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Post Calendar Events API"]
-pub enum MlPostCalendarEventsParts<'a> {
+pub enum MlPostCalendarEventsParts<'b> {
     #[doc = "CalendarId"]
-    CalendarId(&'a str),
+    CalendarId(&'b str),
 }
-impl<'a> MlPostCalendarEventsParts<'a> {
+impl<'b> MlPostCalendarEventsParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Post Calendar Events API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4219,23 +4219,23 @@ impl<'a> MlPostCalendarEventsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Post Calendar Events API"]
-pub struct MlPostCalendarEvents<'a, B> {
-    client: Elasticsearch,
-    parts: MlPostCalendarEventsParts<'a>,
+pub struct MlPostCalendarEvents<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlPostCalendarEventsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlPostCalendarEvents<'a, B>
+impl<'a, 'b, B> MlPostCalendarEvents<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPostCalendarEvents] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlPostCalendarEventsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlPostCalendarEventsParts<'b>) -> Self {
         MlPostCalendarEvents {
             client,
             parts,
@@ -4249,7 +4249,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlPostCalendarEvents<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlPostCalendarEvents<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4271,7 +4271,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4291,7 +4291,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4303,20 +4303,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -4337,11 +4337,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Post Data API"]
-pub enum MlPostDataParts<'a> {
+pub enum MlPostDataParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlPostDataParts<'a> {
+impl<'b> MlPostDataParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Post Data API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4357,25 +4357,25 @@ impl<'a> MlPostDataParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Post Data API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html)."]
-pub struct MlPostData<'a, B> {
-    client: Elasticsearch,
-    parts: MlPostDataParts<'a>,
+pub struct MlPostData<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlPostDataParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    reset_end: Option<&'a str>,
-    reset_start: Option<&'a str>,
-    source: Option<&'a str>,
+    reset_end: Option<&'b str>,
+    reset_start: Option<&'b str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlPostData<'a, B>
+impl<'a, 'b, B> MlPostData<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPostData] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlPostDataParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlPostDataParts<'b>) -> Self {
         MlPostData {
             client,
             parts,
@@ -4391,7 +4391,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: Vec<T>) -> MlPostData<'a, NdBody<T>>
+    pub fn body<T>(self, body: Vec<T>) -> MlPostData<'a, 'b, NdBody<T>>
     where
         T: Body,
     {
@@ -4415,7 +4415,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4435,17 +4435,17 @@ where
         self
     }
     #[doc = "Optional parameter to specify the end of the bucket resetting range"]
-    pub fn reset_end(mut self, reset_end: &'a str) -> Self {
+    pub fn reset_end(mut self, reset_end: &'b str) -> Self {
         self.reset_end = Some(reset_end);
         self
     }
     #[doc = "Optional parameter to specify the start of the bucket resetting range"]
-    pub fn reset_start(mut self, reset_start: &'a str) -> Self {
+    pub fn reset_start(mut self, reset_start: &'b str) -> Self {
         self.reset_start = Some(reset_start);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4457,24 +4457,24 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "reset_end")]
-                reset_end: Option<&'a str>,
+                reset_end: Option<&'b str>,
                 #[serde(rename = "reset_start")]
-                reset_start: Option<&'a str>,
+                reset_start: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -4497,11 +4497,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Preview Datafeed API"]
-pub enum MlPreviewDatafeedParts<'a> {
+pub enum MlPreviewDatafeedParts<'b> {
     #[doc = "DatafeedId"]
-    DatafeedId(&'a str),
+    DatafeedId(&'b str),
 }
-impl<'a> MlPreviewDatafeedParts<'a> {
+impl<'b> MlPreviewDatafeedParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Preview Datafeed API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4517,19 +4517,19 @@ impl<'a> MlPreviewDatafeedParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Preview Datafeed API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html)."]
-pub struct MlPreviewDatafeed<'a> {
-    client: Elasticsearch,
-    parts: MlPreviewDatafeedParts<'a>,
+pub struct MlPreviewDatafeed<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: MlPreviewDatafeedParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> MlPreviewDatafeed<'a> {
+impl<'a, 'b> MlPreviewDatafeed<'a, 'b> {
     #[doc = "Creates a new instance of [MlPreviewDatafeed] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlPreviewDatafeedParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlPreviewDatafeedParts<'b>) -> Self {
         MlPreviewDatafeed {
             client,
             parts,
@@ -4547,7 +4547,7 @@ impl<'a> MlPreviewDatafeed<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4567,7 +4567,7 @@ impl<'a> MlPreviewDatafeed<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4579,20 +4579,20 @@ impl<'a> MlPreviewDatafeed<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -4613,11 +4613,11 @@ impl<'a> MlPreviewDatafeed<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Put Calendar API"]
-pub enum MlPutCalendarParts<'a> {
+pub enum MlPutCalendarParts<'b> {
     #[doc = "CalendarId"]
-    CalendarId(&'a str),
+    CalendarId(&'b str),
 }
-impl<'a> MlPutCalendarParts<'a> {
+impl<'b> MlPutCalendarParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Put Calendar API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4632,23 +4632,23 @@ impl<'a> MlPutCalendarParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Put Calendar API"]
-pub struct MlPutCalendar<'a, B> {
-    client: Elasticsearch,
-    parts: MlPutCalendarParts<'a>,
+pub struct MlPutCalendar<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlPutCalendarParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlPutCalendar<'a, B>
+impl<'a, 'b, B> MlPutCalendar<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPutCalendar] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlPutCalendarParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlPutCalendarParts<'b>) -> Self {
         MlPutCalendar {
             client,
             parts,
@@ -4662,7 +4662,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlPutCalendar<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlPutCalendar<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4684,7 +4684,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4704,7 +4704,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4716,20 +4716,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -4750,11 +4750,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Put Calendar Job API"]
-pub enum MlPutCalendarJobParts<'a> {
+pub enum MlPutCalendarJobParts<'b> {
     #[doc = "CalendarId and JobId"]
-    CalendarIdJobId(&'a str, &'a str),
+    CalendarIdJobId(&'b str, &'b str),
 }
-impl<'a> MlPutCalendarJobParts<'a> {
+impl<'b> MlPutCalendarJobParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Put Calendar Job API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4771,23 +4771,23 @@ impl<'a> MlPutCalendarJobParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Put Calendar Job API"]
-pub struct MlPutCalendarJob<'a, B> {
-    client: Elasticsearch,
-    parts: MlPutCalendarJobParts<'a>,
+pub struct MlPutCalendarJob<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlPutCalendarJobParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlPutCalendarJob<'a, B>
+impl<'a, 'b, B> MlPutCalendarJob<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPutCalendarJob] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlPutCalendarJobParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlPutCalendarJobParts<'b>) -> Self {
         MlPutCalendarJob {
             client,
             parts,
@@ -4801,7 +4801,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlPutCalendarJob<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlPutCalendarJob<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4823,7 +4823,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4843,7 +4843,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4855,20 +4855,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -4889,11 +4889,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Put Datafeed API"]
-pub enum MlPutDatafeedParts<'a> {
+pub enum MlPutDatafeedParts<'b> {
     #[doc = "DatafeedId"]
-    DatafeedId(&'a str),
+    DatafeedId(&'b str),
 }
-impl<'a> MlPutDatafeedParts<'a> {
+impl<'b> MlPutDatafeedParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Put Datafeed API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4908,23 +4908,23 @@ impl<'a> MlPutDatafeedParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Put Datafeed API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html)."]
-pub struct MlPutDatafeed<'a, B> {
-    client: Elasticsearch,
-    parts: MlPutDatafeedParts<'a>,
+pub struct MlPutDatafeed<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlPutDatafeedParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlPutDatafeed<'a, B>
+impl<'a, 'b, B> MlPutDatafeed<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPutDatafeed] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlPutDatafeedParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlPutDatafeedParts<'b>) -> Self {
         MlPutDatafeed {
             client,
             parts,
@@ -4938,7 +4938,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlPutDatafeed<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlPutDatafeed<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4960,7 +4960,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4980,7 +4980,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4992,20 +4992,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -5026,11 +5026,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Put Filter API"]
-pub enum MlPutFilterParts<'a> {
+pub enum MlPutFilterParts<'b> {
     #[doc = "FilterId"]
-    FilterId(&'a str),
+    FilterId(&'b str),
 }
-impl<'a> MlPutFilterParts<'a> {
+impl<'b> MlPutFilterParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Put Filter API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5045,23 +5045,23 @@ impl<'a> MlPutFilterParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Put Filter API"]
-pub struct MlPutFilter<'a, B> {
-    client: Elasticsearch,
-    parts: MlPutFilterParts<'a>,
+pub struct MlPutFilter<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlPutFilterParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlPutFilter<'a, B>
+impl<'a, 'b, B> MlPutFilter<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPutFilter] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlPutFilterParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlPutFilterParts<'b>) -> Self {
         MlPutFilter {
             client,
             parts,
@@ -5075,7 +5075,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlPutFilter<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlPutFilter<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5097,7 +5097,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5117,7 +5117,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -5129,20 +5129,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -5163,11 +5163,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Put Job API"]
-pub enum MlPutJobParts<'a> {
+pub enum MlPutJobParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlPutJobParts<'a> {
+impl<'b> MlPutJobParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Put Job API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5182,23 +5182,23 @@ impl<'a> MlPutJobParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Put Job API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html)."]
-pub struct MlPutJob<'a, B> {
-    client: Elasticsearch,
-    parts: MlPutJobParts<'a>,
+pub struct MlPutJob<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlPutJobParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlPutJob<'a, B>
+impl<'a, 'b, B> MlPutJob<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPutJob] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlPutJobParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlPutJobParts<'b>) -> Self {
         MlPutJob {
             client,
             parts,
@@ -5212,7 +5212,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlPutJob<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlPutJob<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5234,7 +5234,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5254,7 +5254,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -5266,20 +5266,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -5300,11 +5300,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Revert Model Snapshot API"]
-pub enum MlRevertModelSnapshotParts<'a> {
+pub enum MlRevertModelSnapshotParts<'b> {
     #[doc = "JobId and SnapshotId"]
-    JobIdSnapshotId(&'a str, &'a str),
+    JobIdSnapshotId(&'b str, &'b str),
 }
-impl<'a> MlRevertModelSnapshotParts<'a> {
+impl<'b> MlRevertModelSnapshotParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Revert Model Snapshot API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5322,24 +5322,24 @@ impl<'a> MlRevertModelSnapshotParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Revert Model Snapshot API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html)."]
-pub struct MlRevertModelSnapshot<'a, B> {
-    client: Elasticsearch,
-    parts: MlRevertModelSnapshotParts<'a>,
+pub struct MlRevertModelSnapshot<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlRevertModelSnapshotParts<'b>,
     body: Option<B>,
     delete_intervening_results: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlRevertModelSnapshot<'a, B>
+impl<'a, 'b, B> MlRevertModelSnapshot<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlRevertModelSnapshot] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlRevertModelSnapshotParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlRevertModelSnapshotParts<'b>) -> Self {
         MlRevertModelSnapshot {
             client,
             parts,
@@ -5354,7 +5354,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlRevertModelSnapshot<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlRevertModelSnapshot<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5382,7 +5382,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5402,7 +5402,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -5414,7 +5414,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "delete_intervening_results")]
                 delete_intervening_results: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -5423,13 +5423,13 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 delete_intervening_results: self.delete_intervening_results,
@@ -5465,25 +5465,25 @@ impl MlSetUpgradeModeParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Set Upgrade Mode API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html)."]
-pub struct MlSetUpgradeMode<'a, B> {
-    client: Elasticsearch,
+pub struct MlSetUpgradeMode<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: MlSetUpgradeModeParts,
     body: Option<B>,
     enabled: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> MlSetUpgradeMode<'a, B>
+impl<'a, 'b, B> MlSetUpgradeMode<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlSetUpgradeMode]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         MlSetUpgradeMode {
             client,
             parts: MlSetUpgradeModeParts::None,
@@ -5499,7 +5499,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlSetUpgradeMode<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlSetUpgradeMode<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5528,7 +5528,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5548,12 +5548,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Controls the time to wait before action times out. Defaults to 30 seconds"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -5565,7 +5565,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "enabled")]
                 enabled: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -5574,15 +5574,15 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 enabled: self.enabled,
@@ -5605,11 +5605,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Start Datafeed API"]
-pub enum MlStartDatafeedParts<'a> {
+pub enum MlStartDatafeedParts<'b> {
     #[doc = "DatafeedId"]
-    DatafeedId(&'a str),
+    DatafeedId(&'b str),
 }
-impl<'a> MlStartDatafeedParts<'a> {
+impl<'b> MlStartDatafeedParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Start Datafeed API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5625,26 +5625,26 @@ impl<'a> MlStartDatafeedParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Start Datafeed API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html)."]
-pub struct MlStartDatafeed<'a, B> {
-    client: Elasticsearch,
-    parts: MlStartDatafeedParts<'a>,
+pub struct MlStartDatafeed<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlStartDatafeedParts<'b>,
     body: Option<B>,
-    end: Option<&'a str>,
+    end: Option<&'b str>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    start: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    start: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> MlStartDatafeed<'a, B>
+impl<'a, 'b, B> MlStartDatafeed<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlStartDatafeed] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlStartDatafeedParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlStartDatafeedParts<'b>) -> Self {
         MlStartDatafeed {
             client,
             parts,
@@ -5661,7 +5661,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlStartDatafeed<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlStartDatafeed<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5681,7 +5681,7 @@ where
         }
     }
     #[doc = "The end time when the datafeed should stop. When not set, the datafeed continues in real time"]
-    pub fn end(mut self, end: &'a str) -> Self {
+    pub fn end(mut self, end: &'b str) -> Self {
         self.end = Some(end);
         self
     }
@@ -5691,7 +5691,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5711,17 +5711,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "The start time from where the datafeed should begin"]
-    pub fn start(mut self, start: &'a str) -> Self {
+    pub fn start(mut self, start: &'b str) -> Self {
         self.start = Some(start);
         self
     }
     #[doc = "Controls the time to wait until a datafeed has started. Default to 20 seconds"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -5733,26 +5733,26 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "end")]
-                end: Option<&'a str>,
+                end: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "start")]
-                start: Option<&'a str>,
+                start: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 end: self.end,
@@ -5776,11 +5776,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Stop Datafeed API"]
-pub enum MlStopDatafeedParts<'a> {
+pub enum MlStopDatafeedParts<'b> {
     #[doc = "DatafeedId"]
-    DatafeedId(&'a str),
+    DatafeedId(&'b str),
 }
-impl<'a> MlStopDatafeedParts<'a> {
+impl<'b> MlStopDatafeedParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Stop Datafeed API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5796,26 +5796,26 @@ impl<'a> MlStopDatafeedParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Stop Datafeed API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html)."]
-pub struct MlStopDatafeed<'a, B> {
-    client: Elasticsearch,
-    parts: MlStopDatafeedParts<'a>,
+pub struct MlStopDatafeed<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlStopDatafeedParts<'b>,
     allow_no_datafeeds: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     force: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> MlStopDatafeed<'a, B>
+impl<'a, 'b, B> MlStopDatafeed<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlStopDatafeed] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlStopDatafeedParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlStopDatafeedParts<'b>) -> Self {
         MlStopDatafeed {
             client,
             parts,
@@ -5837,7 +5837,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlStopDatafeed<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlStopDatafeed<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5862,7 +5862,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5887,12 +5887,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Controls the time to wait until a datafeed has stopped. Default to 20 seconds"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -5904,7 +5904,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_datafeeds")]
                 allow_no_datafeeds: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -5913,7 +5913,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "force")]
                 force: Option<bool>,
                 #[serde(rename = "human")]
@@ -5921,9 +5921,9 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_datafeeds: self.allow_no_datafeeds,
@@ -5947,11 +5947,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Update Datafeed API"]
-pub enum MlUpdateDatafeedParts<'a> {
+pub enum MlUpdateDatafeedParts<'b> {
     #[doc = "DatafeedId"]
-    DatafeedId(&'a str),
+    DatafeedId(&'b str),
 }
-impl<'a> MlUpdateDatafeedParts<'a> {
+impl<'b> MlUpdateDatafeedParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Update Datafeed API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5967,23 +5967,23 @@ impl<'a> MlUpdateDatafeedParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Update Datafeed API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html)."]
-pub struct MlUpdateDatafeed<'a, B> {
-    client: Elasticsearch,
-    parts: MlUpdateDatafeedParts<'a>,
+pub struct MlUpdateDatafeed<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlUpdateDatafeedParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlUpdateDatafeed<'a, B>
+impl<'a, 'b, B> MlUpdateDatafeed<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlUpdateDatafeed] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlUpdateDatafeedParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlUpdateDatafeedParts<'b>) -> Self {
         MlUpdateDatafeed {
             client,
             parts,
@@ -5997,7 +5997,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlUpdateDatafeed<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlUpdateDatafeed<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6019,7 +6019,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6039,7 +6039,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -6051,20 +6051,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -6085,11 +6085,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Update Filter API"]
-pub enum MlUpdateFilterParts<'a> {
+pub enum MlUpdateFilterParts<'b> {
     #[doc = "FilterId"]
-    FilterId(&'a str),
+    FilterId(&'b str),
 }
-impl<'a> MlUpdateFilterParts<'a> {
+impl<'b> MlUpdateFilterParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Update Filter API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -6105,23 +6105,23 @@ impl<'a> MlUpdateFilterParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Update Filter API"]
-pub struct MlUpdateFilter<'a, B> {
-    client: Elasticsearch,
-    parts: MlUpdateFilterParts<'a>,
+pub struct MlUpdateFilter<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlUpdateFilterParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlUpdateFilter<'a, B>
+impl<'a, 'b, B> MlUpdateFilter<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlUpdateFilter] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlUpdateFilterParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlUpdateFilterParts<'b>) -> Self {
         MlUpdateFilter {
             client,
             parts,
@@ -6135,7 +6135,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlUpdateFilter<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlUpdateFilter<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6157,7 +6157,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6177,7 +6177,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -6189,20 +6189,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -6223,11 +6223,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Update Job API"]
-pub enum MlUpdateJobParts<'a> {
+pub enum MlUpdateJobParts<'b> {
     #[doc = "JobId"]
-    JobId(&'a str),
+    JobId(&'b str),
 }
-impl<'a> MlUpdateJobParts<'a> {
+impl<'b> MlUpdateJobParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Update Job API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -6243,23 +6243,23 @@ impl<'a> MlUpdateJobParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Update Job API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html)."]
-pub struct MlUpdateJob<'a, B> {
-    client: Elasticsearch,
-    parts: MlUpdateJobParts<'a>,
+pub struct MlUpdateJob<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlUpdateJobParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlUpdateJob<'a, B>
+impl<'a, 'b, B> MlUpdateJob<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlUpdateJob] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlUpdateJobParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlUpdateJobParts<'b>) -> Self {
         MlUpdateJob {
             client,
             parts,
@@ -6273,7 +6273,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlUpdateJob<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlUpdateJob<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6295,7 +6295,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6315,7 +6315,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -6327,20 +6327,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -6361,11 +6361,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Ml Update Model Snapshot API"]
-pub enum MlUpdateModelSnapshotParts<'a> {
+pub enum MlUpdateModelSnapshotParts<'b> {
     #[doc = "JobId and SnapshotId"]
-    JobIdSnapshotId(&'a str, &'a str),
+    JobIdSnapshotId(&'b str, &'b str),
 }
-impl<'a> MlUpdateModelSnapshotParts<'a> {
+impl<'b> MlUpdateModelSnapshotParts<'b> {
     #[doc = "Builds a relative URL path to the Ml Update Model Snapshot API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -6383,23 +6383,23 @@ impl<'a> MlUpdateModelSnapshotParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Update Model Snapshot API](http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html)."]
-pub struct MlUpdateModelSnapshot<'a, B> {
-    client: Elasticsearch,
-    parts: MlUpdateModelSnapshotParts<'a>,
+pub struct MlUpdateModelSnapshot<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MlUpdateModelSnapshotParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlUpdateModelSnapshot<'a, B>
+impl<'a, 'b, B> MlUpdateModelSnapshot<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlUpdateModelSnapshot] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MlUpdateModelSnapshotParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MlUpdateModelSnapshotParts<'b>) -> Self {
         MlUpdateModelSnapshot {
             client,
             parts,
@@ -6413,7 +6413,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlUpdateModelSnapshot<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlUpdateModelSnapshot<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6435,7 +6435,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6455,7 +6455,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -6467,20 +6467,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -6515,23 +6515,23 @@ impl MlValidateParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Validate API"]
-pub struct MlValidate<'a, B> {
-    client: Elasticsearch,
+pub struct MlValidate<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: MlValidateParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlValidate<'a, B>
+impl<'a, 'b, B> MlValidate<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlValidate]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         MlValidate {
             client,
             parts: MlValidateParts::None,
@@ -6545,7 +6545,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlValidate<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlValidate<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6567,7 +6567,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6587,7 +6587,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -6599,20 +6599,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -6647,23 +6647,23 @@ impl MlValidateDetectorParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Ml Validate Detector API"]
-pub struct MlValidateDetector<'a, B> {
-    client: Elasticsearch,
+pub struct MlValidateDetector<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: MlValidateDetectorParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> MlValidateDetector<'a, B>
+impl<'a, 'b, B> MlValidateDetector<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlValidateDetector]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         MlValidateDetector {
             client,
             parts: MlValidateDetectorParts::None,
@@ -6677,7 +6677,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> MlValidateDetector<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> MlValidateDetector<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6699,7 +6699,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6719,7 +6719,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -6731,20 +6731,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -6764,192 +6764,219 @@ where
     }
 }
 #[doc = "Namespace client for Machine Learning APIs"]
-pub struct Ml {
-    client: Elasticsearch,
+pub struct Ml<'a> {
+    client: &'a Elasticsearch,
 }
-impl Ml {
+impl<'a> Ml<'a> {
     #[doc = "Creates a new instance of [Ml]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn close_job<'a>(&self, parts: MlCloseJobParts<'a>) -> MlCloseJob<'a, ()> {
-        MlCloseJob::new(self.client.clone(), parts)
+    pub fn close_job<'b>(&'a self, parts: MlCloseJobParts<'b>) -> MlCloseJob<'a, 'b, ()> {
+        MlCloseJob::new(&self.client, parts)
     }
-    pub fn delete_calendar<'a>(&self, parts: MlDeleteCalendarParts<'a>) -> MlDeleteCalendar<'a> {
-        MlDeleteCalendar::new(self.client.clone(), parts)
+    pub fn delete_calendar<'b>(
+        &'a self,
+        parts: MlDeleteCalendarParts<'b>,
+    ) -> MlDeleteCalendar<'a, 'b> {
+        MlDeleteCalendar::new(&self.client, parts)
     }
-    pub fn delete_calendar_event<'a>(
-        &self,
-        parts: MlDeleteCalendarEventParts<'a>,
-    ) -> MlDeleteCalendarEvent<'a> {
-        MlDeleteCalendarEvent::new(self.client.clone(), parts)
+    pub fn delete_calendar_event<'b>(
+        &'a self,
+        parts: MlDeleteCalendarEventParts<'b>,
+    ) -> MlDeleteCalendarEvent<'a, 'b> {
+        MlDeleteCalendarEvent::new(&self.client, parts)
     }
-    pub fn delete_calendar_job<'a>(
-        &self,
-        parts: MlDeleteCalendarJobParts<'a>,
-    ) -> MlDeleteCalendarJob<'a> {
-        MlDeleteCalendarJob::new(self.client.clone(), parts)
+    pub fn delete_calendar_job<'b>(
+        &'a self,
+        parts: MlDeleteCalendarJobParts<'b>,
+    ) -> MlDeleteCalendarJob<'a, 'b> {
+        MlDeleteCalendarJob::new(&self.client, parts)
     }
-    pub fn delete_datafeed<'a>(&self, parts: MlDeleteDatafeedParts<'a>) -> MlDeleteDatafeed<'a> {
-        MlDeleteDatafeed::new(self.client.clone(), parts)
+    pub fn delete_datafeed<'b>(
+        &'a self,
+        parts: MlDeleteDatafeedParts<'b>,
+    ) -> MlDeleteDatafeed<'a, 'b> {
+        MlDeleteDatafeed::new(&self.client, parts)
     }
-    pub fn delete_expired_data<'a>(&self) -> MlDeleteExpiredData<'a> {
-        MlDeleteExpiredData::new(self.client.clone())
+    pub fn delete_expired_data<'b>(&'a self) -> MlDeleteExpiredData<'a, 'b> {
+        MlDeleteExpiredData::new(&self.client)
     }
-    pub fn delete_filter<'a>(&self, parts: MlDeleteFilterParts<'a>) -> MlDeleteFilter<'a> {
-        MlDeleteFilter::new(self.client.clone(), parts)
+    pub fn delete_filter<'b>(&'a self, parts: MlDeleteFilterParts<'b>) -> MlDeleteFilter<'a, 'b> {
+        MlDeleteFilter::new(&self.client, parts)
     }
-    pub fn delete_forecast<'a>(&self, parts: MlDeleteForecastParts<'a>) -> MlDeleteForecast<'a> {
-        MlDeleteForecast::new(self.client.clone(), parts)
+    pub fn delete_forecast<'b>(
+        &'a self,
+        parts: MlDeleteForecastParts<'b>,
+    ) -> MlDeleteForecast<'a, 'b> {
+        MlDeleteForecast::new(&self.client, parts)
     }
-    pub fn delete_job<'a>(&self, parts: MlDeleteJobParts<'a>) -> MlDeleteJob<'a> {
-        MlDeleteJob::new(self.client.clone(), parts)
+    pub fn delete_job<'b>(&'a self, parts: MlDeleteJobParts<'b>) -> MlDeleteJob<'a, 'b> {
+        MlDeleteJob::new(&self.client, parts)
     }
-    pub fn delete_model_snapshot<'a>(
-        &self,
-        parts: MlDeleteModelSnapshotParts<'a>,
-    ) -> MlDeleteModelSnapshot<'a> {
-        MlDeleteModelSnapshot::new(self.client.clone(), parts)
+    pub fn delete_model_snapshot<'b>(
+        &'a self,
+        parts: MlDeleteModelSnapshotParts<'b>,
+    ) -> MlDeleteModelSnapshot<'a, 'b> {
+        MlDeleteModelSnapshot::new(&self.client, parts)
     }
-    pub fn flush_job<'a>(&self, parts: MlFlushJobParts<'a>) -> MlFlushJob<'a, ()> {
-        MlFlushJob::new(self.client.clone(), parts)
+    pub fn flush_job<'b>(&'a self, parts: MlFlushJobParts<'b>) -> MlFlushJob<'a, 'b, ()> {
+        MlFlushJob::new(&self.client, parts)
     }
-    pub fn forecast<'a>(&self, parts: MlForecastParts<'a>) -> MlForecast<'a, ()> {
-        MlForecast::new(self.client.clone(), parts)
+    pub fn forecast<'b>(&'a self, parts: MlForecastParts<'b>) -> MlForecast<'a, 'b, ()> {
+        MlForecast::new(&self.client, parts)
     }
-    pub fn get_buckets<'a>(&self, parts: MlGetBucketsParts<'a>) -> MlGetBuckets<'a, ()> {
-        MlGetBuckets::new(self.client.clone(), parts)
+    pub fn get_buckets<'b>(&'a self, parts: MlGetBucketsParts<'b>) -> MlGetBuckets<'a, 'b, ()> {
+        MlGetBuckets::new(&self.client, parts)
     }
-    pub fn get_calendar_events<'a>(
-        &self,
-        parts: MlGetCalendarEventsParts<'a>,
-    ) -> MlGetCalendarEvents<'a> {
-        MlGetCalendarEvents::new(self.client.clone(), parts)
+    pub fn get_calendar_events<'b>(
+        &'a self,
+        parts: MlGetCalendarEventsParts<'b>,
+    ) -> MlGetCalendarEvents<'a, 'b> {
+        MlGetCalendarEvents::new(&self.client, parts)
     }
-    pub fn get_calendars<'a>(&self, parts: MlGetCalendarsParts<'a>) -> MlGetCalendars<'a, ()> {
-        MlGetCalendars::new(self.client.clone(), parts)
+    pub fn get_calendars<'b>(
+        &'a self,
+        parts: MlGetCalendarsParts<'b>,
+    ) -> MlGetCalendars<'a, 'b, ()> {
+        MlGetCalendars::new(&self.client, parts)
     }
-    pub fn get_categories<'a>(&self, parts: MlGetCategoriesParts<'a>) -> MlGetCategories<'a, ()> {
-        MlGetCategories::new(self.client.clone(), parts)
+    pub fn get_categories<'b>(
+        &'a self,
+        parts: MlGetCategoriesParts<'b>,
+    ) -> MlGetCategories<'a, 'b, ()> {
+        MlGetCategories::new(&self.client, parts)
     }
-    pub fn get_datafeed_stats<'a>(
-        &self,
-        parts: MlGetDatafeedStatsParts<'a>,
-    ) -> MlGetDatafeedStats<'a> {
-        MlGetDatafeedStats::new(self.client.clone(), parts)
+    pub fn get_datafeed_stats<'b>(
+        &'a self,
+        parts: MlGetDatafeedStatsParts<'b>,
+    ) -> MlGetDatafeedStats<'a, 'b> {
+        MlGetDatafeedStats::new(&self.client, parts)
     }
-    pub fn get_datafeeds<'a>(&self, parts: MlGetDatafeedsParts<'a>) -> MlGetDatafeeds<'a> {
-        MlGetDatafeeds::new(self.client.clone(), parts)
+    pub fn get_datafeeds<'b>(&'a self, parts: MlGetDatafeedsParts<'b>) -> MlGetDatafeeds<'a, 'b> {
+        MlGetDatafeeds::new(&self.client, parts)
     }
-    pub fn get_filters<'a>(&self, parts: MlGetFiltersParts<'a>) -> MlGetFilters<'a> {
-        MlGetFilters::new(self.client.clone(), parts)
+    pub fn get_filters<'b>(&'a self, parts: MlGetFiltersParts<'b>) -> MlGetFilters<'a, 'b> {
+        MlGetFilters::new(&self.client, parts)
     }
-    pub fn get_influencers<'a>(
-        &self,
-        parts: MlGetInfluencersParts<'a>,
-    ) -> MlGetInfluencers<'a, ()> {
-        MlGetInfluencers::new(self.client.clone(), parts)
+    pub fn get_influencers<'b>(
+        &'a self,
+        parts: MlGetInfluencersParts<'b>,
+    ) -> MlGetInfluencers<'a, 'b, ()> {
+        MlGetInfluencers::new(&self.client, parts)
     }
-    pub fn get_job_stats<'a>(&self, parts: MlGetJobStatsParts<'a>) -> MlGetJobStats<'a> {
-        MlGetJobStats::new(self.client.clone(), parts)
+    pub fn get_job_stats<'b>(&'a self, parts: MlGetJobStatsParts<'b>) -> MlGetJobStats<'a, 'b> {
+        MlGetJobStats::new(&self.client, parts)
     }
-    pub fn get_jobs<'a>(&self, parts: MlGetJobsParts<'a>) -> MlGetJobs<'a> {
-        MlGetJobs::new(self.client.clone(), parts)
+    pub fn get_jobs<'b>(&'a self, parts: MlGetJobsParts<'b>) -> MlGetJobs<'a, 'b> {
+        MlGetJobs::new(&self.client, parts)
     }
-    pub fn get_model_snapshots<'a>(
-        &self,
-        parts: MlGetModelSnapshotsParts<'a>,
-    ) -> MlGetModelSnapshots<'a, ()> {
-        MlGetModelSnapshots::new(self.client.clone(), parts)
+    pub fn get_model_snapshots<'b>(
+        &'a self,
+        parts: MlGetModelSnapshotsParts<'b>,
+    ) -> MlGetModelSnapshots<'a, 'b, ()> {
+        MlGetModelSnapshots::new(&self.client, parts)
     }
-    pub fn get_overall_buckets<'a>(
-        &self,
-        parts: MlGetOverallBucketsParts<'a>,
-    ) -> MlGetOverallBuckets<'a, ()> {
-        MlGetOverallBuckets::new(self.client.clone(), parts)
+    pub fn get_overall_buckets<'b>(
+        &'a self,
+        parts: MlGetOverallBucketsParts<'b>,
+    ) -> MlGetOverallBuckets<'a, 'b, ()> {
+        MlGetOverallBuckets::new(&self.client, parts)
     }
-    pub fn get_records<'a>(&self, parts: MlGetRecordsParts<'a>) -> MlGetRecords<'a, ()> {
-        MlGetRecords::new(self.client.clone(), parts)
+    pub fn get_records<'b>(&'a self, parts: MlGetRecordsParts<'b>) -> MlGetRecords<'a, 'b, ()> {
+        MlGetRecords::new(&self.client, parts)
     }
-    pub fn info<'a>(&self) -> MlInfo<'a> {
-        MlInfo::new(self.client.clone())
+    pub fn info<'b>(&'a self) -> MlInfo<'a, 'b> {
+        MlInfo::new(&self.client)
     }
-    pub fn open_job<'a>(&self, parts: MlOpenJobParts<'a>) -> MlOpenJob<'a, ()> {
-        MlOpenJob::new(self.client.clone(), parts)
+    pub fn open_job<'b>(&'a self, parts: MlOpenJobParts<'b>) -> MlOpenJob<'a, 'b, ()> {
+        MlOpenJob::new(&self.client, parts)
     }
-    pub fn post_calendar_events<'a>(
-        &self,
-        parts: MlPostCalendarEventsParts<'a>,
-    ) -> MlPostCalendarEvents<'a, ()> {
-        MlPostCalendarEvents::new(self.client.clone(), parts)
+    pub fn post_calendar_events<'b>(
+        &'a self,
+        parts: MlPostCalendarEventsParts<'b>,
+    ) -> MlPostCalendarEvents<'a, 'b, ()> {
+        MlPostCalendarEvents::new(&self.client, parts)
     }
-    pub fn post_data<'a>(&self, parts: MlPostDataParts<'a>) -> MlPostData<'a, ()> {
-        MlPostData::new(self.client.clone(), parts)
+    pub fn post_data<'b>(&'a self, parts: MlPostDataParts<'b>) -> MlPostData<'a, 'b, ()> {
+        MlPostData::new(&self.client, parts)
     }
-    pub fn preview_datafeed<'a>(&self, parts: MlPreviewDatafeedParts<'a>) -> MlPreviewDatafeed<'a> {
-        MlPreviewDatafeed::new(self.client.clone(), parts)
+    pub fn preview_datafeed<'b>(
+        &'a self,
+        parts: MlPreviewDatafeedParts<'b>,
+    ) -> MlPreviewDatafeed<'a, 'b> {
+        MlPreviewDatafeed::new(&self.client, parts)
     }
-    pub fn put_calendar<'a>(&self, parts: MlPutCalendarParts<'a>) -> MlPutCalendar<'a, ()> {
-        MlPutCalendar::new(self.client.clone(), parts)
+    pub fn put_calendar<'b>(&'a self, parts: MlPutCalendarParts<'b>) -> MlPutCalendar<'a, 'b, ()> {
+        MlPutCalendar::new(&self.client, parts)
     }
-    pub fn put_calendar_job<'a>(
-        &self,
-        parts: MlPutCalendarJobParts<'a>,
-    ) -> MlPutCalendarJob<'a, ()> {
-        MlPutCalendarJob::new(self.client.clone(), parts)
+    pub fn put_calendar_job<'b>(
+        &'a self,
+        parts: MlPutCalendarJobParts<'b>,
+    ) -> MlPutCalendarJob<'a, 'b, ()> {
+        MlPutCalendarJob::new(&self.client, parts)
     }
-    pub fn put_datafeed<'a>(&self, parts: MlPutDatafeedParts<'a>) -> MlPutDatafeed<'a, ()> {
-        MlPutDatafeed::new(self.client.clone(), parts)
+    pub fn put_datafeed<'b>(&'a self, parts: MlPutDatafeedParts<'b>) -> MlPutDatafeed<'a, 'b, ()> {
+        MlPutDatafeed::new(&self.client, parts)
     }
-    pub fn put_filter<'a>(&self, parts: MlPutFilterParts<'a>) -> MlPutFilter<'a, ()> {
-        MlPutFilter::new(self.client.clone(), parts)
+    pub fn put_filter<'b>(&'a self, parts: MlPutFilterParts<'b>) -> MlPutFilter<'a, 'b, ()> {
+        MlPutFilter::new(&self.client, parts)
     }
-    pub fn put_job<'a>(&self, parts: MlPutJobParts<'a>) -> MlPutJob<'a, ()> {
-        MlPutJob::new(self.client.clone(), parts)
+    pub fn put_job<'b>(&'a self, parts: MlPutJobParts<'b>) -> MlPutJob<'a, 'b, ()> {
+        MlPutJob::new(&self.client, parts)
     }
-    pub fn revert_model_snapshot<'a>(
-        &self,
-        parts: MlRevertModelSnapshotParts<'a>,
-    ) -> MlRevertModelSnapshot<'a, ()> {
-        MlRevertModelSnapshot::new(self.client.clone(), parts)
+    pub fn revert_model_snapshot<'b>(
+        &'a self,
+        parts: MlRevertModelSnapshotParts<'b>,
+    ) -> MlRevertModelSnapshot<'a, 'b, ()> {
+        MlRevertModelSnapshot::new(&self.client, parts)
     }
-    pub fn set_upgrade_mode<'a>(&self) -> MlSetUpgradeMode<'a, ()> {
-        MlSetUpgradeMode::new(self.client.clone())
+    pub fn set_upgrade_mode<'b>(&'a self) -> MlSetUpgradeMode<'a, 'b, ()> {
+        MlSetUpgradeMode::new(&self.client)
     }
-    pub fn start_datafeed<'a>(&self, parts: MlStartDatafeedParts<'a>) -> MlStartDatafeed<'a, ()> {
-        MlStartDatafeed::new(self.client.clone(), parts)
+    pub fn start_datafeed<'b>(
+        &'a self,
+        parts: MlStartDatafeedParts<'b>,
+    ) -> MlStartDatafeed<'a, 'b, ()> {
+        MlStartDatafeed::new(&self.client, parts)
     }
-    pub fn stop_datafeed<'a>(&self, parts: MlStopDatafeedParts<'a>) -> MlStopDatafeed<'a, ()> {
-        MlStopDatafeed::new(self.client.clone(), parts)
+    pub fn stop_datafeed<'b>(
+        &'a self,
+        parts: MlStopDatafeedParts<'b>,
+    ) -> MlStopDatafeed<'a, 'b, ()> {
+        MlStopDatafeed::new(&self.client, parts)
     }
-    pub fn update_datafeed<'a>(
-        &self,
-        parts: MlUpdateDatafeedParts<'a>,
-    ) -> MlUpdateDatafeed<'a, ()> {
-        MlUpdateDatafeed::new(self.client.clone(), parts)
+    pub fn update_datafeed<'b>(
+        &'a self,
+        parts: MlUpdateDatafeedParts<'b>,
+    ) -> MlUpdateDatafeed<'a, 'b, ()> {
+        MlUpdateDatafeed::new(&self.client, parts)
     }
-    pub fn update_filter<'a>(&self, parts: MlUpdateFilterParts<'a>) -> MlUpdateFilter<'a, ()> {
-        MlUpdateFilter::new(self.client.clone(), parts)
+    pub fn update_filter<'b>(
+        &'a self,
+        parts: MlUpdateFilterParts<'b>,
+    ) -> MlUpdateFilter<'a, 'b, ()> {
+        MlUpdateFilter::new(&self.client, parts)
     }
-    pub fn update_job<'a>(&self, parts: MlUpdateJobParts<'a>) -> MlUpdateJob<'a, ()> {
-        MlUpdateJob::new(self.client.clone(), parts)
+    pub fn update_job<'b>(&'a self, parts: MlUpdateJobParts<'b>) -> MlUpdateJob<'a, 'b, ()> {
+        MlUpdateJob::new(&self.client, parts)
     }
-    pub fn update_model_snapshot<'a>(
-        &self,
-        parts: MlUpdateModelSnapshotParts<'a>,
-    ) -> MlUpdateModelSnapshot<'a, ()> {
-        MlUpdateModelSnapshot::new(self.client.clone(), parts)
+    pub fn update_model_snapshot<'b>(
+        &'a self,
+        parts: MlUpdateModelSnapshotParts<'b>,
+    ) -> MlUpdateModelSnapshot<'a, 'b, ()> {
+        MlUpdateModelSnapshot::new(&self.client, parts)
     }
-    pub fn validate<'a>(&self) -> MlValidate<'a, ()> {
-        MlValidate::new(self.client.clone())
+    pub fn validate<'b>(&'a self) -> MlValidate<'a, 'b, ()> {
+        MlValidate::new(&self.client)
     }
-    pub fn validate_detector<'a>(&self) -> MlValidateDetector<'a, ()> {
-        MlValidateDetector::new(self.client.clone())
+    pub fn validate_detector<'b>(&'a self) -> MlValidateDetector<'a, 'b, ()> {
+        MlValidateDetector::new(&self.client)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Machine Learning APIs"]
     pub fn ml(&self) -> Ml {
-        Ml::new(self.clone())
+        Ml::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/nodes.rs
+++ b/elasticsearch/src/generated/namespace_clients/nodes.rs
@@ -31,13 +31,13 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Nodes Hot Threads API"]
-pub enum NodesHotThreadsParts<'a> {
+pub enum NodesHotThreadsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "NodeId"]
-    NodeId(&'a [&'a str]),
+    NodeId(&'b [&'b str]),
 }
-impl<'a> NodesHotThreadsParts<'a> {
+impl<'b> NodesHotThreadsParts<'b> {
     #[doc = "Builds a relative URL path to the Nodes Hot Threads API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -55,25 +55,25 @@ impl<'a> NodesHotThreadsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Nodes Hot Threads API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html). Returns information about hot threads on each node in the cluster."]
-pub struct NodesHotThreads<'a> {
-    client: Elasticsearch,
-    parts: NodesHotThreadsParts<'a>,
+pub struct NodesHotThreads<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: NodesHotThreadsParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_idle_threads: Option<bool>,
-    interval: Option<&'a str>,
+    interval: Option<&'b str>,
     pretty: Option<bool>,
     snapshots: Option<i64>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     threads: Option<i64>,
-    timeout: Option<&'a str>,
+    timeout: Option<&'b str>,
     ty: Option<Type>,
 }
-impl<'a> NodesHotThreads<'a> {
+impl<'a, 'b> NodesHotThreads<'a, 'b> {
     #[doc = "Creates a new instance of [NodesHotThreads] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: NodesHotThreadsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: NodesHotThreadsParts<'b>) -> Self {
         NodesHotThreads {
             client,
             parts,
@@ -97,7 +97,7 @@ impl<'a> NodesHotThreads<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -117,7 +117,7 @@ impl<'a> NodesHotThreads<'a> {
         self
     }
     #[doc = "The interval for the second sampling of threads"]
-    pub fn interval(mut self, interval: &'a str) -> Self {
+    pub fn interval(mut self, interval: &'b str) -> Self {
         self.interval = Some(interval);
         self
     }
@@ -132,7 +132,7 @@ impl<'a> NodesHotThreads<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -142,7 +142,7 @@ impl<'a> NodesHotThreads<'a> {
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -159,30 +159,30 @@ impl<'a> NodesHotThreads<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_idle_threads")]
                 ignore_idle_threads: Option<bool>,
                 #[serde(rename = "interval")]
-                interval: Option<&'a str>,
+                interval: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "snapshots")]
                 snapshots: Option<i64>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "threads")]
                 threads: Option<i64>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "type")]
                 ty: Option<Type>,
             }
@@ -211,17 +211,17 @@ impl<'a> NodesHotThreads<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Nodes Info API"]
-pub enum NodesInfoParts<'a> {
+pub enum NodesInfoParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "NodeId"]
-    NodeId(&'a [&'a str]),
+    NodeId(&'b [&'b str]),
     #[doc = "Metric"]
-    Metric(&'a [&'a str]),
+    Metric(&'b [&'b str]),
     #[doc = "NodeId and Metric"]
-    NodeIdMetric(&'a [&'a str], &'a [&'a str]),
+    NodeIdMetric(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> NodesInfoParts<'a> {
+impl<'b> NodesInfoParts<'b> {
     #[doc = "Builds a relative URL path to the Nodes Info API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -255,21 +255,21 @@ impl<'a> NodesInfoParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Nodes Info API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html). Returns information about nodes in the cluster."]
-pub struct NodesInfo<'a> {
-    client: Elasticsearch,
-    parts: NodesInfoParts<'a>,
+pub struct NodesInfo<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: NodesInfoParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     flat_settings: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> NodesInfo<'a> {
+impl<'a, 'b> NodesInfo<'a, 'b> {
     #[doc = "Creates a new instance of [NodesInfo] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: NodesInfoParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: NodesInfoParts<'b>) -> Self {
         NodesInfo {
             client,
             parts,
@@ -289,7 +289,7 @@ impl<'a> NodesInfo<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -314,12 +314,12 @@ impl<'a> NodesInfo<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -331,14 +331,14 @@ impl<'a> NodesInfo<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "flat_settings")]
                 flat_settings: Option<bool>,
                 #[serde(rename = "human")]
@@ -346,9 +346,9 @@ impl<'a> NodesInfo<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -371,13 +371,13 @@ impl<'a> NodesInfo<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Nodes Reload Secure Settings API"]
-pub enum NodesReloadSecureSettingsParts<'a> {
+pub enum NodesReloadSecureSettingsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "NodeId"]
-    NodeId(&'a [&'a str]),
+    NodeId(&'b [&'b str]),
 }
-impl<'a> NodesReloadSecureSettingsParts<'a> {
+impl<'b> NodesReloadSecureSettingsParts<'b> {
     #[doc = "Builds a relative URL path to the Nodes Reload Secure Settings API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -395,24 +395,24 @@ impl<'a> NodesReloadSecureSettingsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Nodes Reload Secure Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings). Reloads secure settings."]
-pub struct NodesReloadSecureSettings<'a, B> {
-    client: Elasticsearch,
-    parts: NodesReloadSecureSettingsParts<'a>,
+pub struct NodesReloadSecureSettings<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: NodesReloadSecureSettingsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> NodesReloadSecureSettings<'a, B>
+impl<'a, 'b, B> NodesReloadSecureSettings<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [NodesReloadSecureSettings] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: NodesReloadSecureSettingsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: NodesReloadSecureSettingsParts<'b>) -> Self {
         NodesReloadSecureSettings {
             client,
             parts,
@@ -427,7 +427,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> NodesReloadSecureSettings<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> NodesReloadSecureSettings<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -450,7 +450,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -470,12 +470,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -487,22 +487,22 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -524,21 +524,21 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Nodes Stats API"]
-pub enum NodesStatsParts<'a> {
+pub enum NodesStatsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "NodeId"]
-    NodeId(&'a [&'a str]),
+    NodeId(&'b [&'b str]),
     #[doc = "Metric"]
-    Metric(&'a [&'a str]),
+    Metric(&'b [&'b str]),
     #[doc = "NodeId and Metric"]
-    NodeIdMetric(&'a [&'a str], &'a [&'a str]),
+    NodeIdMetric(&'b [&'b str], &'b [&'b str]),
     #[doc = "Metric and IndexMetric"]
-    MetricIndexMetric(&'a [&'a str], &'a [&'a str]),
+    MetricIndexMetric(&'b [&'b str], &'b [&'b str]),
     #[doc = "NodeId, Metric and IndexMetric"]
-    NodeIdMetricIndexMetric(&'a [&'a str], &'a [&'a str], &'a [&'a str]),
+    NodeIdMetricIndexMetric(&'b [&'b str], &'b [&'b str], &'b [&'b str]),
 }
-impl<'a> NodesStatsParts<'a> {
+impl<'b> NodesStatsParts<'b> {
     #[doc = "Builds a relative URL path to the Nodes Stats API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -599,27 +599,27 @@ impl<'a> NodesStatsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Nodes Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html). Returns statistical information about nodes in the cluster."]
-pub struct NodesStats<'a> {
-    client: Elasticsearch,
-    parts: NodesStatsParts<'a>,
-    completion_fields: Option<&'a [&'a str]>,
+pub struct NodesStats<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: NodesStatsParts<'b>,
+    completion_fields: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
-    fielddata_fields: Option<&'a [&'a str]>,
-    fields: Option<&'a [&'a str]>,
-    filter_path: Option<&'a [&'a str]>,
+    fielddata_fields: Option<&'b [&'b str]>,
+    fields: Option<&'b [&'b str]>,
+    filter_path: Option<&'b [&'b str]>,
     groups: Option<bool>,
     headers: HeaderMap,
     human: Option<bool>,
     include_segment_file_sizes: Option<bool>,
     level: Option<Level>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    types: Option<&'a [&'a str]>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    types: Option<&'b [&'b str]>,
 }
-impl<'a> NodesStats<'a> {
+impl<'a, 'b> NodesStats<'a, 'b> {
     #[doc = "Creates a new instance of [NodesStats] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: NodesStatsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: NodesStatsParts<'b>) -> Self {
         NodesStats {
             client,
             parts,
@@ -640,7 +640,7 @@ impl<'a> NodesStats<'a> {
         }
     }
     #[doc = "A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)"]
-    pub fn completion_fields(mut self, completion_fields: &'a [&'a str]) -> Self {
+    pub fn completion_fields(mut self, completion_fields: &'b [&'b str]) -> Self {
         self.completion_fields = Some(completion_fields);
         self
     }
@@ -650,17 +650,17 @@ impl<'a> NodesStats<'a> {
         self
     }
     #[doc = "A comma-separated list of fields for `fielddata` index metric (supports wildcards)"]
-    pub fn fielddata_fields(mut self, fielddata_fields: &'a [&'a str]) -> Self {
+    pub fn fielddata_fields(mut self, fielddata_fields: &'b [&'b str]) -> Self {
         self.fielddata_fields = Some(fielddata_fields);
         self
     }
     #[doc = "A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)"]
-    pub fn fields(mut self, fields: &'a [&'a str]) -> Self {
+    pub fn fields(mut self, fields: &'b [&'b str]) -> Self {
         self.fields = Some(fields);
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -695,17 +695,17 @@ impl<'a> NodesStats<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "A comma-separated list of document types for the `indexing` index metric"]
-    pub fn types(mut self, types: &'a [&'a str]) -> Self {
+    pub fn types(mut self, types: &'b [&'b str]) -> Self {
         self.types = Some(types);
         self
     }
@@ -717,26 +717,26 @@ impl<'a> NodesStats<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "completion_fields",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                completion_fields: Option<&'a [&'a str]>,
+                completion_fields: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "fielddata_fields",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                fielddata_fields: Option<&'a [&'a str]>,
+                fielddata_fields: Option<&'b [&'b str]>,
                 #[serde(rename = "fields", serialize_with = "crate::client::serialize_coll_qs")]
-                fields: Option<&'a [&'a str]>,
+                fields: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "groups")]
                 groups: Option<bool>,
                 #[serde(rename = "human")]
@@ -748,11 +748,11 @@ impl<'a> NodesStats<'a> {
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "types", serialize_with = "crate::client::serialize_coll_qs")]
-                types: Option<&'a [&'a str]>,
+                types: Option<&'b [&'b str]>,
             }
             let query_params = QueryParams {
                 completion_fields: self.completion_fields,
@@ -781,17 +781,17 @@ impl<'a> NodesStats<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Nodes Usage API"]
-pub enum NodesUsageParts<'a> {
+pub enum NodesUsageParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "NodeId"]
-    NodeId(&'a [&'a str]),
+    NodeId(&'b [&'b str]),
     #[doc = "Metric"]
-    Metric(&'a [&'a str]),
+    Metric(&'b [&'b str]),
     #[doc = "NodeId and Metric"]
-    NodeIdMetric(&'a [&'a str], &'a [&'a str]),
+    NodeIdMetric(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> NodesUsageParts<'a> {
+impl<'b> NodesUsageParts<'b> {
     #[doc = "Builds a relative URL path to the Nodes Usage API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -826,20 +826,20 @@ impl<'a> NodesUsageParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Nodes Usage API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html). Returns low-level information about REST actions usage on nodes."]
-pub struct NodesUsage<'a> {
-    client: Elasticsearch,
-    parts: NodesUsageParts<'a>,
+pub struct NodesUsage<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: NodesUsageParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> NodesUsage<'a> {
+impl<'a, 'b> NodesUsage<'a, 'b> {
     #[doc = "Creates a new instance of [NodesUsage] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: NodesUsageParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: NodesUsageParts<'b>) -> Self {
         NodesUsage {
             client,
             parts,
@@ -858,7 +858,7 @@ impl<'a> NodesUsage<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -878,12 +878,12 @@ impl<'a> NodesUsage<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -895,22 +895,22 @@ impl<'a> NodesUsage<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -931,41 +931,41 @@ impl<'a> NodesUsage<'a> {
     }
 }
 #[doc = "Namespace client for Nodes APIs"]
-pub struct Nodes {
-    client: Elasticsearch,
+pub struct Nodes<'a> {
+    client: &'a Elasticsearch,
 }
-impl Nodes {
+impl<'a> Nodes<'a> {
     #[doc = "Creates a new instance of [Nodes]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
     #[doc = "Returns information about hot threads on each node in the cluster."]
-    pub fn hot_threads<'a>(&self, parts: NodesHotThreadsParts<'a>) -> NodesHotThreads<'a> {
-        NodesHotThreads::new(self.client.clone(), parts)
+    pub fn hot_threads<'b>(&'a self, parts: NodesHotThreadsParts<'b>) -> NodesHotThreads<'a, 'b> {
+        NodesHotThreads::new(&self.client, parts)
     }
     #[doc = "Returns information about nodes in the cluster."]
-    pub fn info<'a>(&self, parts: NodesInfoParts<'a>) -> NodesInfo<'a> {
-        NodesInfo::new(self.client.clone(), parts)
+    pub fn info<'b>(&'a self, parts: NodesInfoParts<'b>) -> NodesInfo<'a, 'b> {
+        NodesInfo::new(&self.client, parts)
     }
     #[doc = "Reloads secure settings."]
-    pub fn reload_secure_settings<'a>(
-        &self,
-        parts: NodesReloadSecureSettingsParts<'a>,
-    ) -> NodesReloadSecureSettings<'a, ()> {
-        NodesReloadSecureSettings::new(self.client.clone(), parts)
+    pub fn reload_secure_settings<'b>(
+        &'a self,
+        parts: NodesReloadSecureSettingsParts<'b>,
+    ) -> NodesReloadSecureSettings<'a, 'b, ()> {
+        NodesReloadSecureSettings::new(&self.client, parts)
     }
     #[doc = "Returns statistical information about nodes in the cluster."]
-    pub fn stats<'a>(&self, parts: NodesStatsParts<'a>) -> NodesStats<'a> {
-        NodesStats::new(self.client.clone(), parts)
+    pub fn stats<'b>(&'a self, parts: NodesStatsParts<'b>) -> NodesStats<'a, 'b> {
+        NodesStats::new(&self.client, parts)
     }
     #[doc = "Returns low-level information about REST actions usage on nodes."]
-    pub fn usage<'a>(&self, parts: NodesUsageParts<'a>) -> NodesUsage<'a> {
-        NodesUsage::new(self.client.clone(), parts)
+    pub fn usage<'b>(&'a self, parts: NodesUsageParts<'b>) -> NodesUsage<'a, 'b> {
+        NodesUsage::new(&self.client, parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Nodes APIs"]
     pub fn nodes(&self) -> Nodes {
-        Nodes::new(self.clone())
+        Nodes::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/security.rs
+++ b/elasticsearch/src/generated/namespace_clients/security.rs
@@ -45,19 +45,19 @@ impl SecurityAuthenticateParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Authenticate API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html)."]
-pub struct SecurityAuthenticate<'a> {
-    client: Elasticsearch,
+pub struct SecurityAuthenticate<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: SecurityAuthenticateParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityAuthenticate<'a> {
+impl<'a, 'b> SecurityAuthenticate<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityAuthenticate]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SecurityAuthenticate {
             client,
             parts: SecurityAuthenticateParts::None,
@@ -75,7 +75,7 @@ impl<'a> SecurityAuthenticate<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -95,7 +95,7 @@ impl<'a> SecurityAuthenticate<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -107,20 +107,20 @@ impl<'a> SecurityAuthenticate<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -141,13 +141,13 @@ impl<'a> SecurityAuthenticate<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Change Password API"]
-pub enum SecurityChangePasswordParts<'a> {
+pub enum SecurityChangePasswordParts<'b> {
     #[doc = "Username"]
-    Username(&'a str),
+    Username(&'b str),
     #[doc = "No parts"]
     None,
 }
-impl<'a> SecurityChangePasswordParts<'a> {
+impl<'b> SecurityChangePasswordParts<'b> {
     #[doc = "Builds a relative URL path to the Security Change Password API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -164,24 +164,24 @@ impl<'a> SecurityChangePasswordParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Change Password API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html)."]
-pub struct SecurityChangePassword<'a, B> {
-    client: Elasticsearch,
-    parts: SecurityChangePasswordParts<'a>,
+pub struct SecurityChangePassword<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SecurityChangePasswordParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityChangePassword<'a, B>
+impl<'a, 'b, B> SecurityChangePassword<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityChangePassword] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityChangePasswordParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityChangePasswordParts<'b>) -> Self {
         SecurityChangePassword {
             client,
             parts,
@@ -196,7 +196,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityChangePassword<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityChangePassword<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -219,7 +219,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -244,7 +244,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -256,14 +256,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -271,7 +271,7 @@ where
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -293,11 +293,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Clear Cached Realms API"]
-pub enum SecurityClearCachedRealmsParts<'a> {
+pub enum SecurityClearCachedRealmsParts<'b> {
     #[doc = "Realms"]
-    Realms(&'a [&'a str]),
+    Realms(&'b [&'b str]),
 }
-impl<'a> SecurityClearCachedRealmsParts<'a> {
+impl<'b> SecurityClearCachedRealmsParts<'b> {
     #[doc = "Builds a relative URL path to the Security Clear Cached Realms API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -314,24 +314,24 @@ impl<'a> SecurityClearCachedRealmsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Clear Cached Realms API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html)."]
-pub struct SecurityClearCachedRealms<'a, B> {
-    client: Elasticsearch,
-    parts: SecurityClearCachedRealmsParts<'a>,
+pub struct SecurityClearCachedRealms<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SecurityClearCachedRealmsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    usernames: Option<&'a [&'a str]>,
+    source: Option<&'b str>,
+    usernames: Option<&'b [&'b str]>,
 }
-impl<'a, B> SecurityClearCachedRealms<'a, B>
+impl<'a, 'b, B> SecurityClearCachedRealms<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityClearCachedRealms] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityClearCachedRealmsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityClearCachedRealmsParts<'b>) -> Self {
         SecurityClearCachedRealms {
             client,
             parts,
@@ -346,7 +346,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityClearCachedRealms<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityClearCachedRealms<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -369,7 +369,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -389,12 +389,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Comma-separated list of usernames to clear from the cache"]
-    pub fn usernames(mut self, usernames: &'a [&'a str]) -> Self {
+    pub fn usernames(mut self, usernames: &'b [&'b str]) -> Self {
         self.usernames = Some(usernames);
         self
     }
@@ -406,25 +406,25 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(
                     rename = "usernames",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                usernames: Option<&'a [&'a str]>,
+                usernames: Option<&'b [&'b str]>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -446,11 +446,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Clear Cached Roles API"]
-pub enum SecurityClearCachedRolesParts<'a> {
+pub enum SecurityClearCachedRolesParts<'b> {
     #[doc = "Name"]
-    Name(&'a [&'a str]),
+    Name(&'b [&'b str]),
 }
-impl<'a> SecurityClearCachedRolesParts<'a> {
+impl<'b> SecurityClearCachedRolesParts<'b> {
     #[doc = "Builds a relative URL path to the Security Clear Cached Roles API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -467,23 +467,23 @@ impl<'a> SecurityClearCachedRolesParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Clear Cached Roles API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html)."]
-pub struct SecurityClearCachedRoles<'a, B> {
-    client: Elasticsearch,
-    parts: SecurityClearCachedRolesParts<'a>,
+pub struct SecurityClearCachedRoles<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SecurityClearCachedRolesParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityClearCachedRoles<'a, B>
+impl<'a, 'b, B> SecurityClearCachedRoles<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityClearCachedRoles] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityClearCachedRolesParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityClearCachedRolesParts<'b>) -> Self {
         SecurityClearCachedRoles {
             client,
             parts,
@@ -497,7 +497,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityClearCachedRoles<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityClearCachedRoles<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -519,7 +519,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -539,7 +539,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -551,20 +551,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -599,24 +599,24 @@ impl SecurityCreateApiKeyParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Create Api Key API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html)."]
-pub struct SecurityCreateApiKey<'a, B> {
-    client: Elasticsearch,
+pub struct SecurityCreateApiKey<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SecurityCreateApiKeyParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityCreateApiKey<'a, B>
+impl<'a, 'b, B> SecurityCreateApiKey<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityCreateApiKey]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SecurityCreateApiKey {
             client,
             parts: SecurityCreateApiKeyParts::None,
@@ -631,7 +631,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityCreateApiKey<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityCreateApiKey<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -654,7 +654,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -679,7 +679,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -691,14 +691,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -706,7 +706,7 @@ where
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -728,11 +728,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Delete Privileges API"]
-pub enum SecurityDeletePrivilegesParts<'a> {
+pub enum SecurityDeletePrivilegesParts<'b> {
     #[doc = "Application and Name"]
-    ApplicationName(&'a str, &'a str),
+    ApplicationName(&'b str, &'b str),
 }
-impl<'a> SecurityDeletePrivilegesParts<'a> {
+impl<'b> SecurityDeletePrivilegesParts<'b> {
     #[doc = "Builds a relative URL path to the Security Delete Privileges API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -749,20 +749,20 @@ impl<'a> SecurityDeletePrivilegesParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Security Delete Privileges API"]
-pub struct SecurityDeletePrivileges<'a> {
-    client: Elasticsearch,
-    parts: SecurityDeletePrivilegesParts<'a>,
+pub struct SecurityDeletePrivileges<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SecurityDeletePrivilegesParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityDeletePrivileges<'a> {
+impl<'a, 'b> SecurityDeletePrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeletePrivileges] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityDeletePrivilegesParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityDeletePrivilegesParts<'b>) -> Self {
         SecurityDeletePrivileges {
             client,
             parts,
@@ -781,7 +781,7 @@ impl<'a> SecurityDeletePrivileges<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -806,7 +806,7 @@ impl<'a> SecurityDeletePrivileges<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -818,14 +818,14 @@ impl<'a> SecurityDeletePrivileges<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -833,7 +833,7 @@ impl<'a> SecurityDeletePrivileges<'a> {
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -855,11 +855,11 @@ impl<'a> SecurityDeletePrivileges<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Delete Role API"]
-pub enum SecurityDeleteRoleParts<'a> {
+pub enum SecurityDeleteRoleParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> SecurityDeleteRoleParts<'a> {
+impl<'b> SecurityDeleteRoleParts<'b> {
     #[doc = "Builds a relative URL path to the Security Delete Role API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -874,20 +874,20 @@ impl<'a> SecurityDeleteRoleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Delete Role API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html)."]
-pub struct SecurityDeleteRole<'a> {
-    client: Elasticsearch,
-    parts: SecurityDeleteRoleParts<'a>,
+pub struct SecurityDeleteRole<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SecurityDeleteRoleParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityDeleteRole<'a> {
+impl<'a, 'b> SecurityDeleteRole<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeleteRole] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityDeleteRoleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityDeleteRoleParts<'b>) -> Self {
         SecurityDeleteRole {
             client,
             parts,
@@ -906,7 +906,7 @@ impl<'a> SecurityDeleteRole<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -931,7 +931,7 @@ impl<'a> SecurityDeleteRole<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -943,14 +943,14 @@ impl<'a> SecurityDeleteRole<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -958,7 +958,7 @@ impl<'a> SecurityDeleteRole<'a> {
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -980,11 +980,11 @@ impl<'a> SecurityDeleteRole<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Delete Role Mapping API"]
-pub enum SecurityDeleteRoleMappingParts<'a> {
+pub enum SecurityDeleteRoleMappingParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> SecurityDeleteRoleMappingParts<'a> {
+impl<'b> SecurityDeleteRoleMappingParts<'b> {
     #[doc = "Builds a relative URL path to the Security Delete Role Mapping API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -999,20 +999,20 @@ impl<'a> SecurityDeleteRoleMappingParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Delete Role Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html)."]
-pub struct SecurityDeleteRoleMapping<'a> {
-    client: Elasticsearch,
-    parts: SecurityDeleteRoleMappingParts<'a>,
+pub struct SecurityDeleteRoleMapping<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SecurityDeleteRoleMappingParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityDeleteRoleMapping<'a> {
+impl<'a, 'b> SecurityDeleteRoleMapping<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeleteRoleMapping] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityDeleteRoleMappingParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityDeleteRoleMappingParts<'b>) -> Self {
         SecurityDeleteRoleMapping {
             client,
             parts,
@@ -1031,7 +1031,7 @@ impl<'a> SecurityDeleteRoleMapping<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1056,7 +1056,7 @@ impl<'a> SecurityDeleteRoleMapping<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1068,14 +1068,14 @@ impl<'a> SecurityDeleteRoleMapping<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -1083,7 +1083,7 @@ impl<'a> SecurityDeleteRoleMapping<'a> {
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1105,11 +1105,11 @@ impl<'a> SecurityDeleteRoleMapping<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Delete User API"]
-pub enum SecurityDeleteUserParts<'a> {
+pub enum SecurityDeleteUserParts<'b> {
     #[doc = "Username"]
-    Username(&'a str),
+    Username(&'b str),
 }
-impl<'a> SecurityDeleteUserParts<'a> {
+impl<'b> SecurityDeleteUserParts<'b> {
     #[doc = "Builds a relative URL path to the Security Delete User API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1124,20 +1124,20 @@ impl<'a> SecurityDeleteUserParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Delete User API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html)."]
-pub struct SecurityDeleteUser<'a> {
-    client: Elasticsearch,
-    parts: SecurityDeleteUserParts<'a>,
+pub struct SecurityDeleteUser<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SecurityDeleteUserParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityDeleteUser<'a> {
+impl<'a, 'b> SecurityDeleteUser<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeleteUser] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityDeleteUserParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityDeleteUserParts<'b>) -> Self {
         SecurityDeleteUser {
             client,
             parts,
@@ -1156,7 +1156,7 @@ impl<'a> SecurityDeleteUser<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1181,7 +1181,7 @@ impl<'a> SecurityDeleteUser<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1193,14 +1193,14 @@ impl<'a> SecurityDeleteUser<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -1208,7 +1208,7 @@ impl<'a> SecurityDeleteUser<'a> {
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1230,11 +1230,11 @@ impl<'a> SecurityDeleteUser<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Disable User API"]
-pub enum SecurityDisableUserParts<'a> {
+pub enum SecurityDisableUserParts<'b> {
     #[doc = "Username"]
-    Username(&'a str),
+    Username(&'b str),
 }
-impl<'a> SecurityDisableUserParts<'a> {
+impl<'b> SecurityDisableUserParts<'b> {
     #[doc = "Builds a relative URL path to the Security Disable User API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1250,24 +1250,24 @@ impl<'a> SecurityDisableUserParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Disable User API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html)."]
-pub struct SecurityDisableUser<'a, B> {
-    client: Elasticsearch,
-    parts: SecurityDisableUserParts<'a>,
+pub struct SecurityDisableUser<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SecurityDisableUserParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityDisableUser<'a, B>
+impl<'a, 'b, B> SecurityDisableUser<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityDisableUser] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityDisableUserParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityDisableUserParts<'b>) -> Self {
         SecurityDisableUser {
             client,
             parts,
@@ -1282,7 +1282,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityDisableUser<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityDisableUser<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1305,7 +1305,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1330,7 +1330,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1342,14 +1342,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -1357,7 +1357,7 @@ where
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1379,11 +1379,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Enable User API"]
-pub enum SecurityEnableUserParts<'a> {
+pub enum SecurityEnableUserParts<'b> {
     #[doc = "Username"]
-    Username(&'a str),
+    Username(&'b str),
 }
-impl<'a> SecurityEnableUserParts<'a> {
+impl<'b> SecurityEnableUserParts<'b> {
     #[doc = "Builds a relative URL path to the Security Enable User API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1399,24 +1399,24 @@ impl<'a> SecurityEnableUserParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Enable User API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html)."]
-pub struct SecurityEnableUser<'a, B> {
-    client: Elasticsearch,
-    parts: SecurityEnableUserParts<'a>,
+pub struct SecurityEnableUser<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SecurityEnableUserParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityEnableUser<'a, B>
+impl<'a, 'b, B> SecurityEnableUser<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityEnableUser] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityEnableUserParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityEnableUserParts<'b>) -> Self {
         SecurityEnableUser {
             client,
             parts,
@@ -1431,7 +1431,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityEnableUser<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityEnableUser<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1454,7 +1454,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1479,7 +1479,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1491,14 +1491,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -1506,7 +1506,7 @@ where
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1542,24 +1542,24 @@ impl SecurityGetApiKeyParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Api Key API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html)."]
-pub struct SecurityGetApiKey<'a> {
-    client: Elasticsearch,
+pub struct SecurityGetApiKey<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: SecurityGetApiKeyParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    id: Option<&'a str>,
-    name: Option<&'a str>,
+    id: Option<&'b str>,
+    name: Option<&'b str>,
     owner: Option<bool>,
     pretty: Option<bool>,
-    realm_name: Option<&'a str>,
-    source: Option<&'a str>,
-    username: Option<&'a str>,
+    realm_name: Option<&'b str>,
+    source: Option<&'b str>,
+    username: Option<&'b str>,
 }
-impl<'a> SecurityGetApiKey<'a> {
+impl<'a, 'b> SecurityGetApiKey<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetApiKey]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SecurityGetApiKey {
             client,
             parts: SecurityGetApiKeyParts::None,
@@ -1582,7 +1582,7 @@ impl<'a> SecurityGetApiKey<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1597,12 +1597,12 @@ impl<'a> SecurityGetApiKey<'a> {
         self
     }
     #[doc = "API key id of the API key to be retrieved"]
-    pub fn id(mut self, id: &'a str) -> Self {
+    pub fn id(mut self, id: &'b str) -> Self {
         self.id = Some(id);
         self
     }
     #[doc = "API key name of the API key to be retrieved"]
-    pub fn name(mut self, name: &'a str) -> Self {
+    pub fn name(mut self, name: &'b str) -> Self {
         self.name = Some(name);
         self
     }
@@ -1617,17 +1617,17 @@ impl<'a> SecurityGetApiKey<'a> {
         self
     }
     #[doc = "realm name of the user who created this API key to be retrieved"]
-    pub fn realm_name(mut self, realm_name: &'a str) -> Self {
+    pub fn realm_name(mut self, realm_name: &'b str) -> Self {
         self.realm_name = Some(realm_name);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "user name of the user who created this API key to be retrieved"]
-    pub fn username(mut self, username: &'a str) -> Self {
+    pub fn username(mut self, username: &'b str) -> Self {
         self.username = Some(username);
         self
     }
@@ -1639,30 +1639,30 @@ impl<'a> SecurityGetApiKey<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "id")]
-                id: Option<&'a str>,
+                id: Option<&'b str>,
                 #[serde(rename = "name")]
-                name: Option<&'a str>,
+                name: Option<&'b str>,
                 #[serde(rename = "owner")]
                 owner: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "realm_name")]
-                realm_name: Option<&'a str>,
+                realm_name: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "username")]
-                username: Option<&'a str>,
+                username: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1702,19 +1702,19 @@ impl SecurityGetBuiltinPrivilegesParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Builtin Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html)."]
-pub struct SecurityGetBuiltinPrivileges<'a> {
-    client: Elasticsearch,
+pub struct SecurityGetBuiltinPrivileges<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: SecurityGetBuiltinPrivilegesParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityGetBuiltinPrivileges<'a> {
+impl<'a, 'b> SecurityGetBuiltinPrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetBuiltinPrivileges]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SecurityGetBuiltinPrivileges {
             client,
             parts: SecurityGetBuiltinPrivilegesParts::None,
@@ -1732,7 +1732,7 @@ impl<'a> SecurityGetBuiltinPrivileges<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1752,7 +1752,7 @@ impl<'a> SecurityGetBuiltinPrivileges<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1764,20 +1764,20 @@ impl<'a> SecurityGetBuiltinPrivileges<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1798,15 +1798,15 @@ impl<'a> SecurityGetBuiltinPrivileges<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Get Privileges API"]
-pub enum SecurityGetPrivilegesParts<'a> {
+pub enum SecurityGetPrivilegesParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Application"]
-    Application(&'a str),
+    Application(&'b str),
     #[doc = "Application and Name"]
-    ApplicationName(&'a str, &'a str),
+    ApplicationName(&'b str, &'b str),
 }
-impl<'a> SecurityGetPrivilegesParts<'a> {
+impl<'b> SecurityGetPrivilegesParts<'b> {
     #[doc = "Builds a relative URL path to the Security Get Privileges API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1830,19 +1830,19 @@ impl<'a> SecurityGetPrivilegesParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html)."]
-pub struct SecurityGetPrivileges<'a> {
-    client: Elasticsearch,
-    parts: SecurityGetPrivilegesParts<'a>,
+pub struct SecurityGetPrivileges<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SecurityGetPrivilegesParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityGetPrivileges<'a> {
+impl<'a, 'b> SecurityGetPrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetPrivileges] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityGetPrivilegesParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityGetPrivilegesParts<'b>) -> Self {
         SecurityGetPrivileges {
             client,
             parts,
@@ -1860,7 +1860,7 @@ impl<'a> SecurityGetPrivileges<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1880,7 +1880,7 @@ impl<'a> SecurityGetPrivileges<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1892,20 +1892,20 @@ impl<'a> SecurityGetPrivileges<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1926,13 +1926,13 @@ impl<'a> SecurityGetPrivileges<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Get Role API"]
-pub enum SecurityGetRoleParts<'a> {
+pub enum SecurityGetRoleParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
     #[doc = "No parts"]
     None,
 }
-impl<'a> SecurityGetRoleParts<'a> {
+impl<'b> SecurityGetRoleParts<'b> {
     #[doc = "Builds a relative URL path to the Security Get Role API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1948,19 +1948,19 @@ impl<'a> SecurityGetRoleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Role API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html)."]
-pub struct SecurityGetRole<'a> {
-    client: Elasticsearch,
-    parts: SecurityGetRoleParts<'a>,
+pub struct SecurityGetRole<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SecurityGetRoleParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityGetRole<'a> {
+impl<'a, 'b> SecurityGetRole<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetRole] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityGetRoleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityGetRoleParts<'b>) -> Self {
         SecurityGetRole {
             client,
             parts,
@@ -1978,7 +1978,7 @@ impl<'a> SecurityGetRole<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1998,7 +1998,7 @@ impl<'a> SecurityGetRole<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2010,20 +2010,20 @@ impl<'a> SecurityGetRole<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2044,13 +2044,13 @@ impl<'a> SecurityGetRole<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Get Role Mapping API"]
-pub enum SecurityGetRoleMappingParts<'a> {
+pub enum SecurityGetRoleMappingParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
     #[doc = "No parts"]
     None,
 }
-impl<'a> SecurityGetRoleMappingParts<'a> {
+impl<'b> SecurityGetRoleMappingParts<'b> {
     #[doc = "Builds a relative URL path to the Security Get Role Mapping API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2066,19 +2066,19 @@ impl<'a> SecurityGetRoleMappingParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Role Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html)."]
-pub struct SecurityGetRoleMapping<'a> {
-    client: Elasticsearch,
-    parts: SecurityGetRoleMappingParts<'a>,
+pub struct SecurityGetRoleMapping<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SecurityGetRoleMappingParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityGetRoleMapping<'a> {
+impl<'a, 'b> SecurityGetRoleMapping<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetRoleMapping] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityGetRoleMappingParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityGetRoleMappingParts<'b>) -> Self {
         SecurityGetRoleMapping {
             client,
             parts,
@@ -2096,7 +2096,7 @@ impl<'a> SecurityGetRoleMapping<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2116,7 +2116,7 @@ impl<'a> SecurityGetRoleMapping<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2128,20 +2128,20 @@ impl<'a> SecurityGetRoleMapping<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2176,23 +2176,23 @@ impl SecurityGetTokenParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Token API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html)."]
-pub struct SecurityGetToken<'a, B> {
-    client: Elasticsearch,
+pub struct SecurityGetToken<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SecurityGetTokenParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityGetToken<'a, B>
+impl<'a, 'b, B> SecurityGetToken<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityGetToken]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SecurityGetToken {
             client,
             parts: SecurityGetTokenParts::None,
@@ -2206,7 +2206,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityGetToken<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityGetToken<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2228,7 +2228,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2248,7 +2248,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2260,20 +2260,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2294,13 +2294,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Get User API"]
-pub enum SecurityGetUserParts<'a> {
+pub enum SecurityGetUserParts<'b> {
     #[doc = "Username"]
-    Username(&'a [&'a str]),
+    Username(&'b [&'b str]),
     #[doc = "No parts"]
     None,
 }
-impl<'a> SecurityGetUserParts<'a> {
+impl<'b> SecurityGetUserParts<'b> {
     #[doc = "Builds a relative URL path to the Security Get User API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2317,19 +2317,19 @@ impl<'a> SecurityGetUserParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get User API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html)."]
-pub struct SecurityGetUser<'a> {
-    client: Elasticsearch,
-    parts: SecurityGetUserParts<'a>,
+pub struct SecurityGetUser<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SecurityGetUserParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityGetUser<'a> {
+impl<'a, 'b> SecurityGetUser<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetUser] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityGetUserParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityGetUserParts<'b>) -> Self {
         SecurityGetUser {
             client,
             parts,
@@ -2347,7 +2347,7 @@ impl<'a> SecurityGetUser<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2367,7 +2367,7 @@ impl<'a> SecurityGetUser<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2379,20 +2379,20 @@ impl<'a> SecurityGetUser<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2427,19 +2427,19 @@ impl SecurityGetUserPrivilegesParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get User Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html)."]
-pub struct SecurityGetUserPrivileges<'a> {
-    client: Elasticsearch,
+pub struct SecurityGetUserPrivileges<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: SecurityGetUserPrivilegesParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SecurityGetUserPrivileges<'a> {
+impl<'a, 'b> SecurityGetUserPrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetUserPrivileges]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SecurityGetUserPrivileges {
             client,
             parts: SecurityGetUserPrivilegesParts::None,
@@ -2457,7 +2457,7 @@ impl<'a> SecurityGetUserPrivileges<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2477,7 +2477,7 @@ impl<'a> SecurityGetUserPrivileges<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2489,20 +2489,20 @@ impl<'a> SecurityGetUserPrivileges<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2523,13 +2523,13 @@ impl<'a> SecurityGetUserPrivileges<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Has Privileges API"]
-pub enum SecurityHasPrivilegesParts<'a> {
+pub enum SecurityHasPrivilegesParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "User"]
-    User(&'a str),
+    User(&'b str),
 }
-impl<'a> SecurityHasPrivilegesParts<'a> {
+impl<'b> SecurityHasPrivilegesParts<'b> {
     #[doc = "Builds a relative URL path to the Security Has Privileges API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2546,23 +2546,23 @@ impl<'a> SecurityHasPrivilegesParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Has Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html)."]
-pub struct SecurityHasPrivileges<'a, B> {
-    client: Elasticsearch,
-    parts: SecurityHasPrivilegesParts<'a>,
+pub struct SecurityHasPrivileges<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SecurityHasPrivilegesParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityHasPrivileges<'a, B>
+impl<'a, 'b, B> SecurityHasPrivileges<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityHasPrivileges] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityHasPrivilegesParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityHasPrivilegesParts<'b>) -> Self {
         SecurityHasPrivileges {
             client,
             parts,
@@ -2576,7 +2576,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityHasPrivileges<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityHasPrivileges<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2598,7 +2598,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2618,7 +2618,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2633,20 +2633,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2681,23 +2681,23 @@ impl SecurityInvalidateApiKeyParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Invalidate Api Key API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html)."]
-pub struct SecurityInvalidateApiKey<'a, B> {
-    client: Elasticsearch,
+pub struct SecurityInvalidateApiKey<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SecurityInvalidateApiKeyParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityInvalidateApiKey<'a, B>
+impl<'a, 'b, B> SecurityInvalidateApiKey<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityInvalidateApiKey]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SecurityInvalidateApiKey {
             client,
             parts: SecurityInvalidateApiKeyParts::None,
@@ -2711,7 +2711,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityInvalidateApiKey<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityInvalidateApiKey<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2733,7 +2733,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2753,7 +2753,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2765,20 +2765,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2813,23 +2813,23 @@ impl SecurityInvalidateTokenParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Invalidate Token API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html)."]
-pub struct SecurityInvalidateToken<'a, B> {
-    client: Elasticsearch,
+pub struct SecurityInvalidateToken<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SecurityInvalidateTokenParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityInvalidateToken<'a, B>
+impl<'a, 'b, B> SecurityInvalidateToken<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityInvalidateToken]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SecurityInvalidateToken {
             client,
             parts: SecurityInvalidateTokenParts::None,
@@ -2843,7 +2843,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityInvalidateToken<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityInvalidateToken<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2865,7 +2865,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2885,7 +2885,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2897,20 +2897,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -2945,24 +2945,24 @@ impl SecurityPutPrivilegesParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Security Put Privileges API"]
-pub struct SecurityPutPrivileges<'a, B> {
-    client: Elasticsearch,
+pub struct SecurityPutPrivileges<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SecurityPutPrivilegesParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityPutPrivileges<'a, B>
+impl<'a, 'b, B> SecurityPutPrivileges<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityPutPrivileges]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SecurityPutPrivileges {
             client,
             parts: SecurityPutPrivilegesParts::None,
@@ -2977,7 +2977,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityPutPrivileges<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityPutPrivileges<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -3000,7 +3000,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3025,7 +3025,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3037,14 +3037,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -3052,7 +3052,7 @@ where
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -3074,11 +3074,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Put Role API"]
-pub enum SecurityPutRoleParts<'a> {
+pub enum SecurityPutRoleParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> SecurityPutRoleParts<'a> {
+impl<'b> SecurityPutRoleParts<'b> {
     #[doc = "Builds a relative URL path to the Security Put Role API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3093,24 +3093,24 @@ impl<'a> SecurityPutRoleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Put Role API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html)."]
-pub struct SecurityPutRole<'a, B> {
-    client: Elasticsearch,
-    parts: SecurityPutRoleParts<'a>,
+pub struct SecurityPutRole<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SecurityPutRoleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityPutRole<'a, B>
+impl<'a, 'b, B> SecurityPutRole<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityPutRole] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityPutRoleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityPutRoleParts<'b>) -> Self {
         SecurityPutRole {
             client,
             parts,
@@ -3125,7 +3125,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityPutRole<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityPutRole<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -3148,7 +3148,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3173,7 +3173,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3185,14 +3185,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -3200,7 +3200,7 @@ where
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -3222,11 +3222,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Put Role Mapping API"]
-pub enum SecurityPutRoleMappingParts<'a> {
+pub enum SecurityPutRoleMappingParts<'b> {
     #[doc = "Name"]
-    Name(&'a str),
+    Name(&'b str),
 }
-impl<'a> SecurityPutRoleMappingParts<'a> {
+impl<'b> SecurityPutRoleMappingParts<'b> {
     #[doc = "Builds a relative URL path to the Security Put Role Mapping API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3241,24 +3241,24 @@ impl<'a> SecurityPutRoleMappingParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Put Role Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html)."]
-pub struct SecurityPutRoleMapping<'a, B> {
-    client: Elasticsearch,
-    parts: SecurityPutRoleMappingParts<'a>,
+pub struct SecurityPutRoleMapping<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SecurityPutRoleMappingParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityPutRoleMapping<'a, B>
+impl<'a, 'b, B> SecurityPutRoleMapping<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityPutRoleMapping] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityPutRoleMappingParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityPutRoleMappingParts<'b>) -> Self {
         SecurityPutRoleMapping {
             client,
             parts,
@@ -3273,7 +3273,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityPutRoleMapping<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityPutRoleMapping<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -3296,7 +3296,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3321,7 +3321,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3333,14 +3333,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -3348,7 +3348,7 @@ where
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -3370,11 +3370,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Security Put User API"]
-pub enum SecurityPutUserParts<'a> {
+pub enum SecurityPutUserParts<'b> {
     #[doc = "Username"]
-    Username(&'a str),
+    Username(&'b str),
 }
-impl<'a> SecurityPutUserParts<'a> {
+impl<'b> SecurityPutUserParts<'b> {
     #[doc = "Builds a relative URL path to the Security Put User API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3389,24 +3389,24 @@ impl<'a> SecurityPutUserParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Put User API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html)."]
-pub struct SecurityPutUser<'a, B> {
-    client: Elasticsearch,
-    parts: SecurityPutUserParts<'a>,
+pub struct SecurityPutUser<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SecurityPutUserParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SecurityPutUser<'a, B>
+impl<'a, 'b, B> SecurityPutUser<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityPutUser] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SecurityPutUserParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SecurityPutUserParts<'b>) -> Self {
         SecurityPutUser {
             client,
             parts,
@@ -3421,7 +3421,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SecurityPutUser<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SecurityPutUser<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -3444,7 +3444,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3469,7 +3469,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3481,14 +3481,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -3496,7 +3496,7 @@ where
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -3517,129 +3517,135 @@ where
     }
 }
 #[doc = "Namespace client for Security APIs"]
-pub struct Security {
-    client: Elasticsearch,
+pub struct Security<'a> {
+    client: &'a Elasticsearch,
 }
-impl Security {
+impl<'a> Security<'a> {
     #[doc = "Creates a new instance of [Security]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn authenticate<'a>(&self) -> SecurityAuthenticate<'a> {
-        SecurityAuthenticate::new(self.client.clone())
+    pub fn authenticate<'b>(&'a self) -> SecurityAuthenticate<'a, 'b> {
+        SecurityAuthenticate::new(&self.client)
     }
-    pub fn change_password<'a>(
-        &self,
-        parts: SecurityChangePasswordParts<'a>,
-    ) -> SecurityChangePassword<'a, ()> {
-        SecurityChangePassword::new(self.client.clone(), parts)
+    pub fn change_password<'b>(
+        &'a self,
+        parts: SecurityChangePasswordParts<'b>,
+    ) -> SecurityChangePassword<'a, 'b, ()> {
+        SecurityChangePassword::new(&self.client, parts)
     }
-    pub fn clear_cached_realms<'a>(
-        &self,
-        parts: SecurityClearCachedRealmsParts<'a>,
-    ) -> SecurityClearCachedRealms<'a, ()> {
-        SecurityClearCachedRealms::new(self.client.clone(), parts)
+    pub fn clear_cached_realms<'b>(
+        &'a self,
+        parts: SecurityClearCachedRealmsParts<'b>,
+    ) -> SecurityClearCachedRealms<'a, 'b, ()> {
+        SecurityClearCachedRealms::new(&self.client, parts)
     }
-    pub fn clear_cached_roles<'a>(
-        &self,
-        parts: SecurityClearCachedRolesParts<'a>,
-    ) -> SecurityClearCachedRoles<'a, ()> {
-        SecurityClearCachedRoles::new(self.client.clone(), parts)
+    pub fn clear_cached_roles<'b>(
+        &'a self,
+        parts: SecurityClearCachedRolesParts<'b>,
+    ) -> SecurityClearCachedRoles<'a, 'b, ()> {
+        SecurityClearCachedRoles::new(&self.client, parts)
     }
-    pub fn create_api_key<'a>(&self) -> SecurityCreateApiKey<'a, ()> {
-        SecurityCreateApiKey::new(self.client.clone())
+    pub fn create_api_key<'b>(&'a self) -> SecurityCreateApiKey<'a, 'b, ()> {
+        SecurityCreateApiKey::new(&self.client)
     }
-    pub fn delete_privileges<'a>(
-        &self,
-        parts: SecurityDeletePrivilegesParts<'a>,
-    ) -> SecurityDeletePrivileges<'a> {
-        SecurityDeletePrivileges::new(self.client.clone(), parts)
+    pub fn delete_privileges<'b>(
+        &'a self,
+        parts: SecurityDeletePrivilegesParts<'b>,
+    ) -> SecurityDeletePrivileges<'a, 'b> {
+        SecurityDeletePrivileges::new(&self.client, parts)
     }
-    pub fn delete_role<'a>(&self, parts: SecurityDeleteRoleParts<'a>) -> SecurityDeleteRole<'a> {
-        SecurityDeleteRole::new(self.client.clone(), parts)
+    pub fn delete_role<'b>(
+        &'a self,
+        parts: SecurityDeleteRoleParts<'b>,
+    ) -> SecurityDeleteRole<'a, 'b> {
+        SecurityDeleteRole::new(&self.client, parts)
     }
-    pub fn delete_role_mapping<'a>(
-        &self,
-        parts: SecurityDeleteRoleMappingParts<'a>,
-    ) -> SecurityDeleteRoleMapping<'a> {
-        SecurityDeleteRoleMapping::new(self.client.clone(), parts)
+    pub fn delete_role_mapping<'b>(
+        &'a self,
+        parts: SecurityDeleteRoleMappingParts<'b>,
+    ) -> SecurityDeleteRoleMapping<'a, 'b> {
+        SecurityDeleteRoleMapping::new(&self.client, parts)
     }
-    pub fn delete_user<'a>(&self, parts: SecurityDeleteUserParts<'a>) -> SecurityDeleteUser<'a> {
-        SecurityDeleteUser::new(self.client.clone(), parts)
+    pub fn delete_user<'b>(
+        &'a self,
+        parts: SecurityDeleteUserParts<'b>,
+    ) -> SecurityDeleteUser<'a, 'b> {
+        SecurityDeleteUser::new(&self.client, parts)
     }
-    pub fn disable_user<'a>(
-        &self,
-        parts: SecurityDisableUserParts<'a>,
-    ) -> SecurityDisableUser<'a, ()> {
-        SecurityDisableUser::new(self.client.clone(), parts)
+    pub fn disable_user<'b>(
+        &'a self,
+        parts: SecurityDisableUserParts<'b>,
+    ) -> SecurityDisableUser<'a, 'b, ()> {
+        SecurityDisableUser::new(&self.client, parts)
     }
-    pub fn enable_user<'a>(
-        &self,
-        parts: SecurityEnableUserParts<'a>,
-    ) -> SecurityEnableUser<'a, ()> {
-        SecurityEnableUser::new(self.client.clone(), parts)
+    pub fn enable_user<'b>(
+        &'a self,
+        parts: SecurityEnableUserParts<'b>,
+    ) -> SecurityEnableUser<'a, 'b, ()> {
+        SecurityEnableUser::new(&self.client, parts)
     }
-    pub fn get_api_key<'a>(&self) -> SecurityGetApiKey<'a> {
-        SecurityGetApiKey::new(self.client.clone())
+    pub fn get_api_key<'b>(&'a self) -> SecurityGetApiKey<'a, 'b> {
+        SecurityGetApiKey::new(&self.client)
     }
-    pub fn get_builtin_privileges<'a>(&self) -> SecurityGetBuiltinPrivileges<'a> {
-        SecurityGetBuiltinPrivileges::new(self.client.clone())
+    pub fn get_builtin_privileges<'b>(&'a self) -> SecurityGetBuiltinPrivileges<'a, 'b> {
+        SecurityGetBuiltinPrivileges::new(&self.client)
     }
-    pub fn get_privileges<'a>(
-        &self,
-        parts: SecurityGetPrivilegesParts<'a>,
-    ) -> SecurityGetPrivileges<'a> {
-        SecurityGetPrivileges::new(self.client.clone(), parts)
+    pub fn get_privileges<'b>(
+        &'a self,
+        parts: SecurityGetPrivilegesParts<'b>,
+    ) -> SecurityGetPrivileges<'a, 'b> {
+        SecurityGetPrivileges::new(&self.client, parts)
     }
-    pub fn get_role<'a>(&self, parts: SecurityGetRoleParts<'a>) -> SecurityGetRole<'a> {
-        SecurityGetRole::new(self.client.clone(), parts)
+    pub fn get_role<'b>(&'a self, parts: SecurityGetRoleParts<'b>) -> SecurityGetRole<'a, 'b> {
+        SecurityGetRole::new(&self.client, parts)
     }
-    pub fn get_role_mapping<'a>(
-        &self,
-        parts: SecurityGetRoleMappingParts<'a>,
-    ) -> SecurityGetRoleMapping<'a> {
-        SecurityGetRoleMapping::new(self.client.clone(), parts)
+    pub fn get_role_mapping<'b>(
+        &'a self,
+        parts: SecurityGetRoleMappingParts<'b>,
+    ) -> SecurityGetRoleMapping<'a, 'b> {
+        SecurityGetRoleMapping::new(&self.client, parts)
     }
-    pub fn get_token<'a>(&self) -> SecurityGetToken<'a, ()> {
-        SecurityGetToken::new(self.client.clone())
+    pub fn get_token<'b>(&'a self) -> SecurityGetToken<'a, 'b, ()> {
+        SecurityGetToken::new(&self.client)
     }
-    pub fn get_user<'a>(&self, parts: SecurityGetUserParts<'a>) -> SecurityGetUser<'a> {
-        SecurityGetUser::new(self.client.clone(), parts)
+    pub fn get_user<'b>(&'a self, parts: SecurityGetUserParts<'b>) -> SecurityGetUser<'a, 'b> {
+        SecurityGetUser::new(&self.client, parts)
     }
-    pub fn get_user_privileges<'a>(&self) -> SecurityGetUserPrivileges<'a> {
-        SecurityGetUserPrivileges::new(self.client.clone())
+    pub fn get_user_privileges<'b>(&'a self) -> SecurityGetUserPrivileges<'a, 'b> {
+        SecurityGetUserPrivileges::new(&self.client)
     }
-    pub fn has_privileges<'a>(
-        &self,
-        parts: SecurityHasPrivilegesParts<'a>,
-    ) -> SecurityHasPrivileges<'a, ()> {
-        SecurityHasPrivileges::new(self.client.clone(), parts)
+    pub fn has_privileges<'b>(
+        &'a self,
+        parts: SecurityHasPrivilegesParts<'b>,
+    ) -> SecurityHasPrivileges<'a, 'b, ()> {
+        SecurityHasPrivileges::new(&self.client, parts)
     }
-    pub fn invalidate_api_key<'a>(&self) -> SecurityInvalidateApiKey<'a, ()> {
-        SecurityInvalidateApiKey::new(self.client.clone())
+    pub fn invalidate_api_key<'b>(&'a self) -> SecurityInvalidateApiKey<'a, 'b, ()> {
+        SecurityInvalidateApiKey::new(&self.client)
     }
-    pub fn invalidate_token<'a>(&self) -> SecurityInvalidateToken<'a, ()> {
-        SecurityInvalidateToken::new(self.client.clone())
+    pub fn invalidate_token<'b>(&'a self) -> SecurityInvalidateToken<'a, 'b, ()> {
+        SecurityInvalidateToken::new(&self.client)
     }
-    pub fn put_privileges<'a>(&self) -> SecurityPutPrivileges<'a, ()> {
-        SecurityPutPrivileges::new(self.client.clone())
+    pub fn put_privileges<'b>(&'a self) -> SecurityPutPrivileges<'a, 'b, ()> {
+        SecurityPutPrivileges::new(&self.client)
     }
-    pub fn put_role<'a>(&self, parts: SecurityPutRoleParts<'a>) -> SecurityPutRole<'a, ()> {
-        SecurityPutRole::new(self.client.clone(), parts)
+    pub fn put_role<'b>(&'a self, parts: SecurityPutRoleParts<'b>) -> SecurityPutRole<'a, 'b, ()> {
+        SecurityPutRole::new(&self.client, parts)
     }
-    pub fn put_role_mapping<'a>(
-        &self,
-        parts: SecurityPutRoleMappingParts<'a>,
-    ) -> SecurityPutRoleMapping<'a, ()> {
-        SecurityPutRoleMapping::new(self.client.clone(), parts)
+    pub fn put_role_mapping<'b>(
+        &'a self,
+        parts: SecurityPutRoleMappingParts<'b>,
+    ) -> SecurityPutRoleMapping<'a, 'b, ()> {
+        SecurityPutRoleMapping::new(&self.client, parts)
     }
-    pub fn put_user<'a>(&self, parts: SecurityPutUserParts<'a>) -> SecurityPutUser<'a, ()> {
-        SecurityPutUser::new(self.client.clone(), parts)
+    pub fn put_user<'b>(&'a self, parts: SecurityPutUserParts<'b>) -> SecurityPutUser<'a, 'b, ()> {
+        SecurityPutUser::new(&self.client, parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Security APIs"]
     pub fn security(&self) -> Security {
-        Security::new(self.clone())
+        Security::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/slm.rs
+++ b/elasticsearch/src/generated/namespace_clients/slm.rs
@@ -31,11 +31,11 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Slm Delete Lifecycle API"]
-pub enum SlmDeleteLifecycleParts<'a> {
+pub enum SlmDeleteLifecycleParts<'b> {
     #[doc = "PolicyId"]
-    PolicyId(&'a str),
+    PolicyId(&'b str),
 }
-impl<'a> SlmDeleteLifecycleParts<'a> {
+impl<'b> SlmDeleteLifecycleParts<'b> {
     #[doc = "Builds a relative URL path to the Slm Delete Lifecycle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -50,19 +50,19 @@ impl<'a> SlmDeleteLifecycleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Delete Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete.html)."]
-pub struct SlmDeleteLifecycle<'a> {
-    client: Elasticsearch,
-    parts: SlmDeleteLifecycleParts<'a>,
+pub struct SlmDeleteLifecycle<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SlmDeleteLifecycleParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SlmDeleteLifecycle<'a> {
+impl<'a, 'b> SlmDeleteLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [SlmDeleteLifecycle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SlmDeleteLifecycleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SlmDeleteLifecycleParts<'b>) -> Self {
         SlmDeleteLifecycle {
             client,
             parts,
@@ -80,7 +80,7 @@ impl<'a> SlmDeleteLifecycle<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -100,7 +100,7 @@ impl<'a> SlmDeleteLifecycle<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -112,20 +112,20 @@ impl<'a> SlmDeleteLifecycle<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -146,11 +146,11 @@ impl<'a> SlmDeleteLifecycle<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Slm Execute Lifecycle API"]
-pub enum SlmExecuteLifecycleParts<'a> {
+pub enum SlmExecuteLifecycleParts<'b> {
     #[doc = "PolicyId"]
-    PolicyId(&'a str),
+    PolicyId(&'b str),
 }
-impl<'a> SlmExecuteLifecycleParts<'a> {
+impl<'b> SlmExecuteLifecycleParts<'b> {
     #[doc = "Builds a relative URL path to the Slm Execute Lifecycle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -166,23 +166,23 @@ impl<'a> SlmExecuteLifecycleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Execute Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html)."]
-pub struct SlmExecuteLifecycle<'a, B> {
-    client: Elasticsearch,
-    parts: SlmExecuteLifecycleParts<'a>,
+pub struct SlmExecuteLifecycle<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SlmExecuteLifecycleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SlmExecuteLifecycle<'a, B>
+impl<'a, 'b, B> SlmExecuteLifecycle<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SlmExecuteLifecycle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SlmExecuteLifecycleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SlmExecuteLifecycleParts<'b>) -> Self {
         SlmExecuteLifecycle {
             client,
             parts,
@@ -196,7 +196,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SlmExecuteLifecycle<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SlmExecuteLifecycle<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -218,7 +218,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -238,7 +238,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -250,20 +250,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -298,23 +298,23 @@ impl SlmExecuteRetentionParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Execute Retention API](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute-retention.html)."]
-pub struct SlmExecuteRetention<'a, B> {
-    client: Elasticsearch,
+pub struct SlmExecuteRetention<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SlmExecuteRetentionParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SlmExecuteRetention<'a, B>
+impl<'a, 'b, B> SlmExecuteRetention<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SlmExecuteRetention]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SlmExecuteRetention {
             client,
             parts: SlmExecuteRetentionParts::None,
@@ -328,7 +328,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SlmExecuteRetention<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SlmExecuteRetention<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -350,7 +350,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -370,7 +370,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -382,20 +382,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -416,13 +416,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Slm Get Lifecycle API"]
-pub enum SlmGetLifecycleParts<'a> {
+pub enum SlmGetLifecycleParts<'b> {
     #[doc = "PolicyId"]
-    PolicyId(&'a [&'a str]),
+    PolicyId(&'b [&'b str]),
     #[doc = "No parts"]
     None,
 }
-impl<'a> SlmGetLifecycleParts<'a> {
+impl<'b> SlmGetLifecycleParts<'b> {
     #[doc = "Builds a relative URL path to the Slm Get Lifecycle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -439,19 +439,19 @@ impl<'a> SlmGetLifecycleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Get Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get.html)."]
-pub struct SlmGetLifecycle<'a> {
-    client: Elasticsearch,
-    parts: SlmGetLifecycleParts<'a>,
+pub struct SlmGetLifecycle<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SlmGetLifecycleParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SlmGetLifecycle<'a> {
+impl<'a, 'b> SlmGetLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [SlmGetLifecycle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SlmGetLifecycleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SlmGetLifecycleParts<'b>) -> Self {
         SlmGetLifecycle {
             client,
             parts,
@@ -469,7 +469,7 @@ impl<'a> SlmGetLifecycle<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -489,7 +489,7 @@ impl<'a> SlmGetLifecycle<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -501,20 +501,20 @@ impl<'a> SlmGetLifecycle<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -549,19 +549,19 @@ impl SlmGetStatsParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Get Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-get-stats.html)."]
-pub struct SlmGetStats<'a> {
-    client: Elasticsearch,
+pub struct SlmGetStats<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: SlmGetStatsParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SlmGetStats<'a> {
+impl<'a, 'b> SlmGetStats<'a, 'b> {
     #[doc = "Creates a new instance of [SlmGetStats]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SlmGetStats {
             client,
             parts: SlmGetStatsParts::None,
@@ -579,7 +579,7 @@ impl<'a> SlmGetStats<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -599,7 +599,7 @@ impl<'a> SlmGetStats<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -611,20 +611,20 @@ impl<'a> SlmGetStats<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -659,19 +659,19 @@ impl SlmGetStatusParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Get Status API](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html)."]
-pub struct SlmGetStatus<'a> {
-    client: Elasticsearch,
+pub struct SlmGetStatus<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: SlmGetStatusParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SlmGetStatus<'a> {
+impl<'a, 'b> SlmGetStatus<'a, 'b> {
     #[doc = "Creates a new instance of [SlmGetStatus]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SlmGetStatus {
             client,
             parts: SlmGetStatusParts::None,
@@ -689,7 +689,7 @@ impl<'a> SlmGetStatus<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -709,7 +709,7 @@ impl<'a> SlmGetStatus<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -721,20 +721,20 @@ impl<'a> SlmGetStatus<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -755,11 +755,11 @@ impl<'a> SlmGetStatus<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Slm Put Lifecycle API"]
-pub enum SlmPutLifecycleParts<'a> {
+pub enum SlmPutLifecycleParts<'b> {
     #[doc = "PolicyId"]
-    PolicyId(&'a str),
+    PolicyId(&'b str),
 }
-impl<'a> SlmPutLifecycleParts<'a> {
+impl<'b> SlmPutLifecycleParts<'b> {
     #[doc = "Builds a relative URL path to the Slm Put Lifecycle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -774,23 +774,23 @@ impl<'a> SlmPutLifecycleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Put Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-put.html)."]
-pub struct SlmPutLifecycle<'a, B> {
-    client: Elasticsearch,
-    parts: SlmPutLifecycleParts<'a>,
+pub struct SlmPutLifecycle<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SlmPutLifecycleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SlmPutLifecycle<'a, B>
+impl<'a, 'b, B> SlmPutLifecycle<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SlmPutLifecycle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SlmPutLifecycleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SlmPutLifecycleParts<'b>) -> Self {
         SlmPutLifecycle {
             client,
             parts,
@@ -804,7 +804,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SlmPutLifecycle<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SlmPutLifecycle<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -826,7 +826,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -846,7 +846,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -858,20 +858,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -906,23 +906,23 @@ impl SlmStartParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Start API](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html)."]
-pub struct SlmStart<'a, B> {
-    client: Elasticsearch,
+pub struct SlmStart<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SlmStartParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SlmStart<'a, B>
+impl<'a, 'b, B> SlmStart<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SlmStart]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SlmStart {
             client,
             parts: SlmStartParts::None,
@@ -936,7 +936,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SlmStart<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SlmStart<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -958,7 +958,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -978,7 +978,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -990,20 +990,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1038,23 +1038,23 @@ impl SlmStopParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Stop API](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html)."]
-pub struct SlmStop<'a, B> {
-    client: Elasticsearch,
+pub struct SlmStop<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SlmStopParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SlmStop<'a, B>
+impl<'a, 'b, B> SlmStop<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SlmStop]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SlmStop {
             client,
             parts: SlmStopParts::None,
@@ -1068,7 +1068,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SlmStop<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SlmStop<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1090,7 +1090,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1110,7 +1110,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1122,20 +1122,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1155,51 +1155,54 @@ where
     }
 }
 #[doc = "Namespace client for Snapshot Lifecycle Management APIs"]
-pub struct Slm {
-    client: Elasticsearch,
+pub struct Slm<'a> {
+    client: &'a Elasticsearch,
 }
-impl Slm {
+impl<'a> Slm<'a> {
     #[doc = "Creates a new instance of [Slm]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn delete_lifecycle<'a>(
-        &self,
-        parts: SlmDeleteLifecycleParts<'a>,
-    ) -> SlmDeleteLifecycle<'a> {
-        SlmDeleteLifecycle::new(self.client.clone(), parts)
+    pub fn delete_lifecycle<'b>(
+        &'a self,
+        parts: SlmDeleteLifecycleParts<'b>,
+    ) -> SlmDeleteLifecycle<'a, 'b> {
+        SlmDeleteLifecycle::new(&self.client, parts)
     }
-    pub fn execute_lifecycle<'a>(
-        &self,
-        parts: SlmExecuteLifecycleParts<'a>,
-    ) -> SlmExecuteLifecycle<'a, ()> {
-        SlmExecuteLifecycle::new(self.client.clone(), parts)
+    pub fn execute_lifecycle<'b>(
+        &'a self,
+        parts: SlmExecuteLifecycleParts<'b>,
+    ) -> SlmExecuteLifecycle<'a, 'b, ()> {
+        SlmExecuteLifecycle::new(&self.client, parts)
     }
-    pub fn execute_retention<'a>(&self) -> SlmExecuteRetention<'a, ()> {
-        SlmExecuteRetention::new(self.client.clone())
+    pub fn execute_retention<'b>(&'a self) -> SlmExecuteRetention<'a, 'b, ()> {
+        SlmExecuteRetention::new(&self.client)
     }
-    pub fn get_lifecycle<'a>(&self, parts: SlmGetLifecycleParts<'a>) -> SlmGetLifecycle<'a> {
-        SlmGetLifecycle::new(self.client.clone(), parts)
+    pub fn get_lifecycle<'b>(&'a self, parts: SlmGetLifecycleParts<'b>) -> SlmGetLifecycle<'a, 'b> {
+        SlmGetLifecycle::new(&self.client, parts)
     }
-    pub fn get_stats<'a>(&self) -> SlmGetStats<'a> {
-        SlmGetStats::new(self.client.clone())
+    pub fn get_stats<'b>(&'a self) -> SlmGetStats<'a, 'b> {
+        SlmGetStats::new(&self.client)
     }
-    pub fn get_status<'a>(&self) -> SlmGetStatus<'a> {
-        SlmGetStatus::new(self.client.clone())
+    pub fn get_status<'b>(&'a self) -> SlmGetStatus<'a, 'b> {
+        SlmGetStatus::new(&self.client)
     }
-    pub fn put_lifecycle<'a>(&self, parts: SlmPutLifecycleParts<'a>) -> SlmPutLifecycle<'a, ()> {
-        SlmPutLifecycle::new(self.client.clone(), parts)
+    pub fn put_lifecycle<'b>(
+        &'a self,
+        parts: SlmPutLifecycleParts<'b>,
+    ) -> SlmPutLifecycle<'a, 'b, ()> {
+        SlmPutLifecycle::new(&self.client, parts)
     }
-    pub fn start<'a>(&self) -> SlmStart<'a, ()> {
-        SlmStart::new(self.client.clone())
+    pub fn start<'b>(&'a self) -> SlmStart<'a, 'b, ()> {
+        SlmStart::new(&self.client)
     }
-    pub fn stop<'a>(&self) -> SlmStop<'a, ()> {
-        SlmStop::new(self.client.clone())
+    pub fn stop<'b>(&'a self) -> SlmStop<'a, 'b, ()> {
+        SlmStop::new(&self.client)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Snapshot Lifecycle Management APIs"]
     pub fn slm(&self) -> Slm {
-        Slm::new(self.clone())
+        Slm::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/snapshot.rs
+++ b/elasticsearch/src/generated/namespace_clients/snapshot.rs
@@ -31,11 +31,11 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Snapshot Cleanup Repository API"]
-pub enum SnapshotCleanupRepositoryParts<'a> {
+pub enum SnapshotCleanupRepositoryParts<'b> {
     #[doc = "Repository"]
-    Repository(&'a str),
+    Repository(&'b str),
 }
-impl<'a> SnapshotCleanupRepositoryParts<'a> {
+impl<'b> SnapshotCleanupRepositoryParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Cleanup Repository API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -51,25 +51,25 @@ impl<'a> SnapshotCleanupRepositoryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Cleanup Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html). Removes stale data from repository."]
-pub struct SnapshotCleanupRepository<'a, B> {
-    client: Elasticsearch,
-    parts: SnapshotCleanupRepositoryParts<'a>,
+pub struct SnapshotCleanupRepository<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SnapshotCleanupRepositoryParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> SnapshotCleanupRepository<'a, B>
+impl<'a, 'b, B> SnapshotCleanupRepository<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SnapshotCleanupRepository] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SnapshotCleanupRepositoryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SnapshotCleanupRepositoryParts<'b>) -> Self {
         SnapshotCleanupRepository {
             client,
             parts,
@@ -85,7 +85,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SnapshotCleanupRepository<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SnapshotCleanupRepository<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -109,7 +109,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -124,7 +124,7 @@ where
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -134,12 +134,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -151,24 +151,24 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -191,11 +191,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Snapshot Create API"]
-pub enum SnapshotCreateParts<'a> {
+pub enum SnapshotCreateParts<'b> {
     #[doc = "Repository and Snapshot"]
-    RepositorySnapshot(&'a str, &'a str),
+    RepositorySnapshot(&'b str, &'b str),
 }
-impl<'a> SnapshotCreateParts<'a> {
+impl<'b> SnapshotCreateParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Create API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -212,25 +212,25 @@ impl<'a> SnapshotCreateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Create API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html). Creates a snapshot in a repository."]
-pub struct SnapshotCreate<'a, B> {
-    client: Elasticsearch,
-    parts: SnapshotCreateParts<'a>,
+pub struct SnapshotCreate<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SnapshotCreateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     wait_for_completion: Option<bool>,
 }
-impl<'a, B> SnapshotCreate<'a, B>
+impl<'a, 'b, B> SnapshotCreate<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SnapshotCreate] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SnapshotCreateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SnapshotCreateParts<'b>) -> Self {
         SnapshotCreate {
             client,
             parts,
@@ -246,7 +246,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SnapshotCreate<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SnapshotCreate<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -270,7 +270,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -285,7 +285,7 @@ where
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -295,7 +295,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -312,22 +312,22 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "wait_for_completion")]
                 wait_for_completion: Option<bool>,
             }
@@ -352,11 +352,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Snapshot Create Repository API"]
-pub enum SnapshotCreateRepositoryParts<'a> {
+pub enum SnapshotCreateRepositoryParts<'b> {
     #[doc = "Repository"]
-    Repository(&'a str),
+    Repository(&'b str),
 }
-impl<'a> SnapshotCreateRepositoryParts<'a> {
+impl<'b> SnapshotCreateRepositoryParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Create Repository API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -371,26 +371,26 @@ impl<'a> SnapshotCreateRepositoryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Create Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html). Creates a repository."]
-pub struct SnapshotCreateRepository<'a, B> {
-    client: Elasticsearch,
-    parts: SnapshotCreateRepositoryParts<'a>,
+pub struct SnapshotCreateRepository<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SnapshotCreateRepositoryParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
     verify: Option<bool>,
 }
-impl<'a, B> SnapshotCreateRepository<'a, B>
+impl<'a, 'b, B> SnapshotCreateRepository<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SnapshotCreateRepository] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SnapshotCreateRepositoryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SnapshotCreateRepositoryParts<'b>) -> Self {
         SnapshotCreateRepository {
             client,
             parts,
@@ -407,7 +407,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SnapshotCreateRepository<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SnapshotCreateRepository<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -432,7 +432,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -447,7 +447,7 @@ where
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -457,12 +457,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -479,24 +479,24 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "verify")]
                 verify: Option<bool>,
             }
@@ -522,11 +522,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Snapshot Delete API"]
-pub enum SnapshotDeleteParts<'a> {
+pub enum SnapshotDeleteParts<'b> {
     #[doc = "Repository and Snapshot"]
-    RepositorySnapshot(&'a str, &'a str),
+    RepositorySnapshot(&'b str, &'b str),
 }
-impl<'a> SnapshotDeleteParts<'a> {
+impl<'b> SnapshotDeleteParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Delete API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -543,20 +543,20 @@ impl<'a> SnapshotDeleteParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html). Deletes a snapshot."]
-pub struct SnapshotDelete<'a> {
-    client: Elasticsearch,
-    parts: SnapshotDeleteParts<'a>,
+pub struct SnapshotDelete<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SnapshotDeleteParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SnapshotDelete<'a> {
+impl<'a, 'b> SnapshotDelete<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotDelete] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SnapshotDeleteParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SnapshotDeleteParts<'b>) -> Self {
         SnapshotDelete {
             client,
             parts,
@@ -575,7 +575,7 @@ impl<'a> SnapshotDelete<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -590,7 +590,7 @@ impl<'a> SnapshotDelete<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -600,7 +600,7 @@ impl<'a> SnapshotDelete<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -612,22 +612,22 @@ impl<'a> SnapshotDelete<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -649,11 +649,11 @@ impl<'a> SnapshotDelete<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Snapshot Delete Repository API"]
-pub enum SnapshotDeleteRepositoryParts<'a> {
+pub enum SnapshotDeleteRepositoryParts<'b> {
     #[doc = "Repository"]
-    Repository(&'a [&'a str]),
+    Repository(&'b [&'b str]),
 }
-impl<'a> SnapshotDeleteRepositoryParts<'a> {
+impl<'b> SnapshotDeleteRepositoryParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Delete Repository API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -669,21 +669,21 @@ impl<'a> SnapshotDeleteRepositoryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Delete Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html). Deletes a repository."]
-pub struct SnapshotDeleteRepository<'a> {
-    client: Elasticsearch,
-    parts: SnapshotDeleteRepositoryParts<'a>,
+pub struct SnapshotDeleteRepository<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SnapshotDeleteRepositoryParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> SnapshotDeleteRepository<'a> {
+impl<'a, 'b> SnapshotDeleteRepository<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotDeleteRepository] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SnapshotDeleteRepositoryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SnapshotDeleteRepositoryParts<'b>) -> Self {
         SnapshotDeleteRepository {
             client,
             parts,
@@ -703,7 +703,7 @@ impl<'a> SnapshotDeleteRepository<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -718,7 +718,7 @@ impl<'a> SnapshotDeleteRepository<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -728,12 +728,12 @@ impl<'a> SnapshotDeleteRepository<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -745,24 +745,24 @@ impl<'a> SnapshotDeleteRepository<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -785,11 +785,11 @@ impl<'a> SnapshotDeleteRepository<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Snapshot Get API"]
-pub enum SnapshotGetParts<'a> {
+pub enum SnapshotGetParts<'b> {
     #[doc = "Repository and Snapshot"]
-    RepositorySnapshot(&'a str, &'a [&'a str]),
+    RepositorySnapshot(&'b str, &'b [&'b str]),
 }
-impl<'a> SnapshotGetParts<'a> {
+impl<'b> SnapshotGetParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Get API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -807,22 +807,22 @@ impl<'a> SnapshotGetParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Get API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html). Returns information about a snapshot."]
-pub struct SnapshotGet<'a> {
-    client: Elasticsearch,
-    parts: SnapshotGetParts<'a>,
+pub struct SnapshotGet<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SnapshotGetParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     verbose: Option<bool>,
 }
-impl<'a> SnapshotGet<'a> {
+impl<'a, 'b> SnapshotGet<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotGet] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SnapshotGetParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SnapshotGetParts<'b>) -> Self {
         SnapshotGet {
             client,
             parts,
@@ -843,7 +843,7 @@ impl<'a> SnapshotGet<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -863,7 +863,7 @@ impl<'a> SnapshotGet<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -873,7 +873,7 @@ impl<'a> SnapshotGet<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -890,24 +890,24 @@ impl<'a> SnapshotGet<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "verbose")]
                 verbose: Option<bool>,
             }
@@ -933,13 +933,13 @@ impl<'a> SnapshotGet<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Snapshot Get Repository API"]
-pub enum SnapshotGetRepositoryParts<'a> {
+pub enum SnapshotGetRepositoryParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Repository"]
-    Repository(&'a [&'a str]),
+    Repository(&'b [&'b str]),
 }
-impl<'a> SnapshotGetRepositoryParts<'a> {
+impl<'b> SnapshotGetRepositoryParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Get Repository API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -956,21 +956,21 @@ impl<'a> SnapshotGetRepositoryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Get Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html). Returns information about a repository."]
-pub struct SnapshotGetRepository<'a> {
-    client: Elasticsearch,
-    parts: SnapshotGetRepositoryParts<'a>,
+pub struct SnapshotGetRepository<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SnapshotGetRepositoryParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     local: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SnapshotGetRepository<'a> {
+impl<'a, 'b> SnapshotGetRepository<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotGetRepository] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SnapshotGetRepositoryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SnapshotGetRepositoryParts<'b>) -> Self {
         SnapshotGetRepository {
             client,
             parts,
@@ -990,7 +990,7 @@ impl<'a> SnapshotGetRepository<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1010,7 +1010,7 @@ impl<'a> SnapshotGetRepository<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1020,7 +1020,7 @@ impl<'a> SnapshotGetRepository<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1032,24 +1032,24 @@ impl<'a> SnapshotGetRepository<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1072,11 +1072,11 @@ impl<'a> SnapshotGetRepository<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Snapshot Restore API"]
-pub enum SnapshotRestoreParts<'a> {
+pub enum SnapshotRestoreParts<'b> {
     #[doc = "Repository and Snapshot"]
-    RepositorySnapshot(&'a str, &'a str),
+    RepositorySnapshot(&'b str, &'b str),
 }
-impl<'a> SnapshotRestoreParts<'a> {
+impl<'b> SnapshotRestoreParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Restore API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1094,25 +1094,25 @@ impl<'a> SnapshotRestoreParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Restore API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html). Restores a snapshot."]
-pub struct SnapshotRestore<'a, B> {
-    client: Elasticsearch,
-    parts: SnapshotRestoreParts<'a>,
+pub struct SnapshotRestore<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SnapshotRestoreParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     wait_for_completion: Option<bool>,
 }
-impl<'a, B> SnapshotRestore<'a, B>
+impl<'a, 'b, B> SnapshotRestore<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SnapshotRestore] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SnapshotRestoreParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SnapshotRestoreParts<'b>) -> Self {
         SnapshotRestore {
             client,
             parts,
@@ -1128,7 +1128,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SnapshotRestore<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SnapshotRestore<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1152,7 +1152,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1167,7 +1167,7 @@ where
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1177,7 +1177,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1194,22 +1194,22 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "wait_for_completion")]
                 wait_for_completion: Option<bool>,
             }
@@ -1234,15 +1234,15 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Snapshot Status API"]
-pub enum SnapshotStatusParts<'a> {
+pub enum SnapshotStatusParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Repository"]
-    Repository(&'a str),
+    Repository(&'b str),
     #[doc = "Repository and Snapshot"]
-    RepositorySnapshot(&'a str, &'a [&'a str]),
+    RepositorySnapshot(&'b str, &'b [&'b str]),
 }
-impl<'a> SnapshotStatusParts<'a> {
+impl<'b> SnapshotStatusParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Status API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1269,21 +1269,21 @@ impl<'a> SnapshotStatusParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Status API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html). Returns information about the status of a snapshot."]
-pub struct SnapshotStatus<'a> {
-    client: Elasticsearch,
-    parts: SnapshotStatusParts<'a>,
+pub struct SnapshotStatus<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: SnapshotStatusParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SnapshotStatus<'a> {
+impl<'a, 'b> SnapshotStatus<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotStatus] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SnapshotStatusParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SnapshotStatusParts<'b>) -> Self {
         SnapshotStatus {
             client,
             parts,
@@ -1303,7 +1303,7 @@ impl<'a> SnapshotStatus<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1323,7 +1323,7 @@ impl<'a> SnapshotStatus<'a> {
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1333,7 +1333,7 @@ impl<'a> SnapshotStatus<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1345,24 +1345,24 @@ impl<'a> SnapshotStatus<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1385,11 +1385,11 @@ impl<'a> SnapshotStatus<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Snapshot Verify Repository API"]
-pub enum SnapshotVerifyRepositoryParts<'a> {
+pub enum SnapshotVerifyRepositoryParts<'b> {
     #[doc = "Repository"]
-    Repository(&'a str),
+    Repository(&'b str),
 }
-impl<'a> SnapshotVerifyRepositoryParts<'a> {
+impl<'b> SnapshotVerifyRepositoryParts<'b> {
     #[doc = "Builds a relative URL path to the Snapshot Verify Repository API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1405,25 +1405,25 @@ impl<'a> SnapshotVerifyRepositoryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Verify Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html). Verifies a repository."]
-pub struct SnapshotVerifyRepository<'a, B> {
-    client: Elasticsearch,
-    parts: SnapshotVerifyRepositoryParts<'a>,
+pub struct SnapshotVerifyRepository<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SnapshotVerifyRepositoryParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> SnapshotVerifyRepository<'a, B>
+impl<'a, 'b, B> SnapshotVerifyRepository<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SnapshotVerifyRepository] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SnapshotVerifyRepositoryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SnapshotVerifyRepositoryParts<'b>) -> Self {
         SnapshotVerifyRepository {
             client,
             parts,
@@ -1439,7 +1439,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SnapshotVerifyRepository<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SnapshotVerifyRepository<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1463,7 +1463,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1478,7 +1478,7 @@ where
         self
     }
     #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1488,12 +1488,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -1505,24 +1505,24 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1544,73 +1544,73 @@ where
     }
 }
 #[doc = "Namespace client for Snapshot APIs"]
-pub struct Snapshot {
-    client: Elasticsearch,
+pub struct Snapshot<'a> {
+    client: &'a Elasticsearch,
 }
-impl Snapshot {
+impl<'a> Snapshot<'a> {
     #[doc = "Creates a new instance of [Snapshot]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
     #[doc = "Removes stale data from repository."]
-    pub fn cleanup_repository<'a>(
-        &self,
-        parts: SnapshotCleanupRepositoryParts<'a>,
-    ) -> SnapshotCleanupRepository<'a, ()> {
-        SnapshotCleanupRepository::new(self.client.clone(), parts)
+    pub fn cleanup_repository<'b>(
+        &'a self,
+        parts: SnapshotCleanupRepositoryParts<'b>,
+    ) -> SnapshotCleanupRepository<'a, 'b, ()> {
+        SnapshotCleanupRepository::new(&self.client, parts)
     }
     #[doc = "Creates a snapshot in a repository."]
-    pub fn create<'a>(&self, parts: SnapshotCreateParts<'a>) -> SnapshotCreate<'a, ()> {
-        SnapshotCreate::new(self.client.clone(), parts)
+    pub fn create<'b>(&'a self, parts: SnapshotCreateParts<'b>) -> SnapshotCreate<'a, 'b, ()> {
+        SnapshotCreate::new(&self.client, parts)
     }
     #[doc = "Creates a repository."]
-    pub fn create_repository<'a>(
-        &self,
-        parts: SnapshotCreateRepositoryParts<'a>,
-    ) -> SnapshotCreateRepository<'a, ()> {
-        SnapshotCreateRepository::new(self.client.clone(), parts)
+    pub fn create_repository<'b>(
+        &'a self,
+        parts: SnapshotCreateRepositoryParts<'b>,
+    ) -> SnapshotCreateRepository<'a, 'b, ()> {
+        SnapshotCreateRepository::new(&self.client, parts)
     }
     #[doc = "Deletes a snapshot."]
-    pub fn delete<'a>(&self, parts: SnapshotDeleteParts<'a>) -> SnapshotDelete<'a> {
-        SnapshotDelete::new(self.client.clone(), parts)
+    pub fn delete<'b>(&'a self, parts: SnapshotDeleteParts<'b>) -> SnapshotDelete<'a, 'b> {
+        SnapshotDelete::new(&self.client, parts)
     }
     #[doc = "Deletes a repository."]
-    pub fn delete_repository<'a>(
-        &self,
-        parts: SnapshotDeleteRepositoryParts<'a>,
-    ) -> SnapshotDeleteRepository<'a> {
-        SnapshotDeleteRepository::new(self.client.clone(), parts)
+    pub fn delete_repository<'b>(
+        &'a self,
+        parts: SnapshotDeleteRepositoryParts<'b>,
+    ) -> SnapshotDeleteRepository<'a, 'b> {
+        SnapshotDeleteRepository::new(&self.client, parts)
     }
     #[doc = "Returns information about a snapshot."]
-    pub fn get<'a>(&self, parts: SnapshotGetParts<'a>) -> SnapshotGet<'a> {
-        SnapshotGet::new(self.client.clone(), parts)
+    pub fn get<'b>(&'a self, parts: SnapshotGetParts<'b>) -> SnapshotGet<'a, 'b> {
+        SnapshotGet::new(&self.client, parts)
     }
     #[doc = "Returns information about a repository."]
-    pub fn get_repository<'a>(
-        &self,
-        parts: SnapshotGetRepositoryParts<'a>,
-    ) -> SnapshotGetRepository<'a> {
-        SnapshotGetRepository::new(self.client.clone(), parts)
+    pub fn get_repository<'b>(
+        &'a self,
+        parts: SnapshotGetRepositoryParts<'b>,
+    ) -> SnapshotGetRepository<'a, 'b> {
+        SnapshotGetRepository::new(&self.client, parts)
     }
     #[doc = "Restores a snapshot."]
-    pub fn restore<'a>(&self, parts: SnapshotRestoreParts<'a>) -> SnapshotRestore<'a, ()> {
-        SnapshotRestore::new(self.client.clone(), parts)
+    pub fn restore<'b>(&'a self, parts: SnapshotRestoreParts<'b>) -> SnapshotRestore<'a, 'b, ()> {
+        SnapshotRestore::new(&self.client, parts)
     }
     #[doc = "Returns information about the status of a snapshot."]
-    pub fn status<'a>(&self, parts: SnapshotStatusParts<'a>) -> SnapshotStatus<'a> {
-        SnapshotStatus::new(self.client.clone(), parts)
+    pub fn status<'b>(&'a self, parts: SnapshotStatusParts<'b>) -> SnapshotStatus<'a, 'b> {
+        SnapshotStatus::new(&self.client, parts)
     }
     #[doc = "Verifies a repository."]
-    pub fn verify_repository<'a>(
-        &self,
-        parts: SnapshotVerifyRepositoryParts<'a>,
-    ) -> SnapshotVerifyRepository<'a, ()> {
-        SnapshotVerifyRepository::new(self.client.clone(), parts)
+    pub fn verify_repository<'b>(
+        &'a self,
+        parts: SnapshotVerifyRepositoryParts<'b>,
+    ) -> SnapshotVerifyRepository<'a, 'b, ()> {
+        SnapshotVerifyRepository::new(&self.client, parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Snapshot APIs"]
     pub fn snapshot(&self) -> Snapshot {
-        Snapshot::new(self.clone())
+        Snapshot::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/sql.rs
+++ b/elasticsearch/src/generated/namespace_clients/sql.rs
@@ -45,23 +45,23 @@ impl SqlClearCursorParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Sql Clear Cursor API"]
-pub struct SqlClearCursor<'a, B> {
-    client: Elasticsearch,
+pub struct SqlClearCursor<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SqlClearCursorParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SqlClearCursor<'a, B>
+impl<'a, 'b, B> SqlClearCursor<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SqlClearCursor]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SqlClearCursor {
             client,
             parts: SqlClearCursorParts::None,
@@ -75,7 +75,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SqlClearCursor<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SqlClearCursor<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -97,7 +97,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -117,7 +117,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -129,20 +129,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -177,24 +177,24 @@ impl SqlQueryParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Sql Query API"]
-pub struct SqlQuery<'a, B> {
-    client: Elasticsearch,
+pub struct SqlQuery<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SqlQueryParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
-    format: Option<&'a str>,
+    filter_path: Option<&'b [&'b str]>,
+    format: Option<&'b str>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SqlQuery<'a, B>
+impl<'a, 'b, B> SqlQuery<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SqlQuery]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SqlQuery {
             client,
             parts: SqlQueryParts::None,
@@ -209,7 +209,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SqlQuery<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SqlQuery<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -232,12 +232,12 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
     #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'a str) -> Self {
+    pub fn format(mut self, format: &'b str) -> Self {
         self.format = Some(format);
         self
     }
@@ -257,7 +257,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -272,22 +272,22 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "format")]
-                format: Option<&'a str>,
+                format: Option<&'b str>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -323,23 +323,23 @@ impl SqlTranslateParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Sql Translate API"]
-pub struct SqlTranslate<'a, B> {
-    client: Elasticsearch,
+pub struct SqlTranslate<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: SqlTranslateParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SqlTranslate<'a, B>
+impl<'a, 'b, B> SqlTranslate<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SqlTranslate]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SqlTranslate {
             client,
             parts: SqlTranslateParts::None,
@@ -353,7 +353,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SqlTranslate<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SqlTranslate<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -375,7 +375,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -395,7 +395,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -410,20 +410,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -443,27 +443,27 @@ where
     }
 }
 #[doc = "Namespace client for Sql APIs"]
-pub struct Sql {
-    client: Elasticsearch,
+pub struct Sql<'a> {
+    client: &'a Elasticsearch,
 }
-impl Sql {
+impl<'a> Sql<'a> {
     #[doc = "Creates a new instance of [Sql]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn clear_cursor<'a>(&self) -> SqlClearCursor<'a, ()> {
-        SqlClearCursor::new(self.client.clone())
+    pub fn clear_cursor<'b>(&'a self) -> SqlClearCursor<'a, 'b, ()> {
+        SqlClearCursor::new(&self.client)
     }
-    pub fn query<'a>(&self) -> SqlQuery<'a, ()> {
-        SqlQuery::new(self.client.clone())
+    pub fn query<'b>(&'a self) -> SqlQuery<'a, 'b, ()> {
+        SqlQuery::new(&self.client)
     }
-    pub fn translate<'a>(&self) -> SqlTranslate<'a, ()> {
-        SqlTranslate::new(self.client.clone())
+    pub fn translate<'b>(&'a self) -> SqlTranslate<'a, 'b, ()> {
+        SqlTranslate::new(&self.client)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Sql APIs"]
     pub fn sql(&self) -> Sql {
-        Sql::new(self.clone())
+        Sql::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/ssl.rs
+++ b/elasticsearch/src/generated/namespace_clients/ssl.rs
@@ -45,19 +45,19 @@ impl SslCertificatesParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ssl Certificates API](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html)."]
-pub struct SslCertificates<'a> {
-    client: Elasticsearch,
+pub struct SslCertificates<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: SslCertificatesParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> SslCertificates<'a> {
+impl<'a, 'b> SslCertificates<'a, 'b> {
     #[doc = "Creates a new instance of [SslCertificates]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         SslCertificates {
             client,
             parts: SslCertificatesParts::None,
@@ -75,7 +75,7 @@ impl<'a> SslCertificates<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -95,7 +95,7 @@ impl<'a> SslCertificates<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -107,20 +107,20 @@ impl<'a> SslCertificates<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -140,21 +140,21 @@ impl<'a> SslCertificates<'a> {
     }
 }
 #[doc = "Namespace client for Ssl APIs"]
-pub struct Ssl {
-    client: Elasticsearch,
+pub struct Ssl<'a> {
+    client: &'a Elasticsearch,
 }
-impl Ssl {
+impl<'a> Ssl<'a> {
     #[doc = "Creates a new instance of [Ssl]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn certificates<'a>(&self) -> SslCertificates<'a> {
-        SslCertificates::new(self.client.clone())
+    pub fn certificates<'b>(&'a self) -> SslCertificates<'a, 'b> {
+        SslCertificates::new(&self.client)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Ssl APIs"]
     pub fn ssl(&self) -> Ssl {
-        Ssl::new(self.clone())
+        Ssl::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/tasks.rs
+++ b/elasticsearch/src/generated/namespace_clients/tasks.rs
@@ -31,13 +31,13 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Tasks Cancel API"]
-pub enum TasksCancelParts<'a> {
+pub enum TasksCancelParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "TaskId"]
-    TaskId(&'a str),
+    TaskId(&'b str),
 }
-impl<'a> TasksCancelParts<'a> {
+impl<'b> TasksCancelParts<'b> {
     #[doc = "Builds a relative URL path to the Tasks Cancel API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -54,26 +54,26 @@ impl<'a> TasksCancelParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Tasks Cancel API](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html). Cancels a task, if it can be cancelled through an API."]
-pub struct TasksCancel<'a, B> {
-    client: Elasticsearch,
-    parts: TasksCancelParts<'a>,
-    actions: Option<&'a [&'a str]>,
+pub struct TasksCancel<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: TasksCancelParts<'b>,
+    actions: Option<&'b [&'b str]>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    nodes: Option<&'a [&'a str]>,
-    parent_task_id: Option<&'a str>,
+    nodes: Option<&'b [&'b str]>,
+    parent_task_id: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> TasksCancel<'a, B>
+impl<'a, 'b, B> TasksCancel<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [TasksCancel] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: TasksCancelParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: TasksCancelParts<'b>) -> Self {
         TasksCancel {
             client,
             parts,
@@ -90,12 +90,12 @@ where
         }
     }
     #[doc = "A comma-separated list of actions that should be cancelled. Leave empty to cancel all."]
-    pub fn actions(mut self, actions: &'a [&'a str]) -> Self {
+    pub fn actions(mut self, actions: &'b [&'b str]) -> Self {
         self.actions = Some(actions);
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> TasksCancel<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> TasksCancel<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -120,7 +120,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -135,12 +135,12 @@ where
         self
     }
     #[doc = "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"]
-    pub fn nodes(mut self, nodes: &'a [&'a str]) -> Self {
+    pub fn nodes(mut self, nodes: &'b [&'b str]) -> Self {
         self.nodes = Some(nodes);
         self
     }
     #[doc = "Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all."]
-    pub fn parent_task_id(mut self, parent_task_id: &'a str) -> Self {
+    pub fn parent_task_id(mut self, parent_task_id: &'b str) -> Self {
         self.parent_task_id = Some(parent_task_id);
         self
     }
@@ -150,7 +150,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -162,29 +162,29 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "actions",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                actions: Option<&'a [&'a str]>,
+                actions: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "nodes", serialize_with = "crate::client::serialize_coll_qs")]
-                nodes: Option<&'a [&'a str]>,
+                nodes: Option<&'b [&'b str]>,
                 #[serde(rename = "parent_task_id")]
-                parent_task_id: Option<&'a str>,
+                parent_task_id: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 actions: self.actions,
@@ -208,11 +208,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Tasks Get API"]
-pub enum TasksGetParts<'a> {
+pub enum TasksGetParts<'b> {
     #[doc = "TaskId"]
-    TaskId(&'a str),
+    TaskId(&'b str),
 }
-impl<'a> TasksGetParts<'a> {
+impl<'b> TasksGetParts<'b> {
     #[doc = "Builds a relative URL path to the Tasks Get API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -227,21 +227,21 @@ impl<'a> TasksGetParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Tasks Get API](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html). Returns information about a task."]
-pub struct TasksGet<'a> {
-    client: Elasticsearch,
-    parts: TasksGetParts<'a>,
+pub struct TasksGet<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: TasksGetParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
     wait_for_completion: Option<bool>,
 }
-impl<'a> TasksGet<'a> {
+impl<'a, 'b> TasksGet<'a, 'b> {
     #[doc = "Creates a new instance of [TasksGet] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: TasksGetParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: TasksGetParts<'b>) -> Self {
         TasksGet {
             client,
             parts,
@@ -261,7 +261,7 @@ impl<'a> TasksGet<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -281,12 +281,12 @@ impl<'a> TasksGet<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -303,22 +303,22 @@ impl<'a> TasksGet<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_completion")]
                 wait_for_completion: Option<bool>,
             }
@@ -357,26 +357,26 @@ impl TasksListParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Tasks List API](https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html). Returns a list of tasks."]
-pub struct TasksList<'a> {
-    client: Elasticsearch,
+pub struct TasksList<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: TasksListParts,
-    actions: Option<&'a [&'a str]>,
+    actions: Option<&'b [&'b str]>,
     detailed: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     group_by: Option<GroupBy>,
     headers: HeaderMap,
     human: Option<bool>,
-    nodes: Option<&'a [&'a str]>,
-    parent_task_id: Option<&'a str>,
+    nodes: Option<&'b [&'b str]>,
+    parent_task_id: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
     wait_for_completion: Option<bool>,
 }
-impl<'a> TasksList<'a> {
+impl<'a, 'b> TasksList<'a, 'b> {
     #[doc = "Creates a new instance of [TasksList]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         TasksList {
             client,
             parts: TasksListParts::None,
@@ -396,7 +396,7 @@ impl<'a> TasksList<'a> {
         }
     }
     #[doc = "A comma-separated list of actions that should be returned. Leave empty to return all."]
-    pub fn actions(mut self, actions: &'a [&'a str]) -> Self {
+    pub fn actions(mut self, actions: &'b [&'b str]) -> Self {
         self.actions = Some(actions);
         self
     }
@@ -411,7 +411,7 @@ impl<'a> TasksList<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -431,12 +431,12 @@ impl<'a> TasksList<'a> {
         self
     }
     #[doc = "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"]
-    pub fn nodes(mut self, nodes: &'a [&'a str]) -> Self {
+    pub fn nodes(mut self, nodes: &'b [&'b str]) -> Self {
         self.nodes = Some(nodes);
         self
     }
     #[doc = "Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all."]
-    pub fn parent_task_id(mut self, parent_task_id: &'a str) -> Self {
+    pub fn parent_task_id(mut self, parent_task_id: &'b str) -> Self {
         self.parent_task_id = Some(parent_task_id);
         self
     }
@@ -446,12 +446,12 @@ impl<'a> TasksList<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -468,12 +468,12 @@ impl<'a> TasksList<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "actions",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                actions: Option<&'a [&'a str]>,
+                actions: Option<&'b [&'b str]>,
                 #[serde(rename = "detailed")]
                 detailed: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -482,21 +482,21 @@ impl<'a> TasksList<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "group_by")]
                 group_by: Option<GroupBy>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "nodes", serialize_with = "crate::client::serialize_coll_qs")]
-                nodes: Option<&'a [&'a str]>,
+                nodes: Option<&'b [&'b str]>,
                 #[serde(rename = "parent_task_id")]
-                parent_task_id: Option<&'a str>,
+                parent_task_id: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_completion")]
                 wait_for_completion: Option<bool>,
             }
@@ -525,30 +525,30 @@ impl<'a> TasksList<'a> {
     }
 }
 #[doc = "Namespace client for Tasks APIs"]
-pub struct Tasks {
-    client: Elasticsearch,
+pub struct Tasks<'a> {
+    client: &'a Elasticsearch,
 }
-impl Tasks {
+impl<'a> Tasks<'a> {
     #[doc = "Creates a new instance of [Tasks]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
     #[doc = "Cancels a task, if it can be cancelled through an API."]
-    pub fn cancel<'a>(&self, parts: TasksCancelParts<'a>) -> TasksCancel<'a, ()> {
-        TasksCancel::new(self.client.clone(), parts)
+    pub fn cancel<'b>(&'a self, parts: TasksCancelParts<'b>) -> TasksCancel<'a, 'b, ()> {
+        TasksCancel::new(&self.client, parts)
     }
     #[doc = "Returns information about a task."]
-    pub fn get<'a>(&self, parts: TasksGetParts<'a>) -> TasksGet<'a> {
-        TasksGet::new(self.client.clone(), parts)
+    pub fn get<'b>(&'a self, parts: TasksGetParts<'b>) -> TasksGet<'a, 'b> {
+        TasksGet::new(&self.client, parts)
     }
     #[doc = "Returns a list of tasks."]
-    pub fn list<'a>(&self) -> TasksList<'a> {
-        TasksList::new(self.client.clone())
+    pub fn list<'b>(&'a self) -> TasksList<'a, 'b> {
+        TasksList::new(&self.client)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Tasks APIs"]
     pub fn tasks(&self) -> Tasks {
-        Tasks::new(self.clone())
+        Tasks::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/watcher.rs
+++ b/elasticsearch/src/generated/namespace_clients/watcher.rs
@@ -31,13 +31,13 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Watcher Ack Watch API"]
-pub enum WatcherAckWatchParts<'a> {
+pub enum WatcherAckWatchParts<'b> {
     #[doc = "WatchId"]
-    WatchId(&'a str),
+    WatchId(&'b str),
     #[doc = "WatchId and ActionId"]
-    WatchIdActionId(&'a str, &'a [&'a str]),
+    WatchIdActionId(&'b str, &'b [&'b str]),
 }
-impl<'a> WatcherAckWatchParts<'a> {
+impl<'b> WatcherAckWatchParts<'b> {
     #[doc = "Builds a relative URL path to the Watcher Ack Watch API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -62,23 +62,23 @@ impl<'a> WatcherAckWatchParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Ack Watch API](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html)."]
-pub struct WatcherAckWatch<'a, B> {
-    client: Elasticsearch,
-    parts: WatcherAckWatchParts<'a>,
+pub struct WatcherAckWatch<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: WatcherAckWatchParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> WatcherAckWatch<'a, B>
+impl<'a, 'b, B> WatcherAckWatch<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherAckWatch] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: WatcherAckWatchParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: WatcherAckWatchParts<'b>) -> Self {
         WatcherAckWatch {
             client,
             parts,
@@ -92,7 +92,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> WatcherAckWatch<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> WatcherAckWatch<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -114,7 +114,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -134,7 +134,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -146,20 +146,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -180,11 +180,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Watcher Activate Watch API"]
-pub enum WatcherActivateWatchParts<'a> {
+pub enum WatcherActivateWatchParts<'b> {
     #[doc = "WatchId"]
-    WatchId(&'a str),
+    WatchId(&'b str),
 }
-impl<'a> WatcherActivateWatchParts<'a> {
+impl<'b> WatcherActivateWatchParts<'b> {
     #[doc = "Builds a relative URL path to the Watcher Activate Watch API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -200,23 +200,23 @@ impl<'a> WatcherActivateWatchParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Activate Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html)."]
-pub struct WatcherActivateWatch<'a, B> {
-    client: Elasticsearch,
-    parts: WatcherActivateWatchParts<'a>,
+pub struct WatcherActivateWatch<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: WatcherActivateWatchParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> WatcherActivateWatch<'a, B>
+impl<'a, 'b, B> WatcherActivateWatch<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherActivateWatch] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: WatcherActivateWatchParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: WatcherActivateWatchParts<'b>) -> Self {
         WatcherActivateWatch {
             client,
             parts,
@@ -230,7 +230,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> WatcherActivateWatch<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> WatcherActivateWatch<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -252,7 +252,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -272,7 +272,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -284,20 +284,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -318,11 +318,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Watcher Deactivate Watch API"]
-pub enum WatcherDeactivateWatchParts<'a> {
+pub enum WatcherDeactivateWatchParts<'b> {
     #[doc = "WatchId"]
-    WatchId(&'a str),
+    WatchId(&'b str),
 }
-impl<'a> WatcherDeactivateWatchParts<'a> {
+impl<'b> WatcherDeactivateWatchParts<'b> {
     #[doc = "Builds a relative URL path to the Watcher Deactivate Watch API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -338,23 +338,23 @@ impl<'a> WatcherDeactivateWatchParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Deactivate Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html)."]
-pub struct WatcherDeactivateWatch<'a, B> {
-    client: Elasticsearch,
-    parts: WatcherDeactivateWatchParts<'a>,
+pub struct WatcherDeactivateWatch<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: WatcherDeactivateWatchParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> WatcherDeactivateWatch<'a, B>
+impl<'a, 'b, B> WatcherDeactivateWatch<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherDeactivateWatch] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: WatcherDeactivateWatchParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: WatcherDeactivateWatchParts<'b>) -> Self {
         WatcherDeactivateWatch {
             client,
             parts,
@@ -368,7 +368,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> WatcherDeactivateWatch<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> WatcherDeactivateWatch<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -390,7 +390,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -410,7 +410,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -422,20 +422,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -456,11 +456,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Watcher Delete Watch API"]
-pub enum WatcherDeleteWatchParts<'a> {
+pub enum WatcherDeleteWatchParts<'b> {
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
 }
-impl<'a> WatcherDeleteWatchParts<'a> {
+impl<'b> WatcherDeleteWatchParts<'b> {
     #[doc = "Builds a relative URL path to the Watcher Delete Watch API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -475,19 +475,19 @@ impl<'a> WatcherDeleteWatchParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Delete Watch API](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html)."]
-pub struct WatcherDeleteWatch<'a> {
-    client: Elasticsearch,
-    parts: WatcherDeleteWatchParts<'a>,
+pub struct WatcherDeleteWatch<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: WatcherDeleteWatchParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> WatcherDeleteWatch<'a> {
+impl<'a, 'b> WatcherDeleteWatch<'a, 'b> {
     #[doc = "Creates a new instance of [WatcherDeleteWatch] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: WatcherDeleteWatchParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: WatcherDeleteWatchParts<'b>) -> Self {
         WatcherDeleteWatch {
             client,
             parts,
@@ -505,7 +505,7 @@ impl<'a> WatcherDeleteWatch<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -525,7 +525,7 @@ impl<'a> WatcherDeleteWatch<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -537,20 +537,20 @@ impl<'a> WatcherDeleteWatch<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -571,13 +571,13 @@ impl<'a> WatcherDeleteWatch<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Watcher Execute Watch API"]
-pub enum WatcherExecuteWatchParts<'a> {
+pub enum WatcherExecuteWatchParts<'b> {
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
     #[doc = "No parts"]
     None,
 }
-impl<'a> WatcherExecuteWatchParts<'a> {
+impl<'b> WatcherExecuteWatchParts<'b> {
     #[doc = "Builds a relative URL path to the Watcher Execute Watch API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -594,24 +594,24 @@ impl<'a> WatcherExecuteWatchParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Execute Watch API](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html)."]
-pub struct WatcherExecuteWatch<'a, B> {
-    client: Elasticsearch,
-    parts: WatcherExecuteWatchParts<'a>,
+pub struct WatcherExecuteWatch<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: WatcherExecuteWatchParts<'b>,
     body: Option<B>,
     debug: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> WatcherExecuteWatch<'a, B>
+impl<'a, 'b, B> WatcherExecuteWatch<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherExecuteWatch] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: WatcherExecuteWatchParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: WatcherExecuteWatchParts<'b>) -> Self {
         WatcherExecuteWatch {
             client,
             parts,
@@ -626,7 +626,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> WatcherExecuteWatch<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> WatcherExecuteWatch<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -654,7 +654,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -674,7 +674,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -686,7 +686,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "debug")]
                 debug: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -695,13 +695,13 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 debug: self.debug,
@@ -723,11 +723,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Watcher Get Watch API"]
-pub enum WatcherGetWatchParts<'a> {
+pub enum WatcherGetWatchParts<'b> {
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
 }
-impl<'a> WatcherGetWatchParts<'a> {
+impl<'b> WatcherGetWatchParts<'b> {
     #[doc = "Builds a relative URL path to the Watcher Get Watch API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -742,19 +742,19 @@ impl<'a> WatcherGetWatchParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Get Watch API](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html)."]
-pub struct WatcherGetWatch<'a> {
-    client: Elasticsearch,
-    parts: WatcherGetWatchParts<'a>,
+pub struct WatcherGetWatch<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: WatcherGetWatchParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> WatcherGetWatch<'a> {
+impl<'a, 'b> WatcherGetWatch<'a, 'b> {
     #[doc = "Creates a new instance of [WatcherGetWatch] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: WatcherGetWatchParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: WatcherGetWatchParts<'b>) -> Self {
         WatcherGetWatch {
             client,
             parts,
@@ -772,7 +772,7 @@ impl<'a> WatcherGetWatch<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -792,7 +792,7 @@ impl<'a> WatcherGetWatch<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -804,20 +804,20 @@ impl<'a> WatcherGetWatch<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -838,11 +838,11 @@ impl<'a> WatcherGetWatch<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Watcher Put Watch API"]
-pub enum WatcherPutWatchParts<'a> {
+pub enum WatcherPutWatchParts<'b> {
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
 }
-impl<'a> WatcherPutWatchParts<'a> {
+impl<'b> WatcherPutWatchParts<'b> {
     #[doc = "Builds a relative URL path to the Watcher Put Watch API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -857,27 +857,27 @@ impl<'a> WatcherPutWatchParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Put Watch API](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html)."]
-pub struct WatcherPutWatch<'a, B> {
-    client: Elasticsearch,
-    parts: WatcherPutWatchParts<'a>,
+pub struct WatcherPutWatch<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: WatcherPutWatchParts<'b>,
     active: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     if_primary_term: Option<i64>,
     if_seq_no: Option<i64>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     version: Option<i64>,
 }
-impl<'a, B> WatcherPutWatch<'a, B>
+impl<'a, 'b, B> WatcherPutWatch<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherPutWatch] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: WatcherPutWatchParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: WatcherPutWatchParts<'b>) -> Self {
         WatcherPutWatch {
             client,
             parts,
@@ -900,7 +900,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> WatcherPutWatch<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> WatcherPutWatch<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -926,7 +926,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -956,7 +956,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -973,7 +973,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "active")]
                 active: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -982,7 +982,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "if_primary_term")]
@@ -992,7 +992,7 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "version")]
                 version: Option<i64>,
             }
@@ -1033,23 +1033,23 @@ impl WatcherStartParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Start API](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html)."]
-pub struct WatcherStart<'a, B> {
-    client: Elasticsearch,
+pub struct WatcherStart<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: WatcherStartParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> WatcherStart<'a, B>
+impl<'a, 'b, B> WatcherStart<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherStart]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         WatcherStart {
             client,
             parts: WatcherStartParts::None,
@@ -1063,7 +1063,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> WatcherStart<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> WatcherStart<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1085,7 +1085,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1105,7 +1105,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1117,20 +1117,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1151,13 +1151,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Watcher Stats API"]
-pub enum WatcherStatsParts<'a> {
+pub enum WatcherStatsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Metric"]
-    Metric(&'a [&'a str]),
+    Metric(&'b [&'b str]),
 }
-impl<'a> WatcherStatsParts<'a> {
+impl<'b> WatcherStatsParts<'b> {
     #[doc = "Builds a relative URL path to the Watcher Stats API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1174,21 +1174,21 @@ impl<'a> WatcherStatsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Stats API](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html)."]
-pub struct WatcherStats<'a> {
-    client: Elasticsearch,
-    parts: WatcherStatsParts<'a>,
+pub struct WatcherStats<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: WatcherStatsParts<'b>,
     emit_stacktraces: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    metric: Option<&'a [&'a str]>,
+    metric: Option<&'b [&'b str]>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> WatcherStats<'a> {
+impl<'a, 'b> WatcherStats<'a, 'b> {
     #[doc = "Creates a new instance of [WatcherStats] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: WatcherStatsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: WatcherStatsParts<'b>) -> Self {
         WatcherStats {
             client,
             parts,
@@ -1213,7 +1213,7 @@ impl<'a> WatcherStats<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1228,7 +1228,7 @@ impl<'a> WatcherStats<'a> {
         self
     }
     #[doc = "Controls what additional stat metrics should be include in the response"]
-    pub fn metric(mut self, metric: &'a [&'a str]) -> Self {
+    pub fn metric(mut self, metric: &'b [&'b str]) -> Self {
         self.metric = Some(metric);
         self
     }
@@ -1238,7 +1238,7 @@ impl<'a> WatcherStats<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1250,7 +1250,7 @@ impl<'a> WatcherStats<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "emit_stacktraces")]
                 emit_stacktraces: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -1259,15 +1259,15 @@ impl<'a> WatcherStats<'a> {
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "metric", serialize_with = "crate::client::serialize_coll_qs")]
-                metric: Option<&'a [&'a str]>,
+                metric: Option<&'b [&'b str]>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 emit_stacktraces: self.emit_stacktraces,
@@ -1304,23 +1304,23 @@ impl WatcherStopParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Stop API](http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html)."]
-pub struct WatcherStop<'a, B> {
-    client: Elasticsearch,
+pub struct WatcherStop<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: WatcherStopParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> WatcherStop<'a, B>
+impl<'a, 'b, B> WatcherStop<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherStop]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         WatcherStop {
             client,
             parts: WatcherStopParts::None,
@@ -1334,7 +1334,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> WatcherStop<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> WatcherStop<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1356,7 +1356,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1376,7 +1376,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1388,20 +1388,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1421,57 +1421,60 @@ where
     }
 }
 #[doc = "Namespace client for Watcher APIs"]
-pub struct Watcher {
-    client: Elasticsearch,
+pub struct Watcher<'a> {
+    client: &'a Elasticsearch,
 }
-impl Watcher {
+impl<'a> Watcher<'a> {
     #[doc = "Creates a new instance of [Watcher]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn ack_watch<'a>(&self, parts: WatcherAckWatchParts<'a>) -> WatcherAckWatch<'a, ()> {
-        WatcherAckWatch::new(self.client.clone(), parts)
+    pub fn ack_watch<'b>(&'a self, parts: WatcherAckWatchParts<'b>) -> WatcherAckWatch<'a, 'b, ()> {
+        WatcherAckWatch::new(&self.client, parts)
     }
-    pub fn activate_watch<'a>(
-        &self,
-        parts: WatcherActivateWatchParts<'a>,
-    ) -> WatcherActivateWatch<'a, ()> {
-        WatcherActivateWatch::new(self.client.clone(), parts)
+    pub fn activate_watch<'b>(
+        &'a self,
+        parts: WatcherActivateWatchParts<'b>,
+    ) -> WatcherActivateWatch<'a, 'b, ()> {
+        WatcherActivateWatch::new(&self.client, parts)
     }
-    pub fn deactivate_watch<'a>(
-        &self,
-        parts: WatcherDeactivateWatchParts<'a>,
-    ) -> WatcherDeactivateWatch<'a, ()> {
-        WatcherDeactivateWatch::new(self.client.clone(), parts)
+    pub fn deactivate_watch<'b>(
+        &'a self,
+        parts: WatcherDeactivateWatchParts<'b>,
+    ) -> WatcherDeactivateWatch<'a, 'b, ()> {
+        WatcherDeactivateWatch::new(&self.client, parts)
     }
-    pub fn delete_watch<'a>(&self, parts: WatcherDeleteWatchParts<'a>) -> WatcherDeleteWatch<'a> {
-        WatcherDeleteWatch::new(self.client.clone(), parts)
+    pub fn delete_watch<'b>(
+        &'a self,
+        parts: WatcherDeleteWatchParts<'b>,
+    ) -> WatcherDeleteWatch<'a, 'b> {
+        WatcherDeleteWatch::new(&self.client, parts)
     }
-    pub fn execute_watch<'a>(
-        &self,
-        parts: WatcherExecuteWatchParts<'a>,
-    ) -> WatcherExecuteWatch<'a, ()> {
-        WatcherExecuteWatch::new(self.client.clone(), parts)
+    pub fn execute_watch<'b>(
+        &'a self,
+        parts: WatcherExecuteWatchParts<'b>,
+    ) -> WatcherExecuteWatch<'a, 'b, ()> {
+        WatcherExecuteWatch::new(&self.client, parts)
     }
-    pub fn get_watch<'a>(&self, parts: WatcherGetWatchParts<'a>) -> WatcherGetWatch<'a> {
-        WatcherGetWatch::new(self.client.clone(), parts)
+    pub fn get_watch<'b>(&'a self, parts: WatcherGetWatchParts<'b>) -> WatcherGetWatch<'a, 'b> {
+        WatcherGetWatch::new(&self.client, parts)
     }
-    pub fn put_watch<'a>(&self, parts: WatcherPutWatchParts<'a>) -> WatcherPutWatch<'a, ()> {
-        WatcherPutWatch::new(self.client.clone(), parts)
+    pub fn put_watch<'b>(&'a self, parts: WatcherPutWatchParts<'b>) -> WatcherPutWatch<'a, 'b, ()> {
+        WatcherPutWatch::new(&self.client, parts)
     }
-    pub fn start<'a>(&self) -> WatcherStart<'a, ()> {
-        WatcherStart::new(self.client.clone())
+    pub fn start<'b>(&'a self) -> WatcherStart<'a, 'b, ()> {
+        WatcherStart::new(&self.client)
     }
-    pub fn stats<'a>(&self, parts: WatcherStatsParts<'a>) -> WatcherStats<'a> {
-        WatcherStats::new(self.client.clone(), parts)
+    pub fn stats<'b>(&'a self, parts: WatcherStatsParts<'b>) -> WatcherStats<'a, 'b> {
+        WatcherStats::new(&self.client, parts)
     }
-    pub fn stop<'a>(&self) -> WatcherStop<'a, ()> {
-        WatcherStop::new(self.client.clone())
+    pub fn stop<'b>(&'a self) -> WatcherStop<'a, 'b, ()> {
+        WatcherStop::new(&self.client)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Watcher APIs"]
     pub fn watcher(&self) -> Watcher {
-        Watcher::new(self.clone())
+        Watcher::new(&self)
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/xpack.rs
+++ b/elasticsearch/src/generated/namespace_clients/xpack.rs
@@ -45,20 +45,20 @@ impl XpackInfoParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Xpack Info API](https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html)."]
-pub struct XpackInfo<'a> {
-    client: Elasticsearch,
+pub struct XpackInfo<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: XpackInfoParts,
-    categories: Option<&'a [&'a str]>,
+    categories: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> XpackInfo<'a> {
+impl<'a, 'b> XpackInfo<'a, 'b> {
     #[doc = "Creates a new instance of [XpackInfo]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         XpackInfo {
             client,
             parts: XpackInfoParts::None,
@@ -72,7 +72,7 @@ impl<'a> XpackInfo<'a> {
         }
     }
     #[doc = "Comma-separated list of info categories. Can be any of: build, license, features"]
-    pub fn categories(mut self, categories: &'a [&'a str]) -> Self {
+    pub fn categories(mut self, categories: &'b [&'b str]) -> Self {
         self.categories = Some(categories);
         self
     }
@@ -82,7 +82,7 @@ impl<'a> XpackInfo<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -102,7 +102,7 @@ impl<'a> XpackInfo<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -114,25 +114,25 @@ impl<'a> XpackInfo<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "categories",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                categories: Option<&'a [&'a str]>,
+                categories: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 categories: self.categories,
@@ -168,20 +168,20 @@ impl XpackUsageParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the Xpack Usage API"]
-pub struct XpackUsage<'a> {
-    client: Elasticsearch,
+pub struct XpackUsage<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: XpackUsageParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> XpackUsage<'a> {
+impl<'a, 'b> XpackUsage<'a, 'b> {
     #[doc = "Creates a new instance of [XpackUsage]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         XpackUsage {
             client,
             parts: XpackUsageParts::None,
@@ -200,7 +200,7 @@ impl<'a> XpackUsage<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -215,7 +215,7 @@ impl<'a> XpackUsage<'a> {
         self
     }
     #[doc = "Specify timeout for watch write operation"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -225,7 +225,7 @@ impl<'a> XpackUsage<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -237,22 +237,22 @@ impl<'a> XpackUsage<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -273,24 +273,24 @@ impl<'a> XpackUsage<'a> {
     }
 }
 #[doc = "Namespace client for X-Pack APIs"]
-pub struct Xpack {
-    client: Elasticsearch,
+pub struct Xpack<'a> {
+    client: &'a Elasticsearch,
 }
-impl Xpack {
+impl<'a> Xpack<'a> {
     #[doc = "Creates a new instance of [Xpack]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Self { client }
     }
-    pub fn info<'a>(&self) -> XpackInfo<'a> {
-        XpackInfo::new(self.client.clone())
+    pub fn info<'b>(&'a self) -> XpackInfo<'a, 'b> {
+        XpackInfo::new(&self.client)
     }
-    pub fn usage<'a>(&self) -> XpackUsage<'a> {
-        XpackUsage::new(self.client.clone())
+    pub fn usage<'b>(&'a self) -> XpackUsage<'a, 'b> {
+        XpackUsage::new(&self.client)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for X-Pack APIs"]
     pub fn xpack(&self) -> Xpack {
-        Xpack::new(self.clone())
+        Xpack::new(&self)
     }
 }

--- a/elasticsearch/src/generated/root.rs
+++ b/elasticsearch/src/generated/root.rs
@@ -31,15 +31,15 @@ use serde_with;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Bulk API"]
-pub enum BulkParts<'a> {
+pub enum BulkParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
     #[doc = "Index and Type"]
-    IndexType(&'a str, &'a str),
+    IndexType(&'b str, &'b str),
 }
-impl<'a> BulkParts<'a> {
+impl<'b> BulkParts<'b> {
     #[doc = "Builds a relative URL path to the Bulk API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -65,32 +65,32 @@ impl<'a> BulkParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html). Allows to perform multiple index/update/delete operations in a single request."]
-pub struct Bulk<'a, B> {
-    client: Elasticsearch,
-    parts: BulkParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct Bulk<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: BulkParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    pipeline: Option<&'a str>,
+    pipeline: Option<&'b str>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    ty: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    ty: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> Bulk<'a, B>
+impl<'a, 'b, B> Bulk<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Bulk] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: BulkParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: BulkParts<'b>) -> Self {
         Bulk {
             client,
             parts,
@@ -113,22 +113,22 @@ where
         }
     }
     #[doc = "True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "Default list of fields to exclude from the returned _source field, can be overridden on each sub-request"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "Default list of fields to extract and return from the _source field, can be overridden on each sub-request"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: Vec<T>) -> Bulk<'a, NdBody<T>>
+    pub fn body<T>(self, body: Vec<T>) -> Bulk<'a, 'b, NdBody<T>>
     where
         T: Body,
     {
@@ -159,7 +159,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -174,7 +174,7 @@ where
         self
     }
     #[doc = "The pipeline id to preprocess incoming documents with"]
-    pub fn pipeline(mut self, pipeline: &'a str) -> Self {
+    pub fn pipeline(mut self, pipeline: &'b str) -> Self {
         self.pipeline = Some(pipeline);
         self
     }
@@ -189,27 +189,27 @@ where
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Default document type for items which don't provide one"]
-    pub fn ty(mut self, ty: &'a str) -> Self {
+    pub fn ty(mut self, ty: &'b str) -> Self {
         self.ty = Some(ty);
         self
     }
     #[doc = "Sets the number of shard copies that must be active before proceeding with the bulk operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -221,47 +221,47 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pipeline")]
-                pipeline: Option<&'a str>,
+                pipeline: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "type")]
-                ty: Option<&'a str>,
+                ty: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 _source: self._source,
@@ -291,13 +291,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Clear Scroll API"]
-pub enum ClearScrollParts<'a> {
+pub enum ClearScrollParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "ScrollId"]
-    ScrollId(&'a [&'a str]),
+    ScrollId(&'b [&'b str]),
 }
-impl<'a> ClearScrollParts<'a> {
+impl<'b> ClearScrollParts<'b> {
     #[doc = "Builds a relative URL path to the Clear Scroll API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -314,23 +314,23 @@ impl<'a> ClearScrollParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Clear Scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#_clear_scroll_api). Explicitly clears the search context for a scroll."]
-pub struct ClearScroll<'a, B> {
-    client: Elasticsearch,
-    parts: ClearScrollParts<'a>,
+pub struct ClearScroll<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: ClearScrollParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> ClearScroll<'a, B>
+impl<'a, 'b, B> ClearScroll<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [ClearScroll] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: ClearScrollParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: ClearScrollParts<'b>) -> Self {
         ClearScroll {
             client,
             parts,
@@ -344,7 +344,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> ClearScroll<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> ClearScroll<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -366,7 +366,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -386,7 +386,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -398,20 +398,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -432,15 +432,15 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Count API"]
-pub enum CountParts<'a> {
+pub enum CountParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> CountParts<'a> {
+impl<'b> CountParts<'b> {
     #[doc = "Builds a relative URL path to the Count API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -469,37 +469,37 @@ impl<'a> CountParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Count API](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html). Returns number of documents matching a query."]
-pub struct Count<'a, B> {
-    client: Elasticsearch,
-    parts: CountParts<'a>,
+pub struct Count<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: CountParts<'b>,
     allow_no_indices: Option<bool>,
     analyze_wildcard: Option<bool>,
-    analyzer: Option<&'a str>,
+    analyzer: Option<&'b str>,
     body: Option<B>,
     default_operator: Option<DefaultOperator>,
-    df: Option<&'a str>,
+    df: Option<&'b str>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_throttled: Option<bool>,
     ignore_unavailable: Option<bool>,
     lenient: Option<bool>,
     min_score: Option<i64>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
-    q: Option<&'a str>,
-    routing: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
+    q: Option<&'b str>,
+    routing: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
     terminate_after: Option<i64>,
 }
-impl<'a, B> Count<'a, B>
+impl<'a, 'b, B> Count<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Count] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CountParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CountParts<'b>) -> Self {
         Count {
             client,
             parts,
@@ -537,12 +537,12 @@ where
         self
     }
     #[doc = "The analyzer to use for the query string"]
-    pub fn analyzer(mut self, analyzer: &'a str) -> Self {
+    pub fn analyzer(mut self, analyzer: &'b str) -> Self {
         self.analyzer = Some(analyzer);
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Count<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Count<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -578,7 +578,7 @@ where
         self
     }
     #[doc = "The field to use as default where no field prefix is given in the query string"]
-    pub fn df(mut self, df: &'a str) -> Self {
+    pub fn df(mut self, df: &'b str) -> Self {
         self.df = Some(df);
         self
     }
@@ -593,7 +593,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -628,7 +628,7 @@ where
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -638,17 +638,17 @@ where
         self
     }
     #[doc = "Query in the Lucene query string syntax"]
-    pub fn q(mut self, q: &'a str) -> Self {
+    pub fn q(mut self, q: &'b str) -> Self {
         self.q = Some(q);
         self
     }
     #[doc = "A comma-separated list of specific routing values"]
-    pub fn routing(mut self, routing: &'a [&'a str]) -> Self {
+    pub fn routing(mut self, routing: &'b [&'b str]) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -668,17 +668,17 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "analyze_wildcard")]
                 analyze_wildcard: Option<bool>,
                 #[serde(rename = "analyzer")]
-                analyzer: Option<&'a str>,
+                analyzer: Option<&'b str>,
                 #[serde(rename = "default_operator")]
                 default_operator: Option<DefaultOperator>,
                 #[serde(rename = "df")]
-                df: Option<&'a str>,
+                df: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "expand_wildcards")]
@@ -687,7 +687,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_throttled")]
@@ -699,18 +699,18 @@ where
                 #[serde(rename = "min_score")]
                 min_score: Option<i64>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "q")]
-                q: Option<&'a str>,
+                q: Option<&'b str>,
                 #[serde(
                     rename = "routing",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                routing: Option<&'a [&'a str]>,
+                routing: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "terminate_after")]
                 terminate_after: Option<i64>,
             }
@@ -747,13 +747,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Create API"]
-pub enum CreateParts<'a> {
+pub enum CreateParts<'b> {
     #[doc = "Index and Id"]
-    IndexId(&'a str, &'a str),
+    IndexId(&'b str, &'b str),
     #[doc = "Index, Type and Id"]
-    IndexTypeId(&'a str, &'a str, &'a str),
+    IndexTypeId(&'b str, &'b str, &'b str),
 }
-impl<'a> CreateParts<'a> {
+impl<'b> CreateParts<'b> {
     #[doc = "Builds a relative URL path to the Create API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -781,30 +781,30 @@ impl<'a> CreateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Create API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html). Creates a new document in the index.\n\nReturns a 409 response when a document with a same ID already exists in the index."]
-pub struct Create<'a, B> {
-    client: Elasticsearch,
-    parts: CreateParts<'a>,
+pub struct Create<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: CreateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    pipeline: Option<&'a str>,
+    pipeline: Option<&'b str>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
     version: Option<i64>,
     version_type: Option<VersionType>,
-    wait_for_active_shards: Option<&'a str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> Create<'a, B>
+impl<'a, 'b, B> Create<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Create] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: CreateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: CreateParts<'b>) -> Self {
         Create {
             client,
             parts,
@@ -825,7 +825,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Create<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Create<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -854,7 +854,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -869,7 +869,7 @@ where
         self
     }
     #[doc = "The pipeline id to preprocess incoming documents with"]
-    pub fn pipeline(mut self, pipeline: &'a str) -> Self {
+    pub fn pipeline(mut self, pipeline: &'b str) -> Self {
         self.pipeline = Some(pipeline);
         self
     }
@@ -884,17 +884,17 @@ where
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -909,7 +909,7 @@ where
         self
     }
     #[doc = "Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -921,34 +921,34 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pipeline")]
-                pipeline: Option<&'a str>,
+                pipeline: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "version")]
                 version: Option<i64>,
                 #[serde(rename = "version_type")]
                 version_type: Option<VersionType>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -976,13 +976,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Delete API"]
-pub enum DeleteParts<'a> {
+pub enum DeleteParts<'b> {
     #[doc = "Index and Id"]
-    IndexId(&'a str, &'a str),
+    IndexId(&'b str, &'b str),
     #[doc = "Index, Type and Id"]
-    IndexTypeId(&'a str, &'a str, &'a str),
+    IndexTypeId(&'b str, &'b str, &'b str),
 }
-impl<'a> DeleteParts<'a> {
+impl<'b> DeleteParts<'b> {
     #[doc = "Builds a relative URL path to the Delete API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1009,27 +1009,27 @@ impl<'a> DeleteParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html). Removes a document from the index."]
-pub struct Delete<'a> {
-    client: Elasticsearch,
-    parts: DeleteParts<'a>,
+pub struct Delete<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: DeleteParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     if_primary_term: Option<i64>,
     if_seq_no: Option<i64>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
     version: Option<i64>,
     version_type: Option<VersionType>,
-    wait_for_active_shards: Option<&'a str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a> Delete<'a> {
+impl<'a, 'b> Delete<'a, 'b> {
     #[doc = "Creates a new instance of [Delete] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: DeleteParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: DeleteParts<'b>) -> Self {
         Delete {
             client,
             parts,
@@ -1055,7 +1055,7 @@ impl<'a> Delete<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1090,17 +1090,17 @@ impl<'a> Delete<'a> {
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -1115,7 +1115,7 @@ impl<'a> Delete<'a> {
         self
     }
     #[doc = "Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -1127,14 +1127,14 @@ impl<'a> Delete<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "if_primary_term")]
@@ -1146,17 +1146,17 @@ impl<'a> Delete<'a> {
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "version")]
                 version: Option<i64>,
                 #[serde(rename = "version_type")]
                 version_type: Option<VersionType>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1185,13 +1185,13 @@ impl<'a> Delete<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Delete By Query API"]
-pub enum DeleteByQueryParts<'a> {
+pub enum DeleteByQueryParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> DeleteByQueryParts<'a> {
+impl<'b> DeleteByQueryParts<'b> {
     #[doc = "Builds a relative URL path to the Delete By Query API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1219,55 +1219,55 @@ impl<'a> DeleteByQueryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Delete By Query API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html). Deletes documents matching the provided query."]
-pub struct DeleteByQuery<'a, B> {
-    client: Elasticsearch,
-    parts: DeleteByQueryParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct DeleteByQuery<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: DeleteByQueryParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     allow_no_indices: Option<bool>,
     analyze_wildcard: Option<bool>,
     body: Option<B>,
     conflicts: Option<Conflicts>,
     default_operator: Option<DefaultOperator>,
-    df: Option<&'a str>,
+    df: Option<&'b str>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i64>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     lenient: Option<bool>,
     max_docs: Option<i64>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
-    q: Option<&'a str>,
+    q: Option<&'b str>,
     refresh: Option<bool>,
     request_cache: Option<bool>,
     requests_per_second: Option<i64>,
-    routing: Option<&'a [&'a str]>,
-    scroll: Option<&'a str>,
+    routing: Option<&'b [&'b str]>,
+    scroll: Option<&'b str>,
     scroll_size: Option<i64>,
-    search_timeout: Option<&'a str>,
+    search_timeout: Option<&'b str>,
     search_type: Option<SearchType>,
     size: Option<i64>,
     slices: Option<i64>,
-    sort: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
-    stats: Option<&'a [&'a str]>,
+    sort: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
+    stats: Option<&'b [&'b str]>,
     terminate_after: Option<i64>,
-    timeout: Option<&'a str>,
+    timeout: Option<&'b str>,
     version: Option<bool>,
-    wait_for_active_shards: Option<&'a str>,
+    wait_for_active_shards: Option<&'b str>,
     wait_for_completion: Option<bool>,
 }
-impl<'a, B> DeleteByQuery<'a, B>
+impl<'a, 'b, B> DeleteByQuery<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [DeleteByQuery] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: DeleteByQueryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: DeleteByQueryParts<'b>) -> Self {
         DeleteByQuery {
             client,
             parts,
@@ -1313,17 +1313,17 @@ where
         }
     }
     #[doc = "True or false to return the _source field or not, or a list of fields to return"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "A list of fields to exclude from the returned _source field"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "A list of fields to extract and return from the _source field"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
@@ -1338,7 +1338,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> DeleteByQuery<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> DeleteByQuery<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1397,7 +1397,7 @@ where
         self
     }
     #[doc = "The field to use as default where no field prefix is given in the query string"]
-    pub fn df(mut self, df: &'a str) -> Self {
+    pub fn df(mut self, df: &'b str) -> Self {
         self.df = Some(df);
         self
     }
@@ -1412,7 +1412,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1447,7 +1447,7 @@ where
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -1457,7 +1457,7 @@ where
         self
     }
     #[doc = "Query in the Lucene query string syntax"]
-    pub fn q(mut self, q: &'a str) -> Self {
+    pub fn q(mut self, q: &'b str) -> Self {
         self.q = Some(q);
         self
     }
@@ -1477,12 +1477,12 @@ where
         self
     }
     #[doc = "A comma-separated list of specific routing values"]
-    pub fn routing(mut self, routing: &'a [&'a str]) -> Self {
+    pub fn routing(mut self, routing: &'b [&'b str]) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "Specify how long a consistent view of the index should be maintained for scrolled search"]
-    pub fn scroll(mut self, scroll: &'a str) -> Self {
+    pub fn scroll(mut self, scroll: &'b str) -> Self {
         self.scroll = Some(scroll);
         self
     }
@@ -1492,7 +1492,7 @@ where
         self
     }
     #[doc = "Explicit timeout for each search request. Defaults to no timeout."]
-    pub fn search_timeout(mut self, search_timeout: &'a str) -> Self {
+    pub fn search_timeout(mut self, search_timeout: &'b str) -> Self {
         self.search_timeout = Some(search_timeout);
         self
     }
@@ -1512,17 +1512,17 @@ where
         self
     }
     #[doc = "A comma-separated list of <field>:<direction> pairs"]
-    pub fn sort(mut self, sort: &'a [&'a str]) -> Self {
+    pub fn sort(mut self, sort: &'b [&'b str]) -> Self {
         self.sort = Some(sort);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Specific 'tag' of the request for logging and statistical purposes"]
-    pub fn stats(mut self, stats: &'a [&'a str]) -> Self {
+    pub fn stats(mut self, stats: &'b [&'b str]) -> Self {
         self.stats = Some(stats);
         self
     }
@@ -1532,7 +1532,7 @@ where
         self
     }
     #[doc = "Time each individual bulk request should wait for shards that are unavailable."]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -1542,7 +1542,7 @@ where
         self
     }
     #[doc = "Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -1559,22 +1559,22 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "analyze_wildcard")]
@@ -1584,7 +1584,7 @@ where
                 #[serde(rename = "default_operator")]
                 default_operator: Option<DefaultOperator>,
                 #[serde(rename = "df")]
-                df: Option<&'a str>,
+                df: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "expand_wildcards")]
@@ -1593,7 +1593,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i64>,
                 #[serde(rename = "human")]
@@ -1605,11 +1605,11 @@ where
                 #[serde(rename = "max_docs")]
                 max_docs: Option<i64>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "q")]
-                q: Option<&'a str>,
+                q: Option<&'b str>,
                 #[serde(rename = "refresh")]
                 refresh: Option<bool>,
                 #[serde(rename = "request_cache")]
@@ -1620,13 +1620,13 @@ where
                     rename = "routing",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                routing: Option<&'a [&'a str]>,
+                routing: Option<&'b [&'b str]>,
                 #[serde(rename = "scroll")]
-                scroll: Option<&'a str>,
+                scroll: Option<&'b str>,
                 #[serde(rename = "scroll_size")]
                 scroll_size: Option<i64>,
                 #[serde(rename = "search_timeout")]
-                search_timeout: Option<&'a str>,
+                search_timeout: Option<&'b str>,
                 #[serde(rename = "search_type")]
                 search_type: Option<SearchType>,
                 #[serde(rename = "size")]
@@ -1634,19 +1634,19 @@ where
                 #[serde(rename = "slices")]
                 slices: Option<i64>,
                 #[serde(rename = "sort", serialize_with = "crate::client::serialize_coll_qs")]
-                sort: Option<&'a [&'a str]>,
+                sort: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "stats", serialize_with = "crate::client::serialize_coll_qs")]
-                stats: Option<&'a [&'a str]>,
+                stats: Option<&'b [&'b str]>,
                 #[serde(rename = "terminate_after")]
                 terminate_after: Option<i64>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "version")]
                 version: Option<bool>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
                 #[serde(rename = "wait_for_completion")]
                 wait_for_completion: Option<bool>,
             }
@@ -1701,11 +1701,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Delete By Query Rethrottle API"]
-pub enum DeleteByQueryRethrottleParts<'a> {
+pub enum DeleteByQueryRethrottleParts<'b> {
     #[doc = "TaskId"]
-    TaskId(&'a str),
+    TaskId(&'b str),
 }
-impl<'a> DeleteByQueryRethrottleParts<'a> {
+impl<'b> DeleteByQueryRethrottleParts<'b> {
     #[doc = "Builds a relative URL path to the Delete By Query Rethrottle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1721,24 +1721,24 @@ impl<'a> DeleteByQueryRethrottleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Delete By Query Rethrottle API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html). Changes the number of requests per second for a particular Delete By Query operation."]
-pub struct DeleteByQueryRethrottle<'a, B> {
-    client: Elasticsearch,
-    parts: DeleteByQueryRethrottleParts<'a>,
+pub struct DeleteByQueryRethrottle<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: DeleteByQueryRethrottleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     requests_per_second: Option<i64>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> DeleteByQueryRethrottle<'a, B>
+impl<'a, 'b, B> DeleteByQueryRethrottle<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [DeleteByQueryRethrottle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: DeleteByQueryRethrottleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: DeleteByQueryRethrottleParts<'b>) -> Self {
         DeleteByQueryRethrottle {
             client,
             parts,
@@ -1753,7 +1753,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> DeleteByQueryRethrottle<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> DeleteByQueryRethrottle<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -1776,7 +1776,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1801,7 +1801,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -1813,14 +1813,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -1828,7 +1828,7 @@ where
                 #[serde(rename = "requests_per_second")]
                 requests_per_second: Option<i64>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1850,11 +1850,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Delete Script API"]
-pub enum DeleteScriptParts<'a> {
+pub enum DeleteScriptParts<'b> {
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
 }
-impl<'a> DeleteScriptParts<'a> {
+impl<'b> DeleteScriptParts<'b> {
     #[doc = "Builds a relative URL path to the Delete Script API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -1869,21 +1869,21 @@ impl<'a> DeleteScriptParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Delete Script API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html). Deletes a script."]
-pub struct DeleteScript<'a> {
-    client: Elasticsearch,
-    parts: DeleteScriptParts<'a>,
+pub struct DeleteScript<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: DeleteScriptParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a> DeleteScript<'a> {
+impl<'a, 'b> DeleteScript<'a, 'b> {
     #[doc = "Creates a new instance of [DeleteScript] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: DeleteScriptParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: DeleteScriptParts<'b>) -> Self {
         DeleteScript {
             client,
             parts,
@@ -1903,7 +1903,7 @@ impl<'a> DeleteScript<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -1918,7 +1918,7 @@ impl<'a> DeleteScript<'a> {
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -1928,12 +1928,12 @@ impl<'a> DeleteScript<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -1945,24 +1945,24 @@ impl<'a> DeleteScript<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -1985,13 +1985,13 @@ impl<'a> DeleteScript<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Exists API"]
-pub enum ExistsParts<'a> {
+pub enum ExistsParts<'b> {
     #[doc = "Index and Id"]
-    IndexId(&'a str, &'a str),
+    IndexId(&'b str, &'b str),
     #[doc = "Index, Type and Id"]
-    IndexTypeId(&'a str, &'a str, &'a str),
+    IndexTypeId(&'b str, &'b str, &'b str),
 }
-impl<'a> ExistsParts<'a> {
+impl<'b> ExistsParts<'b> {
     #[doc = "Builds a relative URL path to the Exists API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2018,29 +2018,29 @@ impl<'a> ExistsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Exists API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html). Returns information about whether a document exists in an index."]
-pub struct Exists<'a> {
-    client: Elasticsearch,
-    parts: ExistsParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct Exists<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: ExistsParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
     realtime: Option<bool>,
     refresh: Option<bool>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
-    stored_fields: Option<&'a [&'a str]>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
+    stored_fields: Option<&'b [&'b str]>,
     version: Option<i64>,
     version_type: Option<VersionType>,
 }
-impl<'a> Exists<'a> {
+impl<'a, 'b> Exists<'a, 'b> {
     #[doc = "Creates a new instance of [Exists] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: ExistsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: ExistsParts<'b>) -> Self {
         Exists {
             client,
             parts,
@@ -2063,17 +2063,17 @@ impl<'a> Exists<'a> {
         }
     }
     #[doc = "True or false to return the _source field or not, or a list of fields to return"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "A list of fields to exclude from the returned _source field"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "A list of fields to extract and return from the _source field"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
@@ -2083,7 +2083,7 @@ impl<'a> Exists<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2098,7 +2098,7 @@ impl<'a> Exists<'a> {
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -2118,17 +2118,17 @@ impl<'a> Exists<'a> {
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "A comma-separated list of stored fields to return in the response"]
-    pub fn stored_fields(mut self, stored_fields: &'a [&'a str]) -> Self {
+    pub fn stored_fields(mut self, stored_fields: &'b [&'b str]) -> Self {
         self.stored_fields = Some(stored_fields);
         self
     }
@@ -2150,33 +2150,33 @@ impl<'a> Exists<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "realtime")]
@@ -2184,14 +2184,14 @@ impl<'a> Exists<'a> {
                 #[serde(rename = "refresh")]
                 refresh: Option<bool>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(
                     rename = "stored_fields",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                stored_fields: Option<&'a [&'a str]>,
+                stored_fields: Option<&'b [&'b str]>,
                 #[serde(rename = "version")]
                 version: Option<i64>,
                 #[serde(rename = "version_type")]
@@ -2226,13 +2226,13 @@ impl<'a> Exists<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Exists Source API"]
-pub enum ExistsSourceParts<'a> {
+pub enum ExistsSourceParts<'b> {
     #[doc = "Index and Id"]
-    IndexId(&'a str, &'a str),
+    IndexId(&'b str, &'b str),
     #[doc = "Index, Type and Id"]
-    IndexTypeId(&'a str, &'a str, &'a str),
+    IndexTypeId(&'b str, &'b str, &'b str),
 }
-impl<'a> ExistsSourceParts<'a> {
+impl<'b> ExistsSourceParts<'b> {
     #[doc = "Builds a relative URL path to the Exists Source API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2260,28 +2260,28 @@ impl<'a> ExistsSourceParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Exists Source API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html). Returns information about whether a document source exists in an index."]
-pub struct ExistsSource<'a> {
-    client: Elasticsearch,
-    parts: ExistsSourceParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct ExistsSource<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: ExistsSourceParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
     realtime: Option<bool>,
     refresh: Option<bool>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
     version: Option<i64>,
     version_type: Option<VersionType>,
 }
-impl<'a> ExistsSource<'a> {
+impl<'a, 'b> ExistsSource<'a, 'b> {
     #[doc = "Creates a new instance of [ExistsSource] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: ExistsSourceParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: ExistsSourceParts<'b>) -> Self {
         ExistsSource {
             client,
             parts,
@@ -2303,17 +2303,17 @@ impl<'a> ExistsSource<'a> {
         }
     }
     #[doc = "True or false to return the _source field or not, or a list of fields to return"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "A list of fields to exclude from the returned _source field"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "A list of fields to extract and return from the _source field"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
@@ -2323,7 +2323,7 @@ impl<'a> ExistsSource<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2338,7 +2338,7 @@ impl<'a> ExistsSource<'a> {
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -2358,12 +2358,12 @@ impl<'a> ExistsSource<'a> {
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2385,33 +2385,33 @@ impl<'a> ExistsSource<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "realtime")]
@@ -2419,9 +2419,9 @@ impl<'a> ExistsSource<'a> {
                 #[serde(rename = "refresh")]
                 refresh: Option<bool>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "version")]
                 version: Option<i64>,
                 #[serde(rename = "version_type")]
@@ -2455,13 +2455,13 @@ impl<'a> ExistsSource<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Explain API"]
-pub enum ExplainParts<'a> {
+pub enum ExplainParts<'b> {
     #[doc = "Index and Id"]
-    IndexId(&'a str, &'a str),
+    IndexId(&'b str, &'b str),
     #[doc = "Index, Type and Id"]
-    IndexTypeId(&'a str, &'a str, &'a str),
+    IndexTypeId(&'b str, &'b str, &'b str),
 }
-impl<'a> ExplainParts<'a> {
+impl<'b> ExplainParts<'b> {
     #[doc = "Builds a relative URL path to the Explain API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2489,35 +2489,35 @@ impl<'a> ExplainParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Explain API](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html). Returns information about why a specific matches (or doesn't match) a query."]
-pub struct Explain<'a, B> {
-    client: Elasticsearch,
-    parts: ExplainParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct Explain<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: ExplainParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     analyze_wildcard: Option<bool>,
-    analyzer: Option<&'a str>,
+    analyzer: Option<&'b str>,
     body: Option<B>,
     default_operator: Option<DefaultOperator>,
-    df: Option<&'a str>,
+    df: Option<&'b str>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     lenient: Option<bool>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
-    q: Option<&'a str>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
-    stored_fields: Option<&'a [&'a str]>,
+    q: Option<&'b str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
+    stored_fields: Option<&'b [&'b str]>,
 }
-impl<'a, B> Explain<'a, B>
+impl<'a, 'b, B> Explain<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Explain] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: ExplainParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: ExplainParts<'b>) -> Self {
         Explain {
             client,
             parts,
@@ -2543,17 +2543,17 @@ where
         }
     }
     #[doc = "True or false to return the _source field or not, or a list of fields to return"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "A list of fields to exclude from the returned _source field"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "A list of fields to extract and return from the _source field"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
@@ -2563,12 +2563,12 @@ where
         self
     }
     #[doc = "The analyzer for the query string query"]
-    pub fn analyzer(mut self, analyzer: &'a str) -> Self {
+    pub fn analyzer(mut self, analyzer: &'b str) -> Self {
         self.analyzer = Some(analyzer);
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Explain<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Explain<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2602,7 +2602,7 @@ where
         self
     }
     #[doc = "The default field for query string query (default: _all)"]
-    pub fn df(mut self, df: &'a str) -> Self {
+    pub fn df(mut self, df: &'b str) -> Self {
         self.df = Some(df);
         self
     }
@@ -2612,7 +2612,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2632,7 +2632,7 @@ where
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -2642,22 +2642,22 @@ where
         self
     }
     #[doc = "Query in the Lucene query string syntax"]
-    pub fn q(mut self, q: &'a str) -> Self {
+    pub fn q(mut self, q: &'b str) -> Self {
         self.q = Some(q);
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "A comma-separated list of stored fields to return in the response"]
-    pub fn stored_fields(mut self, stored_fields: &'a [&'a str]) -> Self {
+    pub fn stored_fields(mut self, stored_fields: &'b [&'b str]) -> Self {
         self.stored_fields = Some(stored_fields);
         self
     }
@@ -2672,56 +2672,56 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "analyze_wildcard")]
                 analyze_wildcard: Option<bool>,
                 #[serde(rename = "analyzer")]
-                analyzer: Option<&'a str>,
+                analyzer: Option<&'b str>,
                 #[serde(rename = "default_operator")]
                 default_operator: Option<DefaultOperator>,
                 #[serde(rename = "df")]
-                df: Option<&'a str>,
+                df: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "lenient")]
                 lenient: Option<bool>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "q")]
-                q: Option<&'a str>,
+                q: Option<&'b str>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(
                     rename = "stored_fields",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                stored_fields: Option<&'a [&'a str]>,
+                stored_fields: Option<&'b [&'b str]>,
             }
             let query_params = QueryParams {
                 _source: self._source,
@@ -2754,13 +2754,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Field Caps API"]
-pub enum FieldCapsParts<'a> {
+pub enum FieldCapsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> FieldCapsParts<'a> {
+impl<'b> FieldCapsParts<'b> {
     #[doc = "Builds a relative URL path to the Field Caps API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2778,28 +2778,28 @@ impl<'a> FieldCapsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Field Caps API](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html). Returns the information about the capabilities of fields among multiple indices."]
-pub struct FieldCaps<'a, B> {
-    client: Elasticsearch,
-    parts: FieldCapsParts<'a>,
+pub struct FieldCaps<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: FieldCapsParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    fields: Option<&'a [&'a str]>,
-    filter_path: Option<&'a [&'a str]>,
+    fields: Option<&'b [&'b str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     include_unmapped: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> FieldCaps<'a, B>
+impl<'a, 'b, B> FieldCaps<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [FieldCaps] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: FieldCapsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: FieldCapsParts<'b>) -> Self {
         FieldCaps {
             client,
             parts,
@@ -2823,7 +2823,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> FieldCaps<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> FieldCaps<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -2855,12 +2855,12 @@ where
         self
     }
     #[doc = "A comma-separated list of field names"]
-    pub fn fields(mut self, fields: &'a [&'a str]) -> Self {
+    pub fn fields(mut self, fields: &'b [&'b str]) -> Self {
         self.fields = Some(fields);
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -2890,7 +2890,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -2905,7 +2905,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -2913,12 +2913,12 @@ where
                 #[serde(rename = "expand_wildcards")]
                 expand_wildcards: Option<ExpandWildcards>,
                 #[serde(rename = "fields", serialize_with = "crate::client::serialize_coll_qs")]
-                fields: Option<&'a [&'a str]>,
+                fields: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -2928,7 +2928,7 @@ where
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -2954,13 +2954,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Get API"]
-pub enum GetParts<'a> {
+pub enum GetParts<'b> {
     #[doc = "Index and Id"]
-    IndexId(&'a str, &'a str),
+    IndexId(&'b str, &'b str),
     #[doc = "Index, Type and Id"]
-    IndexTypeId(&'a str, &'a str, &'a str),
+    IndexTypeId(&'b str, &'b str, &'b str),
 }
-impl<'a> GetParts<'a> {
+impl<'b> GetParts<'b> {
     #[doc = "Builds a relative URL path to the Get API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -2987,29 +2987,29 @@ impl<'a> GetParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Get API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html). Returns a document."]
-pub struct Get<'a> {
-    client: Elasticsearch,
-    parts: GetParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct Get<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: GetParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
     realtime: Option<bool>,
     refresh: Option<bool>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
-    stored_fields: Option<&'a [&'a str]>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
+    stored_fields: Option<&'b [&'b str]>,
     version: Option<i64>,
     version_type: Option<VersionType>,
 }
-impl<'a> Get<'a> {
+impl<'a, 'b> Get<'a, 'b> {
     #[doc = "Creates a new instance of [Get] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: GetParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: GetParts<'b>) -> Self {
         Get {
             client,
             parts,
@@ -3032,17 +3032,17 @@ impl<'a> Get<'a> {
         }
     }
     #[doc = "True or false to return the _source field or not, or a list of fields to return"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "A list of fields to exclude from the returned _source field"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "A list of fields to extract and return from the _source field"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
@@ -3052,7 +3052,7 @@ impl<'a> Get<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3067,7 +3067,7 @@ impl<'a> Get<'a> {
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -3087,17 +3087,17 @@ impl<'a> Get<'a> {
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "A comma-separated list of stored fields to return in the response"]
-    pub fn stored_fields(mut self, stored_fields: &'a [&'a str]) -> Self {
+    pub fn stored_fields(mut self, stored_fields: &'b [&'b str]) -> Self {
         self.stored_fields = Some(stored_fields);
         self
     }
@@ -3119,33 +3119,33 @@ impl<'a> Get<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "realtime")]
@@ -3153,14 +3153,14 @@ impl<'a> Get<'a> {
                 #[serde(rename = "refresh")]
                 refresh: Option<bool>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(
                     rename = "stored_fields",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                stored_fields: Option<&'a [&'a str]>,
+                stored_fields: Option<&'b [&'b str]>,
                 #[serde(rename = "version")]
                 version: Option<i64>,
                 #[serde(rename = "version_type")]
@@ -3195,11 +3195,11 @@ impl<'a> Get<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Get Script API"]
-pub enum GetScriptParts<'a> {
+pub enum GetScriptParts<'b> {
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
 }
-impl<'a> GetScriptParts<'a> {
+impl<'b> GetScriptParts<'b> {
     #[doc = "Builds a relative URL path to the Get Script API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3214,20 +3214,20 @@ impl<'a> GetScriptParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Get Script API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html). Returns a script."]
-pub struct GetScript<'a> {
-    client: Elasticsearch,
-    parts: GetScriptParts<'a>,
+pub struct GetScript<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: GetScriptParts<'b>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> GetScript<'a> {
+impl<'a, 'b> GetScript<'a, 'b> {
     #[doc = "Creates a new instance of [GetScript] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: GetScriptParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: GetScriptParts<'b>) -> Self {
         GetScript {
             client,
             parts,
@@ -3246,7 +3246,7 @@ impl<'a> GetScript<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3261,7 +3261,7 @@ impl<'a> GetScript<'a> {
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -3271,7 +3271,7 @@ impl<'a> GetScript<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3283,22 +3283,22 @@ impl<'a> GetScript<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -3320,13 +3320,13 @@ impl<'a> GetScript<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Get Source API"]
-pub enum GetSourceParts<'a> {
+pub enum GetSourceParts<'b> {
     #[doc = "Index and Id"]
-    IndexId(&'a str, &'a str),
+    IndexId(&'b str, &'b str),
     #[doc = "Index, Type and Id"]
-    IndexTypeId(&'a str, &'a str, &'a str),
+    IndexTypeId(&'b str, &'b str, &'b str),
 }
-impl<'a> GetSourceParts<'a> {
+impl<'b> GetSourceParts<'b> {
     #[doc = "Builds a relative URL path to the Get Source API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3354,28 +3354,28 @@ impl<'a> GetSourceParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Get Source API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html). Returns the source of a document."]
-pub struct GetSource<'a> {
-    client: Elasticsearch,
-    parts: GetSourceParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct GetSource<'a, 'b> {
+    client: &'a Elasticsearch,
+    parts: GetSourceParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
     realtime: Option<bool>,
     refresh: Option<bool>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
     version: Option<i64>,
     version_type: Option<VersionType>,
 }
-impl<'a> GetSource<'a> {
+impl<'a, 'b> GetSource<'a, 'b> {
     #[doc = "Creates a new instance of [GetSource] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: GetSourceParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: GetSourceParts<'b>) -> Self {
         GetSource {
             client,
             parts,
@@ -3397,17 +3397,17 @@ impl<'a> GetSource<'a> {
         }
     }
     #[doc = "True or false to return the _source field or not, or a list of fields to return"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "A list of fields to exclude from the returned _source field"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "A list of fields to extract and return from the _source field"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
@@ -3417,7 +3417,7 @@ impl<'a> GetSource<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3432,7 +3432,7 @@ impl<'a> GetSource<'a> {
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -3452,12 +3452,12 @@ impl<'a> GetSource<'a> {
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3479,33 +3479,33 @@ impl<'a> GetSource<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "realtime")]
@@ -3513,9 +3513,9 @@ impl<'a> GetSource<'a> {
                 #[serde(rename = "refresh")]
                 refresh: Option<bool>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "version")]
                 version: Option<i64>,
                 #[serde(rename = "version_type")]
@@ -3549,17 +3549,17 @@ impl<'a> GetSource<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Index API"]
-pub enum IndexParts<'a> {
+pub enum IndexParts<'b> {
     #[doc = "Index and Id"]
-    IndexId(&'a str, &'a str),
+    IndexId(&'b str, &'b str),
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
     #[doc = "Index and Type"]
-    IndexType(&'a str, &'a str),
+    IndexType(&'b str, &'b str),
     #[doc = "Index, Type and Id"]
-    IndexTypeId(&'a str, &'a str, &'a str),
+    IndexTypeId(&'b str, &'b str, &'b str),
 }
-impl<'a> IndexParts<'a> {
+impl<'b> IndexParts<'b> {
     #[doc = "Builds a relative URL path to the Index API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3601,33 +3601,33 @@ impl<'a> IndexParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Index API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html). Creates or updates a document in an index."]
-pub struct Index<'a, B> {
-    client: Elasticsearch,
-    parts: IndexParts<'a>,
+pub struct Index<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: IndexParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     if_primary_term: Option<i64>,
     if_seq_no: Option<i64>,
     op_type: Option<OpType>,
-    pipeline: Option<&'a str>,
+    pipeline: Option<&'b str>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
     version: Option<i64>,
     version_type: Option<VersionType>,
-    wait_for_active_shards: Option<&'a str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> Index<'a, B>
+impl<'a, 'b, B> Index<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Index] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: IndexParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: IndexParts<'b>) -> Self {
         Index {
             client,
             parts,
@@ -3651,7 +3651,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Index<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Index<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -3683,7 +3683,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3713,7 +3713,7 @@ where
         self
     }
     #[doc = "The pipeline id to preprocess incoming documents with"]
-    pub fn pipeline(mut self, pipeline: &'a str) -> Self {
+    pub fn pipeline(mut self, pipeline: &'b str) -> Self {
         self.pipeline = Some(pipeline);
         self
     }
@@ -3728,17 +3728,17 @@ where
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -3753,7 +3753,7 @@ where
         self
     }
     #[doc = "Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -3765,14 +3765,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "if_primary_term")]
@@ -3782,23 +3782,23 @@ where
                 #[serde(rename = "op_type")]
                 op_type: Option<OpType>,
                 #[serde(rename = "pipeline")]
-                pipeline: Option<&'a str>,
+                pipeline: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "refresh")]
                 refresh: Option<Refresh>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "version")]
                 version: Option<i64>,
                 #[serde(rename = "version_type")]
                 version_type: Option<VersionType>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -3843,19 +3843,19 @@ impl InfoParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Info API](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html). Returns basic information about the cluster."]
-pub struct Info<'a> {
-    client: Elasticsearch,
+pub struct Info<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: InfoParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> Info<'a> {
+impl<'a, 'b> Info<'a, 'b> {
     #[doc = "Creates a new instance of [Info]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Info {
             client,
             parts: InfoParts::None,
@@ -3873,7 +3873,7 @@ impl<'a> Info<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -3893,7 +3893,7 @@ impl<'a> Info<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -3905,20 +3905,20 @@ impl<'a> Info<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -3939,15 +3939,15 @@ impl<'a> Info<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Mget API"]
-pub enum MgetParts<'a> {
+pub enum MgetParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
     #[doc = "Index and Type"]
-    IndexType(&'a str, &'a str),
+    IndexType(&'b str, &'b str),
 }
-impl<'a> MgetParts<'a> {
+impl<'b> MgetParts<'b> {
     #[doc = "Builds a relative URL path to the Mget API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -3973,31 +3973,31 @@ impl<'a> MgetParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Mget API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html). Allows to get multiple documents in one request."]
-pub struct Mget<'a, B> {
-    client: Elasticsearch,
-    parts: MgetParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct Mget<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MgetParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
     realtime: Option<bool>,
     refresh: Option<bool>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
-    stored_fields: Option<&'a [&'a str]>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
+    stored_fields: Option<&'b [&'b str]>,
 }
-impl<'a, B> Mget<'a, B>
+impl<'a, 'b, B> Mget<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Mget] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MgetParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MgetParts<'b>) -> Self {
         Mget {
             client,
             parts,
@@ -4019,22 +4019,22 @@ where
         }
     }
     #[doc = "True or false to return the _source field or not, or a list of fields to return"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "A list of fields to exclude from the returned _source field"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "A list of fields to extract and return from the _source field"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Mget<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Mget<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4064,7 +4064,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4079,7 +4079,7 @@ where
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -4099,17 +4099,17 @@ where
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "A comma-separated list of stored fields to return in the response"]
-    pub fn stored_fields(mut self, stored_fields: &'a [&'a str]) -> Self {
+    pub fn stored_fields(mut self, stored_fields: &'b [&'b str]) -> Self {
         self.stored_fields = Some(stored_fields);
         self
     }
@@ -4124,33 +4124,33 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "realtime")]
@@ -4158,14 +4158,14 @@ where
                 #[serde(rename = "refresh")]
                 refresh: Option<bool>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(
                     rename = "stored_fields",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                stored_fields: Option<&'a [&'a str]>,
+                stored_fields: Option<&'b [&'b str]>,
             }
             let query_params = QueryParams {
                 _source: self._source,
@@ -4194,15 +4194,15 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Msearch API"]
-pub enum MsearchParts<'a> {
+pub enum MsearchParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> MsearchParts<'a> {
+impl<'b> MsearchParts<'b> {
     #[doc = "Builds a relative URL path to the Msearch API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4231,13 +4231,13 @@ impl<'a> MsearchParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Msearch API](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html). Allows to execute several search operations in one request."]
-pub struct Msearch<'a, B> {
-    client: Elasticsearch,
-    parts: MsearchParts<'a>,
+pub struct Msearch<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MsearchParts<'b>,
     body: Option<B>,
     ccs_minimize_roundtrips: Option<bool>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     max_concurrent_searches: Option<i64>,
@@ -4246,15 +4246,15 @@ pub struct Msearch<'a, B> {
     pretty: Option<bool>,
     rest_total_hits_as_int: Option<bool>,
     search_type: Option<SearchType>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     typed_keys: Option<bool>,
 }
-impl<'a, B> Msearch<'a, B>
+impl<'a, 'b, B> Msearch<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Msearch] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MsearchParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MsearchParts<'b>) -> Self {
         Msearch {
             client,
             parts,
@@ -4275,7 +4275,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: Vec<T>) -> Msearch<'a, NdBody<T>>
+    pub fn body<T>(self, body: Vec<T>) -> Msearch<'a, 'b, NdBody<T>>
     where
         T: Body,
     {
@@ -4309,7 +4309,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4354,7 +4354,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4374,7 +4374,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "ccs_minimize_roundtrips")]
                 ccs_minimize_roundtrips: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -4383,7 +4383,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "max_concurrent_searches")]
@@ -4399,7 +4399,7 @@ where
                 #[serde(rename = "search_type")]
                 search_type: Option<SearchType>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "typed_keys")]
                 typed_keys: Option<bool>,
             }
@@ -4429,15 +4429,15 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Msearch Template API"]
-pub enum MsearchTemplateParts<'a> {
+pub enum MsearchTemplateParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> MsearchTemplateParts<'a> {
+impl<'b> MsearchTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Msearch Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4466,27 +4466,27 @@ impl<'a> MsearchTemplateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Msearch Template API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html). Allows to execute several search template operations in one request."]
-pub struct MsearchTemplate<'a, B> {
-    client: Elasticsearch,
-    parts: MsearchTemplateParts<'a>,
+pub struct MsearchTemplate<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MsearchTemplateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     max_concurrent_searches: Option<i64>,
     pretty: Option<bool>,
     rest_total_hits_as_int: Option<bool>,
     search_type: Option<SearchType>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     typed_keys: Option<bool>,
 }
-impl<'a, B> MsearchTemplate<'a, B>
+impl<'a, 'b, B> MsearchTemplate<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [MsearchTemplate] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MsearchTemplateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MsearchTemplateParts<'b>) -> Self {
         MsearchTemplate {
             client,
             parts,
@@ -4504,7 +4504,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: Vec<T>) -> MsearchTemplate<'a, NdBody<T>>
+    pub fn body<T>(self, body: Vec<T>) -> MsearchTemplate<'a, 'b, NdBody<T>>
     where
         T: Body,
     {
@@ -4530,7 +4530,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4565,7 +4565,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4585,14 +4585,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "max_concurrent_searches")]
@@ -4604,7 +4604,7 @@ where
                 #[serde(rename = "search_type")]
                 search_type: Option<SearchType>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "typed_keys")]
                 typed_keys: Option<bool>,
             }
@@ -4631,15 +4631,15 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Mtermvectors API"]
-pub enum MtermvectorsParts<'a> {
+pub enum MtermvectorsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
     #[doc = "Index and Type"]
-    IndexType(&'a str, &'a str),
+    IndexType(&'b str, &'b str),
 }
-impl<'a> MtermvectorsParts<'a> {
+impl<'b> MtermvectorsParts<'b> {
     #[doc = "Builds a relative URL path to the Mtermvectors API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -4665,35 +4665,35 @@ impl<'a> MtermvectorsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Mtermvectors API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html). Returns multiple termvectors in one request."]
-pub struct Mtermvectors<'a, B> {
-    client: Elasticsearch,
-    parts: MtermvectorsParts<'a>,
+pub struct Mtermvectors<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: MtermvectorsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
     field_statistics: Option<bool>,
-    fields: Option<&'a [&'a str]>,
-    filter_path: Option<&'a [&'a str]>,
+    fields: Option<&'b [&'b str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    ids: Option<&'a [&'a str]>,
+    ids: Option<&'b [&'b str]>,
     offsets: Option<bool>,
     payloads: Option<bool>,
     positions: Option<bool>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
     realtime: Option<bool>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
     term_statistics: Option<bool>,
     version: Option<i64>,
     version_type: Option<VersionType>,
 }
-impl<'a, B> Mtermvectors<'a, B>
+impl<'a, 'b, B> Mtermvectors<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Mtermvectors] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: MtermvectorsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: MtermvectorsParts<'b>) -> Self {
         Mtermvectors {
             client,
             parts,
@@ -4719,7 +4719,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Mtermvectors<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Mtermvectors<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -4758,12 +4758,12 @@ where
         self
     }
     #[doc = "A comma-separated list of fields to return. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\"."]
-    pub fn fields(mut self, fields: &'a [&'a str]) -> Self {
+    pub fn fields(mut self, fields: &'b [&'b str]) -> Self {
         self.fields = Some(fields);
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4778,7 +4778,7 @@ where
         self
     }
     #[doc = "A comma-separated list of documents ids. You must define ids as parameter or set \"ids\" or \"docs\" in the request body"]
-    pub fn ids(mut self, ids: &'a [&'a str]) -> Self {
+    pub fn ids(mut self, ids: &'b [&'b str]) -> Self {
         self.ids = Some(ids);
         self
     }
@@ -4798,7 +4798,7 @@ where
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random) .Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\"."]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -4813,12 +4813,12 @@ where
         self
     }
     #[doc = "Specific routing value. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\"."]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4848,22 +4848,22 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "field_statistics")]
                 field_statistics: Option<bool>,
                 #[serde(rename = "fields", serialize_with = "crate::client::serialize_coll_qs")]
-                fields: Option<&'a [&'a str]>,
+                fields: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ids", serialize_with = "crate::client::serialize_coll_qs")]
-                ids: Option<&'a [&'a str]>,
+                ids: Option<&'b [&'b str]>,
                 #[serde(rename = "offsets")]
                 offsets: Option<bool>,
                 #[serde(rename = "payloads")]
@@ -4871,15 +4871,15 @@ where
                 #[serde(rename = "positions")]
                 positions: Option<bool>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "realtime")]
                 realtime: Option<bool>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "term_statistics")]
                 term_statistics: Option<bool>,
                 #[serde(rename = "version")]
@@ -4932,19 +4932,19 @@ impl PingParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ping API](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html). Returns whether the cluster is running."]
-pub struct Ping<'a> {
-    client: Elasticsearch,
+pub struct Ping<'a, 'b> {
+    client: &'a Elasticsearch,
     parts: PingParts,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a> Ping<'a> {
+impl<'a, 'b> Ping<'a, 'b> {
     #[doc = "Creates a new instance of [Ping]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Ping {
             client,
             parts: PingParts::None,
@@ -4962,7 +4962,7 @@ impl<'a> Ping<'a> {
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -4982,7 +4982,7 @@ impl<'a> Ping<'a> {
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -4994,20 +4994,20 @@ impl<'a> Ping<'a> {
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -5028,13 +5028,13 @@ impl<'a> Ping<'a> {
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Put Script API"]
-pub enum PutScriptParts<'a> {
+pub enum PutScriptParts<'b> {
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
     #[doc = "Id and Context"]
-    IdContext(&'a str, &'a str),
+    IdContext(&'b str, &'b str),
 }
-impl<'a> PutScriptParts<'a> {
+impl<'b> PutScriptParts<'b> {
     #[doc = "Builds a relative URL path to the Put Script API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5057,26 +5057,26 @@ impl<'a> PutScriptParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Put Script API](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html). Creates or updates a script."]
-pub struct PutScript<'a, B> {
-    client: Elasticsearch,
-    parts: PutScriptParts<'a>,
+pub struct PutScript<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: PutScriptParts<'b>,
     body: Option<B>,
-    context: Option<&'a str>,
+    context: Option<&'b str>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
-    master_timeout: Option<&'a str>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, B> PutScript<'a, B>
+impl<'a, 'b, B> PutScript<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [PutScript] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: PutScriptParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: PutScriptParts<'b>) -> Self {
         PutScript {
             client,
             parts,
@@ -5093,7 +5093,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> PutScript<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> PutScript<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5113,7 +5113,7 @@ where
         }
     }
     #[doc = "Context name to compile script against"]
-    pub fn context(mut self, context: &'a str) -> Self {
+    pub fn context(mut self, context: &'b str) -> Self {
         self.context = Some(context);
         self
     }
@@ -5123,7 +5123,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5138,7 +5138,7 @@ where
         self
     }
     #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'a str) -> Self {
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
         self.master_timeout = Some(master_timeout);
         self
     }
@@ -5148,12 +5148,12 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -5165,26 +5165,26 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "context")]
-                context: Option<&'a str>,
+                context: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'a str>,
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
                 context: self.context,
@@ -5222,31 +5222,31 @@ impl ReindexParts {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Reindex API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html). Allows to copy documents from one index to another, optionally filtering the source\ndocuments by a query, changing the destination index settings, or fetching the\ndocuments from a remote cluster."]
-pub struct Reindex<'a, B> {
-    client: Elasticsearch,
+pub struct Reindex<'a, 'b, B> {
+    client: &'a Elasticsearch,
     parts: ReindexParts,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     max_docs: Option<i64>,
     pretty: Option<bool>,
     refresh: Option<bool>,
     requests_per_second: Option<i64>,
-    scroll: Option<&'a str>,
+    scroll: Option<&'b str>,
     slices: Option<i64>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
     wait_for_completion: Option<bool>,
 }
-impl<'a, B> Reindex<'a, B>
+impl<'a, 'b, B> Reindex<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Reindex]"]
-    pub fn new(client: Elasticsearch) -> Self {
+    pub fn new(client: &'a Elasticsearch) -> Self {
         Reindex {
             client,
             parts: ReindexParts::None,
@@ -5268,7 +5268,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Reindex<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Reindex<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5298,7 +5298,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5333,7 +5333,7 @@ where
         self
     }
     #[doc = "Control how long to keep the search context alive"]
-    pub fn scroll(mut self, scroll: &'a str) -> Self {
+    pub fn scroll(mut self, scroll: &'b str) -> Self {
         self.scroll = Some(scroll);
         self
     }
@@ -5343,17 +5343,17 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Time each individual bulk request should wait for shards that are unavailable."]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Sets the number of shard copies that must be active before proceeding with the reindex operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -5370,14 +5370,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "max_docs")]
@@ -5389,15 +5389,15 @@ where
                 #[serde(rename = "requests_per_second")]
                 requests_per_second: Option<i64>,
                 #[serde(rename = "scroll")]
-                scroll: Option<&'a str>,
+                scroll: Option<&'b str>,
                 #[serde(rename = "slices")]
                 slices: Option<i64>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
                 #[serde(rename = "wait_for_completion")]
                 wait_for_completion: Option<bool>,
             }
@@ -5428,11 +5428,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Reindex Rethrottle API"]
-pub enum ReindexRethrottleParts<'a> {
+pub enum ReindexRethrottleParts<'b> {
     #[doc = "TaskId"]
-    TaskId(&'a str),
+    TaskId(&'b str),
 }
-impl<'a> ReindexRethrottleParts<'a> {
+impl<'b> ReindexRethrottleParts<'b> {
     #[doc = "Builds a relative URL path to the Reindex Rethrottle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5448,24 +5448,24 @@ impl<'a> ReindexRethrottleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Reindex Rethrottle API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html). Changes the number of requests per second for a particular Reindex operation."]
-pub struct ReindexRethrottle<'a, B> {
-    client: Elasticsearch,
-    parts: ReindexRethrottleParts<'a>,
+pub struct ReindexRethrottle<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: ReindexRethrottleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     requests_per_second: Option<i64>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> ReindexRethrottle<'a, B>
+impl<'a, 'b, B> ReindexRethrottle<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [ReindexRethrottle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: ReindexRethrottleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: ReindexRethrottleParts<'b>) -> Self {
         ReindexRethrottle {
             client,
             parts,
@@ -5480,7 +5480,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> ReindexRethrottle<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> ReindexRethrottle<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5503,7 +5503,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5528,7 +5528,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -5540,14 +5540,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -5555,7 +5555,7 @@ where
                 #[serde(rename = "requests_per_second")]
                 requests_per_second: Option<i64>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -5577,13 +5577,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Render Search Template API"]
-pub enum RenderSearchTemplateParts<'a> {
+pub enum RenderSearchTemplateParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Id"]
-    Id(&'a str),
+    Id(&'b str),
 }
-impl<'a> RenderSearchTemplateParts<'a> {
+impl<'b> RenderSearchTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Render Search Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5599,23 +5599,23 @@ impl<'a> RenderSearchTemplateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Render Search Template API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#_validating_templates). Allows to use the Mustache language to pre-render a search definition."]
-pub struct RenderSearchTemplate<'a, B> {
-    client: Elasticsearch,
-    parts: RenderSearchTemplateParts<'a>,
+pub struct RenderSearchTemplate<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: RenderSearchTemplateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> RenderSearchTemplate<'a, B>
+impl<'a, 'b, B> RenderSearchTemplate<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [RenderSearchTemplate] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: RenderSearchTemplateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: RenderSearchTemplateParts<'b>) -> Self {
         RenderSearchTemplate {
             client,
             parts,
@@ -5629,7 +5629,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> RenderSearchTemplate<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> RenderSearchTemplate<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5651,7 +5651,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5671,7 +5671,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -5686,20 +5686,20 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -5720,13 +5720,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Scroll API"]
-pub enum ScrollParts<'a> {
+pub enum ScrollParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "ScrollId"]
-    ScrollId(&'a str),
+    ScrollId(&'b str),
 }
-impl<'a> ScrollParts<'a> {
+impl<'b> ScrollParts<'b> {
     #[doc = "Builds a relative URL path to the Scroll API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5742,26 +5742,26 @@ impl<'a> ScrollParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll). Allows to retrieve a large numbers of results from a single search request."]
-pub struct Scroll<'a, B> {
-    client: Elasticsearch,
-    parts: ScrollParts<'a>,
+pub struct Scroll<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: ScrollParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     rest_total_hits_as_int: Option<bool>,
-    scroll: Option<&'a str>,
-    scroll_id: Option<&'a str>,
-    source: Option<&'a str>,
+    scroll: Option<&'b str>,
+    scroll_id: Option<&'b str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> Scroll<'a, B>
+impl<'a, 'b, B> Scroll<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Scroll] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: ScrollParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: ScrollParts<'b>) -> Self {
         Scroll {
             client,
             parts,
@@ -5778,7 +5778,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Scroll<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Scroll<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -5803,7 +5803,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -5828,17 +5828,17 @@ where
         self
     }
     #[doc = "Specify how long a consistent view of the index should be maintained for scrolled search"]
-    pub fn scroll(mut self, scroll: &'a str) -> Self {
+    pub fn scroll(mut self, scroll: &'b str) -> Self {
         self.scroll = Some(scroll);
         self
     }
     #[doc = "The scroll ID for scrolled search"]
-    pub fn scroll_id(mut self, scroll_id: &'a str) -> Self {
+    pub fn scroll_id(mut self, scroll_id: &'b str) -> Self {
         self.scroll_id = Some(scroll_id);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -5853,14 +5853,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -5868,11 +5868,11 @@ where
                 #[serde(rename = "rest_total_hits_as_int")]
                 rest_total_hits_as_int: Option<bool>,
                 #[serde(rename = "scroll")]
-                scroll: Option<&'a str>,
+                scroll: Option<&'b str>,
                 #[serde(rename = "scroll_id")]
-                scroll_id: Option<&'a str>,
+                scroll_id: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -5896,15 +5896,15 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Search API"]
-pub enum SearchParts<'a> {
+pub enum SearchParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> SearchParts<'a> {
+impl<'b> SearchParts<'b> {
     #[doc = "Builds a relative URL path to the Search API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -5933,26 +5933,26 @@ impl<'a> SearchParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Search API](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html). Returns results matching a query."]
-pub struct Search<'a, B> {
-    client: Elasticsearch,
-    parts: SearchParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct Search<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SearchParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     allow_no_indices: Option<bool>,
     allow_partial_search_results: Option<bool>,
     analyze_wildcard: Option<bool>,
-    analyzer: Option<&'a str>,
+    analyzer: Option<&'b str>,
     batched_reduce_size: Option<i64>,
     body: Option<B>,
     ccs_minimize_roundtrips: Option<bool>,
     default_operator: Option<DefaultOperator>,
-    df: Option<&'a str>,
-    docvalue_fields: Option<&'a [&'a str]>,
+    df: Option<&'b str>,
+    docvalue_fields: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
     explain: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i64>,
     headers: HeaderMap,
     human: Option<bool>,
@@ -5961,37 +5961,37 @@ pub struct Search<'a, B> {
     lenient: Option<bool>,
     max_concurrent_shard_requests: Option<i64>,
     pre_filter_shard_size: Option<i64>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
-    q: Option<&'a str>,
+    q: Option<&'b str>,
     request_cache: Option<bool>,
     rest_total_hits_as_int: Option<bool>,
-    routing: Option<&'a [&'a str]>,
-    scroll: Option<&'a str>,
+    routing: Option<&'b [&'b str]>,
+    scroll: Option<&'b str>,
     search_type: Option<SearchType>,
     seq_no_primary_term: Option<bool>,
     size: Option<i64>,
-    sort: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
-    stats: Option<&'a [&'a str]>,
-    stored_fields: Option<&'a [&'a str]>,
-    suggest_field: Option<&'a str>,
+    sort: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
+    stats: Option<&'b [&'b str]>,
+    stored_fields: Option<&'b [&'b str]>,
+    suggest_field: Option<&'b str>,
     suggest_mode: Option<SuggestMode>,
     suggest_size: Option<i64>,
-    suggest_text: Option<&'a str>,
+    suggest_text: Option<&'b str>,
     terminate_after: Option<i64>,
-    timeout: Option<&'a str>,
+    timeout: Option<&'b str>,
     track_scores: Option<bool>,
     track_total_hits: Option<bool>,
     typed_keys: Option<bool>,
     version: Option<bool>,
 }
-impl<'a, B> Search<'a, B>
+impl<'a, 'b, B> Search<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Search] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SearchParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SearchParts<'b>) -> Self {
         Search {
             client,
             parts,
@@ -6047,17 +6047,17 @@ where
         }
     }
     #[doc = "True or false to return the _source field or not, or a list of fields to return"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "A list of fields to exclude from the returned _source field"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "A list of fields to extract and return from the _source field"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
@@ -6077,7 +6077,7 @@ where
         self
     }
     #[doc = "The analyzer to use for the query string"]
-    pub fn analyzer(mut self, analyzer: &'a str) -> Self {
+    pub fn analyzer(mut self, analyzer: &'b str) -> Self {
         self.analyzer = Some(analyzer);
         self
     }
@@ -6087,7 +6087,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Search<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Search<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6156,12 +6156,12 @@ where
         self
     }
     #[doc = "The field to use as default where no field prefix is given in the query string"]
-    pub fn df(mut self, df: &'a str) -> Self {
+    pub fn df(mut self, df: &'b str) -> Self {
         self.df = Some(df);
         self
     }
     #[doc = "A comma-separated list of fields to return as the docvalue representation of a field for each hit"]
-    pub fn docvalue_fields(mut self, docvalue_fields: &'a [&'a str]) -> Self {
+    pub fn docvalue_fields(mut self, docvalue_fields: &'b [&'b str]) -> Self {
         self.docvalue_fields = Some(docvalue_fields);
         self
     }
@@ -6181,7 +6181,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6226,7 +6226,7 @@ where
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -6236,7 +6236,7 @@ where
         self
     }
     #[doc = "Query in the Lucene query string syntax"]
-    pub fn q(mut self, q: &'a str) -> Self {
+    pub fn q(mut self, q: &'b str) -> Self {
         self.q = Some(q);
         self
     }
@@ -6251,12 +6251,12 @@ where
         self
     }
     #[doc = "A comma-separated list of specific routing values"]
-    pub fn routing(mut self, routing: &'a [&'a str]) -> Self {
+    pub fn routing(mut self, routing: &'b [&'b str]) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "Specify how long a consistent view of the index should be maintained for scrolled search"]
-    pub fn scroll(mut self, scroll: &'a str) -> Self {
+    pub fn scroll(mut self, scroll: &'b str) -> Self {
         self.scroll = Some(scroll);
         self
     }
@@ -6276,27 +6276,27 @@ where
         self
     }
     #[doc = "A comma-separated list of <field>:<direction> pairs"]
-    pub fn sort(mut self, sort: &'a [&'a str]) -> Self {
+    pub fn sort(mut self, sort: &'b [&'b str]) -> Self {
         self.sort = Some(sort);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Specific 'tag' of the request for logging and statistical purposes"]
-    pub fn stats(mut self, stats: &'a [&'a str]) -> Self {
+    pub fn stats(mut self, stats: &'b [&'b str]) -> Self {
         self.stats = Some(stats);
         self
     }
     #[doc = "A comma-separated list of stored fields to return as part of a hit"]
-    pub fn stored_fields(mut self, stored_fields: &'a [&'a str]) -> Self {
+    pub fn stored_fields(mut self, stored_fields: &'b [&'b str]) -> Self {
         self.stored_fields = Some(stored_fields);
         self
     }
     #[doc = "Specify which field to use for suggestions"]
-    pub fn suggest_field(mut self, suggest_field: &'a str) -> Self {
+    pub fn suggest_field(mut self, suggest_field: &'b str) -> Self {
         self.suggest_field = Some(suggest_field);
         self
     }
@@ -6311,7 +6311,7 @@ where
         self
     }
     #[doc = "The source text for which the suggestions should be returned"]
-    pub fn suggest_text(mut self, suggest_text: &'a str) -> Self {
+    pub fn suggest_text(mut self, suggest_text: &'b str) -> Self {
         self.suggest_text = Some(suggest_text);
         self
     }
@@ -6321,7 +6321,7 @@ where
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -6356,22 +6356,22 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "allow_partial_search_results")]
@@ -6379,7 +6379,7 @@ where
                 #[serde(rename = "analyze_wildcard")]
                 analyze_wildcard: Option<bool>,
                 #[serde(rename = "analyzer")]
-                analyzer: Option<&'a str>,
+                analyzer: Option<&'b str>,
                 #[serde(rename = "batched_reduce_size")]
                 batched_reduce_size: Option<i64>,
                 #[serde(rename = "ccs_minimize_roundtrips")]
@@ -6387,12 +6387,12 @@ where
                 #[serde(rename = "default_operator")]
                 default_operator: Option<DefaultOperator>,
                 #[serde(rename = "df")]
-                df: Option<&'a str>,
+                df: Option<&'b str>,
                 #[serde(
                     rename = "docvalue_fields",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                docvalue_fields: Option<&'a [&'a str]>,
+                docvalue_fields: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "expand_wildcards")]
@@ -6403,7 +6403,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i64>,
                 #[serde(rename = "human")]
@@ -6419,11 +6419,11 @@ where
                 #[serde(rename = "pre_filter_shard_size")]
                 pre_filter_shard_size: Option<i64>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "q")]
-                q: Option<&'a str>,
+                q: Option<&'b str>,
                 #[serde(rename = "request_cache")]
                 request_cache: Option<bool>,
                 #[serde(rename = "rest_total_hits_as_int")]
@@ -6432,9 +6432,9 @@ where
                     rename = "routing",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                routing: Option<&'a [&'a str]>,
+                routing: Option<&'b [&'b str]>,
                 #[serde(rename = "scroll")]
-                scroll: Option<&'a str>,
+                scroll: Option<&'b str>,
                 #[serde(rename = "search_type")]
                 search_type: Option<SearchType>,
                 #[serde(rename = "seq_no_primary_term")]
@@ -6442,28 +6442,28 @@ where
                 #[serde(rename = "size")]
                 size: Option<i64>,
                 #[serde(rename = "sort", serialize_with = "crate::client::serialize_coll_qs")]
-                sort: Option<&'a [&'a str]>,
+                sort: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "stats", serialize_with = "crate::client::serialize_coll_qs")]
-                stats: Option<&'a [&'a str]>,
+                stats: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "stored_fields",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                stored_fields: Option<&'a [&'a str]>,
+                stored_fields: Option<&'b [&'b str]>,
                 #[serde(rename = "suggest_field")]
-                suggest_field: Option<&'a str>,
+                suggest_field: Option<&'b str>,
                 #[serde(rename = "suggest_mode")]
                 suggest_mode: Option<SuggestMode>,
                 #[serde(rename = "suggest_size")]
                 suggest_size: Option<i64>,
                 #[serde(rename = "suggest_text")]
-                suggest_text: Option<&'a str>,
+                suggest_text: Option<&'b str>,
                 #[serde(rename = "terminate_after")]
                 terminate_after: Option<i64>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "track_scores")]
                 track_scores: Option<bool>,
                 #[serde(rename = "track_total_hits")]
@@ -6534,13 +6534,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Search Shards API"]
-pub enum SearchShardsParts<'a> {
+pub enum SearchShardsParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
 }
-impl<'a> SearchShardsParts<'a> {
+impl<'b> SearchShardsParts<'b> {
     #[doc = "Builds a relative URL path to the Search Shards API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -6558,29 +6558,29 @@ impl<'a> SearchShardsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Search Shards API](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html). Returns information about the indices and shards that a search request would be executed against."]
-pub struct SearchShards<'a, B> {
-    client: Elasticsearch,
-    parts: SearchShardsParts<'a>,
+pub struct SearchShards<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SearchShardsParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     local: Option<bool>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> SearchShards<'a, B>
+impl<'a, 'b, B> SearchShards<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SearchShards] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SearchShardsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SearchShardsParts<'b>) -> Self {
         SearchShards {
             client,
             parts,
@@ -6605,7 +6605,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SearchShards<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SearchShards<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6638,7 +6638,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6663,7 +6663,7 @@ where
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -6673,12 +6673,12 @@ where
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -6693,7 +6693,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -6704,7 +6704,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_unavailable")]
@@ -6712,13 +6712,13 @@ where
                 #[serde(rename = "local")]
                 local: Option<bool>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 allow_no_indices: self.allow_no_indices,
@@ -6745,15 +6745,15 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Search Template API"]
-pub enum SearchTemplateParts<'a> {
+pub enum SearchTemplateParts<'b> {
     #[doc = "No parts"]
     None,
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> SearchTemplateParts<'a> {
+impl<'b> SearchTemplateParts<'b> {
     #[doc = "Builds a relative URL path to the Search Template API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -6782,35 +6782,35 @@ impl<'a> SearchTemplateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Search Template API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html). Allows to use the Mustache language to pre-render a search definition."]
-pub struct SearchTemplate<'a, B> {
-    client: Elasticsearch,
-    parts: SearchTemplateParts<'a>,
+pub struct SearchTemplate<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: SearchTemplateParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
     explain: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_throttled: Option<bool>,
     ignore_unavailable: Option<bool>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
     profile: Option<bool>,
     rest_total_hits_as_int: Option<bool>,
-    routing: Option<&'a [&'a str]>,
-    scroll: Option<&'a str>,
+    routing: Option<&'b [&'b str]>,
+    scroll: Option<&'b str>,
     search_type: Option<SearchType>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
     typed_keys: Option<bool>,
 }
-impl<'a, B> SearchTemplate<'a, B>
+impl<'a, 'b, B> SearchTemplate<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [SearchTemplate] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: SearchTemplateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: SearchTemplateParts<'b>) -> Self {
         SearchTemplate {
             client,
             parts,
@@ -6841,7 +6841,7 @@ where
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SearchTemplate<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> SearchTemplate<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -6885,7 +6885,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -6910,7 +6910,7 @@ where
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -6930,12 +6930,12 @@ where
         self
     }
     #[doc = "A comma-separated list of specific routing values"]
-    pub fn routing(mut self, routing: &'a [&'a str]) -> Self {
+    pub fn routing(mut self, routing: &'b [&'b str]) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "Specify how long a consistent view of the index should be maintained for scrolled search"]
-    pub fn scroll(mut self, scroll: &'a str) -> Self {
+    pub fn scroll(mut self, scroll: &'b str) -> Self {
         self.scroll = Some(scroll);
         self
     }
@@ -6945,7 +6945,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -6965,7 +6965,7 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "error_trace")]
@@ -6978,7 +6978,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "ignore_throttled")]
@@ -6986,7 +6986,7 @@ where
                 #[serde(rename = "ignore_unavailable")]
                 ignore_unavailable: Option<bool>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "profile")]
@@ -6997,13 +6997,13 @@ where
                     rename = "routing",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                routing: Option<&'a [&'a str]>,
+                routing: Option<&'b [&'b str]>,
                 #[serde(rename = "scroll")]
-                scroll: Option<&'a str>,
+                scroll: Option<&'b str>,
                 #[serde(rename = "search_type")]
                 search_type: Option<SearchType>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "typed_keys")]
                 typed_keys: Option<bool>,
             }
@@ -7038,17 +7038,17 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Termvectors API"]
-pub enum TermvectorsParts<'a> {
+pub enum TermvectorsParts<'b> {
     #[doc = "Index and Id"]
-    IndexId(&'a str, &'a str),
+    IndexId(&'b str, &'b str),
     #[doc = "Index"]
-    Index(&'a str),
+    Index(&'b str),
     #[doc = "Index, Type and Id"]
-    IndexTypeId(&'a str, &'a str, &'a str),
+    IndexTypeId(&'b str, &'b str, &'b str),
     #[doc = "Index and Type"]
-    IndexType(&'a str, &'a str),
+    IndexType(&'b str, &'b str),
 }
-impl<'a> TermvectorsParts<'a> {
+impl<'b> TermvectorsParts<'b> {
     #[doc = "Builds a relative URL path to the Termvectors API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -7092,34 +7092,34 @@ impl<'a> TermvectorsParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Termvectors API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html). Returns information and statistics about terms in the fields of a particular document."]
-pub struct Termvectors<'a, B> {
-    client: Elasticsearch,
-    parts: TermvectorsParts<'a>,
+pub struct Termvectors<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: TermvectorsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
     field_statistics: Option<bool>,
-    fields: Option<&'a [&'a str]>,
-    filter_path: Option<&'a [&'a str]>,
+    fields: Option<&'b [&'b str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     offsets: Option<bool>,
     payloads: Option<bool>,
     positions: Option<bool>,
-    preference: Option<&'a str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
     realtime: Option<bool>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
     term_statistics: Option<bool>,
     version: Option<i64>,
     version_type: Option<VersionType>,
 }
-impl<'a, B> Termvectors<'a, B>
+impl<'a, 'b, B> Termvectors<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Termvectors] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: TermvectorsParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: TermvectorsParts<'b>) -> Self {
         Termvectors {
             client,
             parts,
@@ -7144,7 +7144,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Termvectors<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Termvectors<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -7182,12 +7182,12 @@ where
         self
     }
     #[doc = "A comma-separated list of fields to return."]
-    pub fn fields(mut self, fields: &'a [&'a str]) -> Self {
+    pub fn fields(mut self, fields: &'b [&'b str]) -> Self {
         self.fields = Some(fields);
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -7217,7 +7217,7 @@ where
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)."]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -7232,12 +7232,12 @@ where
         self
     }
     #[doc = "Specific routing value."]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -7267,18 +7267,18 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "field_statistics")]
                 field_statistics: Option<bool>,
                 #[serde(rename = "fields", serialize_with = "crate::client::serialize_coll_qs")]
-                fields: Option<&'a [&'a str]>,
+                fields: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "offsets")]
@@ -7288,15 +7288,15 @@ where
                 #[serde(rename = "positions")]
                 positions: Option<bool>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "realtime")]
                 realtime: Option<bool>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "term_statistics")]
                 term_statistics: Option<bool>,
                 #[serde(rename = "version")]
@@ -7334,13 +7334,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Update API"]
-pub enum UpdateParts<'a> {
+pub enum UpdateParts<'b> {
     #[doc = "Index and Id"]
-    IndexId(&'a str, &'a str),
+    IndexId(&'b str, &'b str),
     #[doc = "Index, Type and Id"]
-    IndexTypeId(&'a str, &'a str, &'a str),
+    IndexTypeId(&'b str, &'b str, &'b str),
 }
-impl<'a> UpdateParts<'a> {
+impl<'b> UpdateParts<'b> {
     #[doc = "Builds a relative URL path to the Update API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -7368,34 +7368,34 @@ impl<'a> UpdateParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Update API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html). Updates a document with a script or partial document."]
-pub struct Update<'a, B> {
-    client: Elasticsearch,
-    parts: UpdateParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct Update<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: UpdateParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     if_primary_term: Option<i64>,
     if_seq_no: Option<i64>,
-    lang: Option<&'a str>,
+    lang: Option<&'b str>,
     pretty: Option<bool>,
     refresh: Option<Refresh>,
     retry_on_conflict: Option<i64>,
-    routing: Option<&'a str>,
-    source: Option<&'a str>,
-    timeout: Option<&'a str>,
-    wait_for_active_shards: Option<&'a str>,
+    routing: Option<&'b str>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+    wait_for_active_shards: Option<&'b str>,
 }
-impl<'a, B> Update<'a, B>
+impl<'a, 'b, B> Update<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [Update] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: UpdateParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: UpdateParts<'b>) -> Self {
         Update {
             client,
             parts,
@@ -7420,22 +7420,22 @@ where
         }
     }
     #[doc = "True or false to return the _source field or not, or a list of fields to return"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "A list of fields to exclude from the returned _source field"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "A list of fields to extract and return from the _source field"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> Update<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> Update<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -7468,7 +7468,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -7493,7 +7493,7 @@ where
         self
     }
     #[doc = "The script language (default: painless)"]
-    pub fn lang(mut self, lang: &'a str) -> Self {
+    pub fn lang(mut self, lang: &'b str) -> Self {
         self.lang = Some(lang);
         self
     }
@@ -7513,22 +7513,22 @@ where
         self
     }
     #[doc = "Specific routing value"]
-    pub fn routing(mut self, routing: &'a str) -> Self {
+    pub fn routing(mut self, routing: &'b str) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
     #[doc = "Sets the number of shard copies that must be active before proceeding with the update operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -7540,29 +7540,29 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "if_primary_term")]
@@ -7570,7 +7570,7 @@ where
                 #[serde(rename = "if_seq_no")]
                 if_seq_no: Option<i64>,
                 #[serde(rename = "lang")]
-                lang: Option<&'a str>,
+                lang: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "refresh")]
@@ -7578,13 +7578,13 @@ where
                 #[serde(rename = "retry_on_conflict")]
                 retry_on_conflict: Option<i64>,
                 #[serde(rename = "routing")]
-                routing: Option<&'a str>,
+                routing: Option<&'b str>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
             }
             let query_params = QueryParams {
                 _source: self._source,
@@ -7616,13 +7616,13 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Update By Query API"]
-pub enum UpdateByQueryParts<'a> {
+pub enum UpdateByQueryParts<'b> {
     #[doc = "Index"]
-    Index(&'a [&'a str]),
+    Index(&'b [&'b str]),
     #[doc = "Index and Type"]
-    IndexType(&'a [&'a str], &'a [&'a str]),
+    IndexType(&'b [&'b str], &'b [&'b str]),
 }
-impl<'a> UpdateByQueryParts<'a> {
+impl<'b> UpdateByQueryParts<'b> {
     #[doc = "Builds a relative URL path to the Update By Query API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -7650,58 +7650,58 @@ impl<'a> UpdateByQueryParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Update By Query API](https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html). Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change."]
-pub struct UpdateByQuery<'a, B> {
-    client: Elasticsearch,
-    parts: UpdateByQueryParts<'a>,
-    _source: Option<&'a [&'a str]>,
-    _source_excludes: Option<&'a [&'a str]>,
-    _source_includes: Option<&'a [&'a str]>,
+pub struct UpdateByQuery<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: UpdateByQueryParts<'b>,
+    _source: Option<&'b [&'b str]>,
+    _source_excludes: Option<&'b [&'b str]>,
+    _source_includes: Option<&'b [&'b str]>,
     allow_no_indices: Option<bool>,
     analyze_wildcard: Option<bool>,
-    analyzer: Option<&'a str>,
+    analyzer: Option<&'b str>,
     body: Option<B>,
     conflicts: Option<Conflicts>,
     default_operator: Option<DefaultOperator>,
-    df: Option<&'a str>,
+    df: Option<&'b str>,
     error_trace: Option<bool>,
     expand_wildcards: Option<ExpandWildcards>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     from: Option<i64>,
     headers: HeaderMap,
     human: Option<bool>,
     ignore_unavailable: Option<bool>,
     lenient: Option<bool>,
     max_docs: Option<i64>,
-    pipeline: Option<&'a str>,
-    preference: Option<&'a str>,
+    pipeline: Option<&'b str>,
+    preference: Option<&'b str>,
     pretty: Option<bool>,
-    q: Option<&'a str>,
+    q: Option<&'b str>,
     refresh: Option<bool>,
     request_cache: Option<bool>,
     requests_per_second: Option<i64>,
-    routing: Option<&'a [&'a str]>,
-    scroll: Option<&'a str>,
+    routing: Option<&'b [&'b str]>,
+    scroll: Option<&'b str>,
     scroll_size: Option<i64>,
-    search_timeout: Option<&'a str>,
+    search_timeout: Option<&'b str>,
     search_type: Option<SearchType>,
     size: Option<i64>,
     slices: Option<i64>,
-    sort: Option<&'a [&'a str]>,
-    source: Option<&'a str>,
-    stats: Option<&'a [&'a str]>,
+    sort: Option<&'b [&'b str]>,
+    source: Option<&'b str>,
+    stats: Option<&'b [&'b str]>,
     terminate_after: Option<i64>,
-    timeout: Option<&'a str>,
+    timeout: Option<&'b str>,
     version: Option<bool>,
     version_type: Option<bool>,
-    wait_for_active_shards: Option<&'a str>,
+    wait_for_active_shards: Option<&'b str>,
     wait_for_completion: Option<bool>,
 }
-impl<'a, B> UpdateByQuery<'a, B>
+impl<'a, 'b, B> UpdateByQuery<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [UpdateByQuery] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: UpdateByQueryParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: UpdateByQueryParts<'b>) -> Self {
         UpdateByQuery {
             client,
             parts,
@@ -7750,17 +7750,17 @@ where
         }
     }
     #[doc = "True or false to return the _source field or not, or a list of fields to return"]
-    pub fn _source(mut self, _source: &'a [&'a str]) -> Self {
+    pub fn _source(mut self, _source: &'b [&'b str]) -> Self {
         self._source = Some(_source);
         self
     }
     #[doc = "A list of fields to exclude from the returned _source field"]
-    pub fn _source_excludes(mut self, _source_excludes: &'a [&'a str]) -> Self {
+    pub fn _source_excludes(mut self, _source_excludes: &'b [&'b str]) -> Self {
         self._source_excludes = Some(_source_excludes);
         self
     }
     #[doc = "A list of fields to extract and return from the _source field"]
-    pub fn _source_includes(mut self, _source_includes: &'a [&'a str]) -> Self {
+    pub fn _source_includes(mut self, _source_includes: &'b [&'b str]) -> Self {
         self._source_includes = Some(_source_includes);
         self
     }
@@ -7775,12 +7775,12 @@ where
         self
     }
     #[doc = "The analyzer to use for the query string"]
-    pub fn analyzer(mut self, analyzer: &'a str) -> Self {
+    pub fn analyzer(mut self, analyzer: &'b str) -> Self {
         self.analyzer = Some(analyzer);
         self
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> UpdateByQuery<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> UpdateByQuery<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -7842,7 +7842,7 @@ where
         self
     }
     #[doc = "The field to use as default where no field prefix is given in the query string"]
-    pub fn df(mut self, df: &'a str) -> Self {
+    pub fn df(mut self, df: &'b str) -> Self {
         self.df = Some(df);
         self
     }
@@ -7857,7 +7857,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -7892,12 +7892,12 @@ where
         self
     }
     #[doc = "Ingest pipeline to set on index requests made by this action. (default: none)"]
-    pub fn pipeline(mut self, pipeline: &'a str) -> Self {
+    pub fn pipeline(mut self, pipeline: &'b str) -> Self {
         self.pipeline = Some(pipeline);
         self
     }
     #[doc = "Specify the node or shard the operation should be performed on (default: random)"]
-    pub fn preference(mut self, preference: &'a str) -> Self {
+    pub fn preference(mut self, preference: &'b str) -> Self {
         self.preference = Some(preference);
         self
     }
@@ -7907,7 +7907,7 @@ where
         self
     }
     #[doc = "Query in the Lucene query string syntax"]
-    pub fn q(mut self, q: &'a str) -> Self {
+    pub fn q(mut self, q: &'b str) -> Self {
         self.q = Some(q);
         self
     }
@@ -7927,12 +7927,12 @@ where
         self
     }
     #[doc = "A comma-separated list of specific routing values"]
-    pub fn routing(mut self, routing: &'a [&'a str]) -> Self {
+    pub fn routing(mut self, routing: &'b [&'b str]) -> Self {
         self.routing = Some(routing);
         self
     }
     #[doc = "Specify how long a consistent view of the index should be maintained for scrolled search"]
-    pub fn scroll(mut self, scroll: &'a str) -> Self {
+    pub fn scroll(mut self, scroll: &'b str) -> Self {
         self.scroll = Some(scroll);
         self
     }
@@ -7942,7 +7942,7 @@ where
         self
     }
     #[doc = "Explicit timeout for each search request. Defaults to no timeout."]
-    pub fn search_timeout(mut self, search_timeout: &'a str) -> Self {
+    pub fn search_timeout(mut self, search_timeout: &'b str) -> Self {
         self.search_timeout = Some(search_timeout);
         self
     }
@@ -7962,17 +7962,17 @@ where
         self
     }
     #[doc = "A comma-separated list of <field>:<direction> pairs"]
-    pub fn sort(mut self, sort: &'a [&'a str]) -> Self {
+    pub fn sort(mut self, sort: &'b [&'b str]) -> Self {
         self.sort = Some(sort);
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
     #[doc = "Specific 'tag' of the request for logging and statistical purposes"]
-    pub fn stats(mut self, stats: &'a [&'a str]) -> Self {
+    pub fn stats(mut self, stats: &'b [&'b str]) -> Self {
         self.stats = Some(stats);
         self
     }
@@ -7982,7 +7982,7 @@ where
         self
     }
     #[doc = "Time each individual bulk request should wait for shards that are unavailable."]
-    pub fn timeout(mut self, timeout: &'a str) -> Self {
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
         self.timeout = Some(timeout);
         self
     }
@@ -7997,7 +7997,7 @@ where
         self
     }
     #[doc = "Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"]
-    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'a str) -> Self {
+    pub fn wait_for_active_shards(mut self, wait_for_active_shards: &'b str) -> Self {
         self.wait_for_active_shards = Some(wait_for_active_shards);
         self
     }
@@ -8014,34 +8014,34 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(
                     rename = "_source",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source: Option<&'a [&'a str]>,
+                _source: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_excludes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_excludes: Option<&'a [&'a str]>,
+                _source_excludes: Option<&'b [&'b str]>,
                 #[serde(
                     rename = "_source_includes",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                _source_includes: Option<&'a [&'a str]>,
+                _source_includes: Option<&'b [&'b str]>,
                 #[serde(rename = "allow_no_indices")]
                 allow_no_indices: Option<bool>,
                 #[serde(rename = "analyze_wildcard")]
                 analyze_wildcard: Option<bool>,
                 #[serde(rename = "analyzer")]
-                analyzer: Option<&'a str>,
+                analyzer: Option<&'b str>,
                 #[serde(rename = "conflicts")]
                 conflicts: Option<Conflicts>,
                 #[serde(rename = "default_operator")]
                 default_operator: Option<DefaultOperator>,
                 #[serde(rename = "df")]
-                df: Option<&'a str>,
+                df: Option<&'b str>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(rename = "expand_wildcards")]
@@ -8050,7 +8050,7 @@ where
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "from")]
                 from: Option<i64>,
                 #[serde(rename = "human")]
@@ -8062,13 +8062,13 @@ where
                 #[serde(rename = "max_docs")]
                 max_docs: Option<i64>,
                 #[serde(rename = "pipeline")]
-                pipeline: Option<&'a str>,
+                pipeline: Option<&'b str>,
                 #[serde(rename = "preference")]
-                preference: Option<&'a str>,
+                preference: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "q")]
-                q: Option<&'a str>,
+                q: Option<&'b str>,
                 #[serde(rename = "refresh")]
                 refresh: Option<bool>,
                 #[serde(rename = "request_cache")]
@@ -8079,13 +8079,13 @@ where
                     rename = "routing",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                routing: Option<&'a [&'a str]>,
+                routing: Option<&'b [&'b str]>,
                 #[serde(rename = "scroll")]
-                scroll: Option<&'a str>,
+                scroll: Option<&'b str>,
                 #[serde(rename = "scroll_size")]
                 scroll_size: Option<i64>,
                 #[serde(rename = "search_timeout")]
-                search_timeout: Option<&'a str>,
+                search_timeout: Option<&'b str>,
                 #[serde(rename = "search_type")]
                 search_type: Option<SearchType>,
                 #[serde(rename = "size")]
@@ -8093,21 +8093,21 @@ where
                 #[serde(rename = "slices")]
                 slices: Option<i64>,
                 #[serde(rename = "sort", serialize_with = "crate::client::serialize_coll_qs")]
-                sort: Option<&'a [&'a str]>,
+                sort: Option<&'b [&'b str]>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
                 #[serde(rename = "stats", serialize_with = "crate::client::serialize_coll_qs")]
-                stats: Option<&'a [&'a str]>,
+                stats: Option<&'b [&'b str]>,
                 #[serde(rename = "terminate_after")]
                 terminate_after: Option<i64>,
                 #[serde(rename = "timeout")]
-                timeout: Option<&'a str>,
+                timeout: Option<&'b str>,
                 #[serde(rename = "version")]
                 version: Option<bool>,
                 #[serde(rename = "version_type")]
                 version_type: Option<bool>,
                 #[serde(rename = "wait_for_active_shards")]
-                wait_for_active_shards: Option<&'a str>,
+                wait_for_active_shards: Option<&'b str>,
                 #[serde(rename = "wait_for_completion")]
                 wait_for_completion: Option<bool>,
             }
@@ -8165,11 +8165,11 @@ where
 }
 #[derive(Debug, Clone, PartialEq)]
 #[doc = "API parts for the Update By Query Rethrottle API"]
-pub enum UpdateByQueryRethrottleParts<'a> {
+pub enum UpdateByQueryRethrottleParts<'b> {
     #[doc = "TaskId"]
-    TaskId(&'a str),
+    TaskId(&'b str),
 }
-impl<'a> UpdateByQueryRethrottleParts<'a> {
+impl<'b> UpdateByQueryRethrottleParts<'b> {
     #[doc = "Builds a relative URL path to the Update By Query Rethrottle API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
@@ -8185,24 +8185,24 @@ impl<'a> UpdateByQueryRethrottleParts<'a> {
 }
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Update By Query Rethrottle API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html). Changes the number of requests per second for a particular Update By Query operation."]
-pub struct UpdateByQueryRethrottle<'a, B> {
-    client: Elasticsearch,
-    parts: UpdateByQueryRethrottleParts<'a>,
+pub struct UpdateByQueryRethrottle<'a, 'b, B> {
+    client: &'a Elasticsearch,
+    parts: UpdateByQueryRethrottleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
-    filter_path: Option<&'a [&'a str]>,
+    filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
     pretty: Option<bool>,
     requests_per_second: Option<i64>,
-    source: Option<&'a str>,
+    source: Option<&'b str>,
 }
-impl<'a, B> UpdateByQueryRethrottle<'a, B>
+impl<'a, 'b, B> UpdateByQueryRethrottle<'a, 'b, B>
 where
     B: Body,
 {
     #[doc = "Creates a new instance of [UpdateByQueryRethrottle] with the specified API parts"]
-    pub fn new(client: Elasticsearch, parts: UpdateByQueryRethrottleParts<'a>) -> Self {
+    pub fn new(client: &'a Elasticsearch, parts: UpdateByQueryRethrottleParts<'b>) -> Self {
         UpdateByQueryRethrottle {
             client,
             parts,
@@ -8217,7 +8217,7 @@ where
         }
     }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> UpdateByQueryRethrottle<'a, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> UpdateByQueryRethrottle<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
@@ -8240,7 +8240,7 @@ where
         self
     }
     #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'a [&'a str]) -> Self {
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
         self.filter_path = Some(filter_path);
         self
     }
@@ -8265,7 +8265,7 @@ where
         self
     }
     #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'a str) -> Self {
+    pub fn source(mut self, source: &'b str) -> Self {
         self.source = Some(source);
         self
     }
@@ -8277,14 +8277,14 @@ where
         let query_string = {
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
-            struct QueryParams<'a> {
+            struct QueryParams<'b> {
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
                     rename = "filter_path",
                     serialize_with = "crate::client::serialize_coll_qs"
                 )]
-                filter_path: Option<&'a [&'a str]>,
+                filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
                 #[serde(rename = "pretty")]
@@ -8292,7 +8292,7 @@ where
                 #[serde(rename = "requests_per_second")]
                 requests_per_second: Option<i64>,
                 #[serde(rename = "source")]
-                source: Option<&'a str>,
+                source: Option<&'b str>,
             }
             let query_params = QueryParams {
                 error_trace: self.error_trace,
@@ -8314,151 +8314,169 @@ where
 }
 impl Elasticsearch {
     #[doc = "Allows to perform multiple index/update/delete operations in a single request."]
-    pub fn bulk<'a>(&self, parts: BulkParts<'a>) -> Bulk<'a, ()> {
-        Bulk::new(self.clone(), parts)
+    pub fn bulk<'a, 'b>(&'a self, parts: BulkParts<'b>) -> Bulk<'a, 'b, ()> {
+        Bulk::new(&self, parts)
     }
     #[doc = "Explicitly clears the search context for a scroll."]
-    pub fn clear_scroll<'a>(&self, parts: ClearScrollParts<'a>) -> ClearScroll<'a, ()> {
-        ClearScroll::new(self.clone(), parts)
+    pub fn clear_scroll<'a, 'b>(&'a self, parts: ClearScrollParts<'b>) -> ClearScroll<'a, 'b, ()> {
+        ClearScroll::new(&self, parts)
     }
     #[doc = "Returns number of documents matching a query."]
-    pub fn count<'a>(&self, parts: CountParts<'a>) -> Count<'a, ()> {
-        Count::new(self.clone(), parts)
+    pub fn count<'a, 'b>(&'a self, parts: CountParts<'b>) -> Count<'a, 'b, ()> {
+        Count::new(&self, parts)
     }
     #[doc = "Creates a new document in the index.\n\nReturns a 409 response when a document with a same ID already exists in the index."]
-    pub fn create<'a>(&self, parts: CreateParts<'a>) -> Create<'a, ()> {
-        Create::new(self.clone(), parts)
+    pub fn create<'a, 'b>(&'a self, parts: CreateParts<'b>) -> Create<'a, 'b, ()> {
+        Create::new(&self, parts)
     }
     #[doc = "Removes a document from the index."]
-    pub fn delete<'a>(&self, parts: DeleteParts<'a>) -> Delete<'a> {
-        Delete::new(self.clone(), parts)
+    pub fn delete<'a, 'b>(&'a self, parts: DeleteParts<'b>) -> Delete<'a, 'b> {
+        Delete::new(&self, parts)
     }
     #[doc = "Deletes documents matching the provided query."]
-    pub fn delete_by_query<'a>(&self, parts: DeleteByQueryParts<'a>) -> DeleteByQuery<'a, ()> {
-        DeleteByQuery::new(self.clone(), parts)
+    pub fn delete_by_query<'a, 'b>(
+        &'a self,
+        parts: DeleteByQueryParts<'b>,
+    ) -> DeleteByQuery<'a, 'b, ()> {
+        DeleteByQuery::new(&self, parts)
     }
     #[doc = "Changes the number of requests per second for a particular Delete By Query operation."]
-    pub fn delete_by_query_rethrottle<'a>(
-        &self,
-        parts: DeleteByQueryRethrottleParts<'a>,
-    ) -> DeleteByQueryRethrottle<'a, ()> {
-        DeleteByQueryRethrottle::new(self.clone(), parts)
+    pub fn delete_by_query_rethrottle<'a, 'b>(
+        &'a self,
+        parts: DeleteByQueryRethrottleParts<'b>,
+    ) -> DeleteByQueryRethrottle<'a, 'b, ()> {
+        DeleteByQueryRethrottle::new(&self, parts)
     }
     #[doc = "Deletes a script."]
-    pub fn delete_script<'a>(&self, parts: DeleteScriptParts<'a>) -> DeleteScript<'a> {
-        DeleteScript::new(self.clone(), parts)
+    pub fn delete_script<'a, 'b>(&'a self, parts: DeleteScriptParts<'b>) -> DeleteScript<'a, 'b> {
+        DeleteScript::new(&self, parts)
     }
     #[doc = "Returns information about whether a document exists in an index."]
-    pub fn exists<'a>(&self, parts: ExistsParts<'a>) -> Exists<'a> {
-        Exists::new(self.clone(), parts)
+    pub fn exists<'a, 'b>(&'a self, parts: ExistsParts<'b>) -> Exists<'a, 'b> {
+        Exists::new(&self, parts)
     }
     #[doc = "Returns information about whether a document source exists in an index."]
-    pub fn exists_source<'a>(&self, parts: ExistsSourceParts<'a>) -> ExistsSource<'a> {
-        ExistsSource::new(self.clone(), parts)
+    pub fn exists_source<'a, 'b>(&'a self, parts: ExistsSourceParts<'b>) -> ExistsSource<'a, 'b> {
+        ExistsSource::new(&self, parts)
     }
     #[doc = "Returns information about why a specific matches (or doesn't match) a query."]
-    pub fn explain<'a>(&self, parts: ExplainParts<'a>) -> Explain<'a, ()> {
-        Explain::new(self.clone(), parts)
+    pub fn explain<'a, 'b>(&'a self, parts: ExplainParts<'b>) -> Explain<'a, 'b, ()> {
+        Explain::new(&self, parts)
     }
     #[doc = "Returns the information about the capabilities of fields among multiple indices."]
-    pub fn field_caps<'a>(&self, parts: FieldCapsParts<'a>) -> FieldCaps<'a, ()> {
-        FieldCaps::new(self.clone(), parts)
+    pub fn field_caps<'a, 'b>(&'a self, parts: FieldCapsParts<'b>) -> FieldCaps<'a, 'b, ()> {
+        FieldCaps::new(&self, parts)
     }
     #[doc = "Returns a document."]
-    pub fn get<'a>(&self, parts: GetParts<'a>) -> Get<'a> {
-        Get::new(self.clone(), parts)
+    pub fn get<'a, 'b>(&'a self, parts: GetParts<'b>) -> Get<'a, 'b> {
+        Get::new(&self, parts)
     }
     #[doc = "Returns a script."]
-    pub fn get_script<'a>(&self, parts: GetScriptParts<'a>) -> GetScript<'a> {
-        GetScript::new(self.clone(), parts)
+    pub fn get_script<'a, 'b>(&'a self, parts: GetScriptParts<'b>) -> GetScript<'a, 'b> {
+        GetScript::new(&self, parts)
     }
     #[doc = "Returns the source of a document."]
-    pub fn get_source<'a>(&self, parts: GetSourceParts<'a>) -> GetSource<'a> {
-        GetSource::new(self.clone(), parts)
+    pub fn get_source<'a, 'b>(&'a self, parts: GetSourceParts<'b>) -> GetSource<'a, 'b> {
+        GetSource::new(&self, parts)
     }
     #[doc = "Creates or updates a document in an index."]
-    pub fn index<'a>(&self, parts: IndexParts<'a>) -> Index<'a, ()> {
-        Index::new(self.clone(), parts)
+    pub fn index<'a, 'b>(&'a self, parts: IndexParts<'b>) -> Index<'a, 'b, ()> {
+        Index::new(&self, parts)
     }
     #[doc = "Returns basic information about the cluster."]
-    pub fn info<'a>(&self) -> Info<'a> {
-        Info::new(self.clone())
+    pub fn info<'a, 'b>(&'a self) -> Info<'a, 'b> {
+        Info::new(&self)
     }
     #[doc = "Allows to get multiple documents in one request."]
-    pub fn mget<'a>(&self, parts: MgetParts<'a>) -> Mget<'a, ()> {
-        Mget::new(self.clone(), parts)
+    pub fn mget<'a, 'b>(&'a self, parts: MgetParts<'b>) -> Mget<'a, 'b, ()> {
+        Mget::new(&self, parts)
     }
     #[doc = "Allows to execute several search operations in one request."]
-    pub fn msearch<'a>(&self, parts: MsearchParts<'a>) -> Msearch<'a, ()> {
-        Msearch::new(self.clone(), parts)
+    pub fn msearch<'a, 'b>(&'a self, parts: MsearchParts<'b>) -> Msearch<'a, 'b, ()> {
+        Msearch::new(&self, parts)
     }
     #[doc = "Allows to execute several search template operations in one request."]
-    pub fn msearch_template<'a>(&self, parts: MsearchTemplateParts<'a>) -> MsearchTemplate<'a, ()> {
-        MsearchTemplate::new(self.clone(), parts)
+    pub fn msearch_template<'a, 'b>(
+        &'a self,
+        parts: MsearchTemplateParts<'b>,
+    ) -> MsearchTemplate<'a, 'b, ()> {
+        MsearchTemplate::new(&self, parts)
     }
     #[doc = "Returns multiple termvectors in one request."]
-    pub fn mtermvectors<'a>(&self, parts: MtermvectorsParts<'a>) -> Mtermvectors<'a, ()> {
-        Mtermvectors::new(self.clone(), parts)
+    pub fn mtermvectors<'a, 'b>(
+        &'a self,
+        parts: MtermvectorsParts<'b>,
+    ) -> Mtermvectors<'a, 'b, ()> {
+        Mtermvectors::new(&self, parts)
     }
     #[doc = "Returns whether the cluster is running."]
-    pub fn ping<'a>(&self) -> Ping<'a> {
-        Ping::new(self.clone())
+    pub fn ping<'a, 'b>(&'a self) -> Ping<'a, 'b> {
+        Ping::new(&self)
     }
     #[doc = "Creates or updates a script."]
-    pub fn put_script<'a>(&self, parts: PutScriptParts<'a>) -> PutScript<'a, ()> {
-        PutScript::new(self.clone(), parts)
+    pub fn put_script<'a, 'b>(&'a self, parts: PutScriptParts<'b>) -> PutScript<'a, 'b, ()> {
+        PutScript::new(&self, parts)
     }
     #[doc = "Allows to copy documents from one index to another, optionally filtering the source\ndocuments by a query, changing the destination index settings, or fetching the\ndocuments from a remote cluster."]
-    pub fn reindex<'a>(&self) -> Reindex<'a, ()> {
-        Reindex::new(self.clone())
+    pub fn reindex<'a, 'b>(&'a self) -> Reindex<'a, 'b, ()> {
+        Reindex::new(&self)
     }
     #[doc = "Changes the number of requests per second for a particular Reindex operation."]
-    pub fn reindex_rethrottle<'a>(
-        &self,
-        parts: ReindexRethrottleParts<'a>,
-    ) -> ReindexRethrottle<'a, ()> {
-        ReindexRethrottle::new(self.clone(), parts)
+    pub fn reindex_rethrottle<'a, 'b>(
+        &'a self,
+        parts: ReindexRethrottleParts<'b>,
+    ) -> ReindexRethrottle<'a, 'b, ()> {
+        ReindexRethrottle::new(&self, parts)
     }
     #[doc = "Allows to use the Mustache language to pre-render a search definition."]
-    pub fn render_search_template<'a>(
-        &self,
-        parts: RenderSearchTemplateParts<'a>,
-    ) -> RenderSearchTemplate<'a, ()> {
-        RenderSearchTemplate::new(self.clone(), parts)
+    pub fn render_search_template<'a, 'b>(
+        &'a self,
+        parts: RenderSearchTemplateParts<'b>,
+    ) -> RenderSearchTemplate<'a, 'b, ()> {
+        RenderSearchTemplate::new(&self, parts)
     }
     #[doc = "Allows to retrieve a large numbers of results from a single search request."]
-    pub fn scroll<'a>(&self, parts: ScrollParts<'a>) -> Scroll<'a, ()> {
-        Scroll::new(self.clone(), parts)
+    pub fn scroll<'a, 'b>(&'a self, parts: ScrollParts<'b>) -> Scroll<'a, 'b, ()> {
+        Scroll::new(&self, parts)
     }
     #[doc = "Returns results matching a query."]
-    pub fn search<'a>(&self, parts: SearchParts<'a>) -> Search<'a, ()> {
-        Search::new(self.clone(), parts)
+    pub fn search<'a, 'b>(&'a self, parts: SearchParts<'b>) -> Search<'a, 'b, ()> {
+        Search::new(&self, parts)
     }
     #[doc = "Returns information about the indices and shards that a search request would be executed against."]
-    pub fn search_shards<'a>(&self, parts: SearchShardsParts<'a>) -> SearchShards<'a, ()> {
-        SearchShards::new(self.clone(), parts)
+    pub fn search_shards<'a, 'b>(
+        &'a self,
+        parts: SearchShardsParts<'b>,
+    ) -> SearchShards<'a, 'b, ()> {
+        SearchShards::new(&self, parts)
     }
     #[doc = "Allows to use the Mustache language to pre-render a search definition."]
-    pub fn search_template<'a>(&self, parts: SearchTemplateParts<'a>) -> SearchTemplate<'a, ()> {
-        SearchTemplate::new(self.clone(), parts)
+    pub fn search_template<'a, 'b>(
+        &'a self,
+        parts: SearchTemplateParts<'b>,
+    ) -> SearchTemplate<'a, 'b, ()> {
+        SearchTemplate::new(&self, parts)
     }
     #[doc = "Returns information and statistics about terms in the fields of a particular document."]
-    pub fn termvectors<'a>(&self, parts: TermvectorsParts<'a>) -> Termvectors<'a, ()> {
-        Termvectors::new(self.clone(), parts)
+    pub fn termvectors<'a, 'b>(&'a self, parts: TermvectorsParts<'b>) -> Termvectors<'a, 'b, ()> {
+        Termvectors::new(&self, parts)
     }
     #[doc = "Updates a document with a script or partial document."]
-    pub fn update<'a>(&self, parts: UpdateParts<'a>) -> Update<'a, ()> {
-        Update::new(self.clone(), parts)
+    pub fn update<'a, 'b>(&'a self, parts: UpdateParts<'b>) -> Update<'a, 'b, ()> {
+        Update::new(&self, parts)
     }
     #[doc = "Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change."]
-    pub fn update_by_query<'a>(&self, parts: UpdateByQueryParts<'a>) -> UpdateByQuery<'a, ()> {
-        UpdateByQuery::new(self.clone(), parts)
+    pub fn update_by_query<'a, 'b>(
+        &'a self,
+        parts: UpdateByQueryParts<'b>,
+    ) -> UpdateByQuery<'a, 'b, ()> {
+        UpdateByQuery::new(&self, parts)
     }
     #[doc = "Changes the number of requests per second for a particular Update By Query operation."]
-    pub fn update_by_query_rethrottle<'a>(
-        &self,
-        parts: UpdateByQueryRethrottleParts<'a>,
-    ) -> UpdateByQueryRethrottle<'a, ()> {
-        UpdateByQueryRethrottle::new(self.clone(), parts)
+    pub fn update_by_query_rethrottle<'a, 'b>(
+        &'a self,
+        parts: UpdateByQueryRethrottleParts<'b>,
+    ) -> UpdateByQueryRethrottle<'a, 'b, ()> {
+        UpdateByQueryRethrottle::new(&self, parts)
     }
 }


### PR DESCRIPTION
This commit changes the api_generator to pass a reference to an instance of
Elasticsearch struct to each builder struct. The reference has a lifetime of  'a,
distinct from the lifetime 'b of the *Parts enum and references passed to builder
struct functions.

Closes #36