### PR TITLE
Make ConnectionPool Sync/Send

### DIFF
--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -85,7 +85,7 @@ impl TransportBuilder {
     /// from which [Connection]s to Elasticsearch will be retrieved.
     pub fn new<P>(conn_pool: P) -> Self
     where
-        P: ConnectionPool + Debug + Clone + 'static,
+        P: ConnectionPool + Debug + Clone + Send + 'static,
     {
         Self {
             client_builder: reqwest::ClientBuilder::new(),
@@ -303,7 +303,7 @@ impl Default for Transport {
 /// to get the next [Connection]. The simplest type of [ConnectionPool] is [SingleNodeConnectionPool],
 /// which manages only a single connection, but other implementations may manage connections more
 /// dynamically at runtime, based upon the response to API calls.
-pub trait ConnectionPool: Debug + dyn_clone::DynClone {
+pub trait ConnectionPool: Debug + dyn_clone::DynClone + Sync + Send {
     /// Gets a reference to the next [Connection]
     fn next(&self) -> &Connection;
 }


### PR DESCRIPTION
There's currently nothing preventing ConnectionPool from being Sync/Send, but the fact that it's not means I can't use the client in any context other than the most trivial `block_on()` as seen in the examples. If I want to use the client in any future which is `spawn`ed for example (e.g., I have a task which receives on an mpsc::channel, batches up index operations, and makes a bulk call with that batch), the fact that ConnectionPool isn't Sync/Send means the client isn't either, which means my structure which holds the client can't be Sync/Send and thus can't be `spawn`'d.

Note that you don't even have to have an explicit structure containing the client -- you can't even create a client in an `async fn` that then `.await`'s the result of a request, as the yield point will force the compiler to generate an intermediate structure which can't be Sync/Send as it holds the client.

This PR simply adds `Sync + Send` on the supertrait bounds of ConnectionPool, which seems to just work. Not sure if the lack of `Sync + Send` was a conscious decision or an oversight but hopefully this PR opens a discussion.

Cheers!