### PR TITLE
Make the top-level error type opaque

### DIFF
--- a/elasticsearch/src/http/request.rs
+++ b/elasticsearch/src/http/request.rs
@@ -42,10 +42,9 @@ where
 {
     fn write(&self, bytes: &mut BytesMut) -> Result<(), Error> {
         let writer = bytes.writer();
-        match serde_json::to_writer(writer, &self.0) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(Error::Json(e)),
-        }
+        serde_json::to_writer(writer, &self.0)?;
+
+        Ok(())
     }
 }
 

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -266,9 +266,9 @@ impl Transport {
             Ok(r) => Ok(Response::new(r)),
             Err(e) => {
                 if e.is_timeout() {
-                    Err(Error::Lib(format!("Request timed out to {:?}", e.url())))
+                    Err(Error::lib(format!("Request timed out to {:?}", e.url())))
                 } else {
-                    Err(Error::Http(e))
+                    Err(e.into())
                 }
             }
         }
@@ -341,21 +341,21 @@ impl CloudId {
     /// web console
     pub fn parse(cloud_id: &str) -> Result<CloudId, Error> {
         if cloud_id.is_empty() || !cloud_id.contains(':') {
-            return Err(Error::Lib(
-                "cloud_id should be of the form '<cluster name>:<base64 data>'".into(),
+            return Err(Error::lib(
+                "cloud_id should be of the form '<cluster name>:<base64 data>'"
             ));
         }
 
         let parts: Vec<&str> = cloud_id.splitn(2, ':').collect();
         let name: String = parts[0].into();
         if name.is_empty() {
-            return Err(Error::Lib("cloud_id cluster name cannot be empty".into()));
+            return Err(Error::lib("cloud_id cluster name cannot be empty"));
         }
 
         let data = parts[1];
         let decoded_result = base64::decode(data);
         if decoded_result.is_err() {
-            return Err(Error::Lib(format!("cannot base 64 decode '{}'", data)));
+            return Err(Error::lib(format!("cannot base 64 decode '{}'", data)));
         }
 
         let decoded = decoded_result.unwrap();
@@ -369,20 +369,19 @@ impl CloudId {
                     Ok(s) => {
                         domain_name = s.trim();
                         if domain_name.is_empty() {
-                            return Err(Error::Lib("decoded '<base64 data>' must contain a domain name as the first part".into()));
+                            return Err(Error::lib("decoded '<base64 data>' must contain a domain name as the first part"));
                         }
                     }
                     Err(_) => {
-                        return Err(Error::Lib(
+                        return Err(Error::lib(
                             "decoded '<base64 data>' must contain a domain name as the first part"
-                                .into(),
                         ))
                     }
                 }
             }
             None => {
-                return Err(Error::Lib(
-                    "decoded '<base64 data>' must contain a domain name as the first part".into(),
+                return Err(Error::lib(
+                    "decoded '<base64 data>' must contain a domain name as the first part"
                 ));
             }
         }
@@ -392,20 +391,20 @@ impl CloudId {
                 Ok(s) => {
                     uuid = s.trim();
                     if uuid.is_empty() {
-                        return Err(Error::Lib(
-                            "decoded '<base64 data>' must contain a uuid as the second part".into(),
+                        return Err(Error::lib(
+                            "decoded '<base64 data>' must contain a uuid as the second part"
                         ));
                     }
                 }
                 Err(_) => {
-                    return Err(Error::Lib(
-                        "decoded '<base64 data>' must contain a uuid as the second part".into(),
+                    return Err(Error::lib(
+                        "decoded '<base64 data>' must contain a uuid as the second part"
                     ))
                 }
             },
             None => {
-                return Err(Error::Lib(
-                    "decoded '<base64 data>' must contain at least two parts".into(),
+                return Err(Error::lib(
+                    "decoded '<base64 data>' must contain at least two parts"
                 ));
             }
         }

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -306,9 +306,6 @@ type _DoctestReadme = ();
 
 #[macro_use]
 extern crate dyn_clone;
-extern crate reqwest;
-extern crate serde;
-extern crate serde_json;
 
 pub mod auth;
 pub mod http;


### PR DESCRIPTION
Hi! :wave:

I'm spending some time poking around and thought I'd submit a few PRs for bits and pieces.

This PR refactors the top-level `Error` enum so that it's an opaque struct instead of an open `enum`. This means changes can be made to the internals of the error without breaking callers relying on the enum having a particular shape. As an example of a change, one day we might want to replace the `Lib(String)` variant with something strongly typed. It also means a [`Backtrace`](https://doc.rust-lang.org/std/backtrace/struct.Backtrace.html) could be introduced, because it'll have a natural place to live within the struct.