### PR TITLE
Provide native-tls and rustls-tls features

### DIFF
--- a/.ci/DockerFile
+++ b/.ci/DockerFile
@@ -12,4 +12,4 @@ RUN mkdir src && echo "// dummy file" > src/lib.rs && cargo build --tests
 # install app dependencies and build
 COPY README.md ./../
 COPY elasticsearch .
-RUN cargo build --tests
+RUN cargo build --tests --all-features

--- a/.ci/run-elasticsearch.ps1
+++ b/.ci/run-elasticsearch.ps1
@@ -278,8 +278,12 @@ if ($DETACH) {
   while((!$(container_running -Name $NODE_NAME)) -or ((container_running -Name $NODE_NAME) -and ($(docker inspect -f '{{.State.Health.Status}}' $NODE_NAME) -eq "starting"))) {
     Start-Sleep 2;
     $logs = docker inspect -f '{{json .State.Health.Log}}' $NODE_NAME | ConvertFrom-Json
-    $lastLog = $logs[$logs.Length-1]
-    Write-Output $lastLog.Output
+    if ($logs) {
+      $lastLog = $logs[$logs.Length-1]
+      Write-Output $lastLog.Output
+    } else {
+      Write-Output "No logs from docker inspect"
+    }
     log "waiting for node $NODE_NAME to be up"
   }
 

--- a/.ci/run-tests.ps1
+++ b/.ci/run-tests.ps1
@@ -4,16 +4,23 @@ param (
     $ELASTICSEARCH_VERSION,
 
     [string]
+    [Parameter(Mandatory = $false)]
     [ValidateSet("oss", "xpack")]
-    $TEST_SUITE = "oss",
+    $TEST_SUITE = "xpack",
 
     # TODO: move to stable once elasticsearch-rs compiles on stable
     [string]
+    [Parameter(Mandatory = $false)]
     $RUST_VERSION = "nightly",
 
     [string]
     [ValidateSet("1", "full")]
-    $RUST_BACKTRACE
+    [Parameter(Mandatory = $false)]
+    $RUST_BACKTRACE,
+
+    [string]
+    [Parameter(Mandatory = $false)]
+    $CARGO_TEST_FLAGS = "--all-features"
 )
 
 trap {
@@ -117,7 +124,7 @@ docker run `
   --name elasticsearch-rs `
   --rm `
 elastic/elasticsearch-rs `
-cargo test
+cargo test $CARGO_TEST_FLAGS
 
 if ($LASTEXITCODE) {
     docker rm elasticsearch-rs

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 .idea
 .vscode/
 *.log
+yaml_test_runner/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ functions on the client will be compatible.
 Elasticsearch**. Major differences likely exist between major versions of Elasticsearch, particularly
 around request and response object formats, but also around API urls and behaviour.
 
+## Features
+
+The following are a list of Cargo features that can be enabled or disabled:
+
+- **native-tls** *(enabled by default)*: Enables TLS functionality provided by `native-tls`.
+- **rustls-tls**: Enables TLS functionality provided by `rustls`.
+
 ## Getting started
 
 The client exposes all Elasticsearch APIs as associated functions, either on

--- a/api_generator/Cargo.toml
+++ b/api_generator/Cargo.toml
@@ -16,7 +16,7 @@ lazy_static = "1.4.0"
 quote = "~0.3"
 reduce = "0.1.2"
 regex = "1.3.1"
-reqwest = "~0.9"
+reqwest = { version = "~0.10", features = ["blocking", "json", "gzip"] }
 rustfmt-nightly = "~1"
 semver = "0.9.0"
 serde = "~1"

--- a/api_generator/src/rest_spec/mod.rs
+++ b/api_generator/src/rest_spec/mod.rs
@@ -61,10 +61,14 @@ pub fn download_specs(branch: &str, download_dir: &PathBuf) {
 }
 
 fn download_endpoints(spec: &GitHubSpec, download_dir: &PathBuf) {
-    let mut response = reqwest::get(&spec.url).unwrap();
-    let rest_api_specs: Vec<RestApiSpec> = response.json().unwrap();
+    let client = reqwest::blocking::ClientBuilder::new()
+        .user_agent(concat!("RustApiGenerator/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .unwrap();
 
+    let response = client.get(&spec.url).send().unwrap();
+    let rest_api_specs: Vec<RestApiSpec> = response.json().unwrap();
     println!("Downloading {} specs from {}", spec.dir, spec.branch);
-    download_specs_to_dir(rest_api_specs.as_slice(), download_dir).unwrap();
+    download_specs_to_dir(client,rest_api_specs.as_slice(), download_dir).unwrap();
     println!("Done downloading {} specs from {}", spec.dir, spec.branch);
 }

--- a/api_generator/src/rest_spec/parallel_downloading.rs
+++ b/api_generator/src/rest_spec/parallel_downloading.rs
@@ -19,10 +19,10 @@ pub(super) enum DownloadSpecsErrors {
 /// Downloads the given specs to the provided director in parallel, displaying progress bars for
 /// each file.
 pub(super) fn download_specs_to_dir(
+    client: reqwest::blocking::Client,
     specs: &[RestApiSpec],
     download_dir: &PathBuf,
 ) -> Result<(), DownloadSpecsErrors> {
-    let client = reqwest::Client::new();
     let sty = ProgressStyle::default_bar()
         .template("{spinner:.green} {msg} [{elapsed_precise} (ETA: {eta})] [{bar:40.cyan/blue}] {bytes}/{total_bytes}")
         .progress_chars("#>-");

--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -6,15 +6,22 @@ authors = ["Elastic and Contributors"]
 description = "Official Elasticsearch Rust client"
 repository = "https://github.com/elastic/elasticsearch-rs"
 keywords = ["elasticsearch", "elastic", "search", "lucene"]
+categories = ["api-bindings", "database"]
 documentation = "https://docs.rs/elasticsearch/"
 license = "Apache-2.0"
 readme = "../README.md"
+
+[features]
+default = ["native-tls"]
+
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 base64 = "^0.11"
 bytes = "^0.5"
 dyn-clone = "~1"
-reqwest = { version = "^0.10", features = ["gzip", "json", "native-tls"] }
+reqwest = { version = "~0.10", default-features = false, features = ["gzip", "json"] }
 url = "^2.1"
 serde = { version = "~1", features = ["derive"] }
 serde_json = "~1"

--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -11,9 +11,13 @@ documentation = "https://docs.rs/elasticsearch/"
 license = "Apache-2.0"
 readme = "../README.md"
 
+[package.metadata."docs.rs"]
+all-features = true
+
 [features]
 default = ["native-tls"]
 
+# optional TLS
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
@@ -21,7 +25,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 base64 = "^0.11"
 bytes = "^0.5"
 dyn-clone = "~1"
-reqwest = { version = "~0.10", default-features = false, features = ["gzip", "json"] }
+reqwest = { version = "~0.10", default-features = false, features = ["default-tls", "gzip", "json"] }
 url = "^2.1"
 serde = { version = "~1", features = ["derive"] }
 serde_json = "~1"

--- a/elasticsearch/src/auth.rs
+++ b/elasticsearch/src/auth.rs
@@ -7,13 +7,45 @@ pub enum Credentials {
     Basic(String, String),
     /// An access_token to use for Bearer authentication
     Bearer(String),
-    /// Bytes of a DER-formatted PKCS#12 archive and password to use for
-    /// PKI (Client Certificate) authentication.
+    /// A client certificate to use for PKI (Client Certificate) authentication.
+    /// # Optional
     ///
-    /// The archive should contain a leaf certificate and its private key, as well any intermediate
-    /// certificates that allow clients to build a chain to a trusted root. The chain certificates
-    /// should be in order from the leaf certificate towards the root.
-    Cert(Vec<u8>, String),
+    /// This requires the `native-tls` or `rustls-tls` feature to be enabled.
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    Certificate(ClientCertificate),
     /// An id and api_key to use for API key authentication
     ApiKey(String, String),
+}
+
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+#[derive(Debug, Clone)]
+pub enum ClientCertificate {
+    /// Bytes of a DER-formatted PKCS#12 archive and optional passphrase.
+    ///
+    /// The archive should contain a leaf certificate and its private key,
+    /// as well any intermediate certificates that allow clients to build a chain to
+    /// a trusted root. The chain certificates
+    /// should be in order from the leaf certificate towards the root.
+    ///
+    /// # Optional
+    ///
+    /// This requires the `native-tls` feature to be enabled.
+    #[cfg(feature = "native-tls")]
+    Pkcs12(Vec<u8>, Option<String>),
+
+    /// Bytes of a PEM encoded private key and
+    /// at least one PEM encoded certificate.
+    ///
+    /// # Optional
+    ///
+    /// This requires the `rustls-tls` feature to be enabled.
+    #[cfg(feature = "rustls-tls")]
+    Pem(Vec<u8>)
+}
+
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+impl From<ClientCertificate> for Credentials {
+    fn from(cert: ClientCertificate) -> Self {
+        Credentials::Certificate(cert)
+    }
 }

--- a/elasticsearch/src/cert.rs
+++ b/elasticsearch/src/cert.rs
@@ -14,9 +14,80 @@ pub use reqwest::Certificate;
 ///
 /// ## Full validation
 ///
-/// With Elasticsearch running at https://example.com, configured to use a certificate generated
+/// This requires the `native-tls`, or `rustls-tls` feature to be enabled.
+///
+/// With Elasticsearch running at `https://example.com`, configured to use a certificate generated
 /// with your own Certificate Authority (CA), and where the certificate contains a CommonName (CN)
 /// or Subject Alternative Name (SAN) that matches the hostname of Elasticsearch
+#[cfg_attr(any(feature = "native-tls", feature = "rustls-tls"), doc = r##"
+```rust,norun
+# use elasticsearch::{
+#     auth::Credentials,
+#     cert::{Certificate,CertificateValidation},
+#     Error, Elasticsearch,
+#     http::transport::{TransportBuilder,SingleNodeConnectionPool},
+# };
+# use std::fs::File;
+# use std::io::Read;
+# use url::Url;
+# async fn run() -> Result<(), Error> {
+let url = Url::parse("https://example.com")?;
+let conn_pool = SingleNodeConnectionPool::new(url);
+
+// load the CA certificate
+let mut buf = Vec::new();
+File::open("my_ca_cert.pem")?
+    .read_to_end(&mut buf)?;
+let cert = Certificate::from_pem(&buf)?;
+
+let transport = TransportBuilder::new(conn_pool)
+    .cert_validation(CertificateValidation::Full(cert))
+    .build()?;
+let client = Elasticsearch::new(transport);
+let _response = client.ping().send().await?;
+# Ok(())
+# }
+```
+"##)]
+/// ## Certificate validation
+///
+/// This requires the `native-tls` feature to be enabled.
+///
+/// With Elasticsearch running at `https://example.com`, configured to use a certificate generated
+/// with your own Certificate Authority (CA)
+#[cfg_attr(feature = "native-tls", doc = r##"
+```rust,norun
+# use elasticsearch::{
+#     auth::Credentials,
+#     cert::{Certificate,CertificateValidation},
+#     Error, Elasticsearch,
+#     http::transport::{TransportBuilder,SingleNodeConnectionPool},
+# };
+# use std::fs::File;
+# use std::io::Read;
+# use url::Url;
+# async fn run() -> Result<(), Error> {
+let url = Url::parse("https://example.com")?;
+let conn_pool = SingleNodeConnectionPool::new(url);
+
+// load the CA certificate
+let mut buf = Vec::new();
+File::open("my_ca_cert.pem")?
+    .read_to_end(&mut buf)?;
+let cert = Certificate::from_pem(&buf)?;
+let transport = TransportBuilder::new(conn_pool)
+    .cert_validation(CertificateValidation::Certificate(cert))
+    .build()?;
+let client = Elasticsearch::new(transport);
+let _response = client.ping().send().await?;
+# Ok(())
+# }
+```
+"##)]
+/// ## No validation
+///
+/// No validation is performed on the certificate provided by the server.
+/// **Use on production clusters is strongly discouraged**
 ///
 /// ```rust,norun
 /// # use elasticsearch::{
@@ -31,15 +102,8 @@ pub use reqwest::Certificate;
 /// # async fn run() -> Result<(), Error> {
 /// let url = Url::parse("https://example.com")?;
 /// let conn_pool = SingleNodeConnectionPool::new(url);
-///
-/// // load the CA certificate
-/// let mut buf = Vec::new();
-/// File::open("my_ca_cert.pem")?
-///     .read_to_end(&mut buf)?;
-/// let cert = Certificate::from_pem(&buf)?;
-///
 /// let transport = TransportBuilder::new(conn_pool)
-///     .cert_validation(CertificateValidation::Full(cert))
+///     .cert_validation(CertificateValidation::None)
 ///     .build()?;
 /// let client = Elasticsearch::new(transport);
 /// let _response = client.ping().send().await?;
@@ -67,6 +131,10 @@ pub enum CertificateValidation {
     ///
     /// Typically, the certificate provided to the client is the Certificate Authority (CA)
     /// used to sign the certificate used by the server.
+    ///
+    /// # Optional
+    /// This requires the `native-tls`, or `rustls-tls` feature to be enabled.
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     Full(Certificate),
     /// Validates that the certificate provided by the server is signed by a trusted
     /// Certificate Authority (CA), but does not perform hostname verification.
@@ -77,6 +145,11 @@ pub enum CertificateValidation {
     ///
     /// Typically, the certificate provided to the client will be the Certificate Authority (CA)
     /// used to sign the certificate used by the server.
+    ///
+    /// # Optional
+    ///
+    /// This requires the `native-tls` feature to be enabled.
+    #[cfg(feature = "native-tls")]
     Certificate(Certificate),
     /// No validation is performed on the certificate provided by the server.
     ///

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -148,27 +148,24 @@ impl TransportBuilder {
 
         #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
         {
-            if let Some(c) = &self.credentials {
-                match c {
-                    Credentials::Certificate(client_cert) => {
-                        client_builder = match client_cert {
-                            #[cfg(feature = "native-tls")]
-                            ClientCertificate::Pkcs12(b, p) => {
-                                let password = match p {
-                                    Some(pass) => pass.as_str(),
-                                    None => ""
-                                };
-                                let pkcs12 = reqwest::Identity::from_pkcs12_der(b, password)?;
-                                client_builder.identity(pkcs12)
-                            },
-                            #[cfg(feature = "rustls-tls")]
-                            ClientCertificate::Pem(b) => {
-                                let pem = reqwest::Identity::from_pem(b)?;
-                                client_builder.identity(pem)
-                            },
-                        }
+            if let Some(creds) = &self.credentials {
+                if let Credentials::Certificate(cert) = creds {
+                    client_builder = match cert {
+                        #[cfg(feature = "native-tls")]
+                        ClientCertificate::Pkcs12(b, p) => {
+                            let password = match p {
+                                Some(pass) => pass.as_str(),
+                                None => ""
+                            };
+                            let pkcs12 = reqwest::Identity::from_pkcs12_der(b, password)?;
+                            client_builder.identity(pkcs12)
+                        },
+                        #[cfg(feature = "rustls-tls")]
+                        ClientCertificate::Pem(b) => {
+                            let pem = reqwest::Identity::from_pem(b)?;
+                            client_builder.identity(pem)
+                        },
                     }
-                    _ => { },
                 }
             };
         }

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -29,6 +29,13 @@
 //! Elasticsearch**. Major differences likely exist between major versions of Elasticsearch, particularly
 //! around request and response object formats, but also around API urls and behaviour.
 //!
+//! # Features
+//!
+//! The following are a list of Cargo features that can be enabled or disabled:
+//!
+//! - **native-tls** *(enabled by default)*: Enables TLS functionality provided by `native-tls`.
+//! - **rustls-tls**: Enables TLS functionality provided by `rustls`.
+//!
 //! # Getting started
 //!
 //! Add the `elasticsearch` crate and version to Cargo.toml. Choose the version that is compatible with

--- a/elasticsearch/tests/cert.rs
+++ b/elasticsearch/tests/cert.rs
@@ -55,6 +55,7 @@ async fn none_certificate_validation() -> Result<(), failure::Error> {
 /// Certificate provided by the server contains the one given to the client
 /// within the authority chain, and hostname matches
 #[tokio::test]
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
 async fn full_certificate_ca_validation() -> Result<(), failure::Error> {
     let cert = Certificate::from_pem(CA_CERT)?;
     let builder =
@@ -66,7 +67,7 @@ async fn full_certificate_ca_validation() -> Result<(), failure::Error> {
 
 /// Certificate provided by the server is the one given to the client and hostname matches
 #[tokio::test]
-#[cfg(windows)]
+#[cfg(all(windows, any(feature = "native-tls", feature = "rustls-tls")))]
 async fn full_certificate_validation() -> Result<(), failure::Error> {
     let cert = Certificate::from_pem(TESTNODE_SAN_CERT)?;
     let builder =
@@ -79,7 +80,7 @@ async fn full_certificate_validation() -> Result<(), failure::Error> {
 /// Certificate provided by the server is the one given to the client. This fails on Linux because
 /// it appears that it also needs the CA for the cert
 #[tokio::test]
-#[cfg(unix)]
+#[cfg(all(unix, any(feature = "native-tls", feature = "rustls-tls")))]
 async fn full_certificate_validation() -> Result<(), failure::Error> {
     let cert = Certificate::from_pem(TESTNODE_SAN_CERT)?;
     let builder =
@@ -107,7 +108,7 @@ async fn full_certificate_validation() -> Result<(), failure::Error> {
 
 /// Certificate provided by the server is the one given to the client
 #[tokio::test]
-#[cfg(windows)]
+#[cfg(all(windows, feature = "native-tls"))]
 async fn certificate_certificate_validation() -> Result<(), failure::Error> {
     let cert = Certificate::from_pem(TESTNODE_SAN_CERT)?;
     let builder =
@@ -120,7 +121,7 @@ async fn certificate_certificate_validation() -> Result<(), failure::Error> {
 /// Certificate provided by the server is the one given to the client. This fails on Linux because
 /// it appears that it also needs the CA for the cert
 #[tokio::test]
-#[cfg(unix)]
+#[cfg(all(unix, feature = "native-tls"))]
 async fn certificate_certificate_validation() -> Result<(), failure::Error> {
     let cert = Certificate::from_pem(TESTNODE_SAN_CERT)?;
     let builder =
@@ -149,6 +150,7 @@ async fn certificate_certificate_validation() -> Result<(), failure::Error> {
 /// Certificate provided by the server contains the one given to the client
 /// within the authority chain
 #[tokio::test]
+#[cfg(feature = "native-tls")]
 async fn certificate_certificate_ca_validation() -> Result<(), failure::Error> {
     let cert = Certificate::from_pem(CA_CERT)?;
     let builder =
@@ -160,6 +162,7 @@ async fn certificate_certificate_ca_validation() -> Result<(), failure::Error> {
 
 /// Certificate provided by the server does not match the one given to the client
 #[tokio::test]
+#[cfg(feature = "native-tls")]
 async fn fail_certificate_certificate_validation() -> Result<(), failure::Error> {
     let cert = Certificate::from_pem(TESTNODE_CERT)?;
     let builder =


### PR DESCRIPTION
This PR provides the following features

- **native-tls** *(enabled by default)*: Enables TLS functionality provided by `native-tls`.

  passes through to `reqwest/native-tls` and is set as a default feature.

- **rustls-tls**: Enables TLS functionality provided by `rustls`.

  passes through to `reqwest/rustls-tls`

Other features of `reqwest` such as cookies and socks are not exposed in the client because they are not used by the client. It doesn't feel correct to expose features of dependencies that are not relevant.

Closes #44

