### PR TITLE
Feature / objekt -> dyn-clone

### DIFF
--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 [dependencies]
 base64 = "0.11.0"
 bytes = "^0.5"
-objekt = "0.1.2"
+dyn-clone = "1.0.1"
 reqwest = { version = "0.10.0", features = ["gzip", "json", "native-tls"] }
 url = "1.7.2"
 serde = { version = "~1", features = ["derive"] }

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -286,7 +286,7 @@ impl Default for Transport {
 /// to get the next [Connection]. The simplest type of [ConnectionPool] is [SingleNodeConnectionPool],
 /// which manages only a single connection, but other implementations may manage connections more
 /// dynamically at runtime, based upon the response to API calls.
-pub trait ConnectionPool: Debug + objekt::Clone {
+pub trait ConnectionPool: Debug + dyn_clone::DynClone {
     /// Gets a reference to the next [Connection]
     fn next(&self) -> &Connection;
 }

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -308,7 +308,7 @@ type _DoctestReadme = ();
 //#![deny(missing_docs)]
 
 #[macro_use]
-extern crate objekt;
+extern crate dyn_clone;
 extern crate reqwest;
 extern crate serde;
 extern crate serde_json;


### PR DESCRIPTION
- The crate `objekt` has been renamed to `dyn-clone`, this updates that
change and closes #39

![image](https://user-images.githubusercontent.com/10913471/72006472-b7f5c880-321d-11ea-9a6a-416aa6eec3e5.png)
