### PR TITLE
Use text/plain content-type and accept headers for cat APIs

### DIFF
--- a/api_generator/src/api_generator/code_gen/mod.rs
+++ b/api_generator/src/api_generator/code_gen/mod.rs
@@ -18,7 +18,7 @@ pub fn use_declarations() -> Tokens {
             params::*,
             error::Error,
             http::{
-                headers::{HeaderName, HeaderMap, HeaderValue},
+                headers::{HeaderName, HeaderMap, HeaderValue, CONTENT_TYPE, ACCEPT},
                 Method,
                 request::{Body, NdBody, JsonBody},
                 response::Response,

--- a/api_generator/src/rest_spec/mod.rs
+++ b/api_generator/src/rest_spec/mod.rs
@@ -69,6 +69,6 @@ fn download_endpoints(spec: &GitHubSpec, download_dir: &PathBuf) {
     let response = client.get(&spec.url).send().unwrap();
     let rest_api_specs: Vec<RestApiSpec> = response.json().unwrap();
     println!("Downloading {} specs from {}", spec.dir, spec.branch);
-    download_specs_to_dir(client,rest_api_specs.as_slice(), download_dir).unwrap();
+    download_specs_to_dir(client, rest_api_specs.as_slice(), download_dir).unwrap();
     println!("Done downloading {} specs from {}", spec.dir, spec.branch);
 }

--- a/elasticsearch/src/auth.rs
+++ b/elasticsearch/src/auth.rs
@@ -40,7 +40,7 @@ pub enum ClientCertificate {
     ///
     /// This requires the `rustls-tls` feature to be enabled.
     #[cfg(feature = "rustls-tls")]
-    Pem(Vec<u8>)
+    Pem(Vec<u8>),
 }
 
 #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]

--- a/elasticsearch/src/cat/mod.rs
+++ b/elasticsearch/src/cat/mod.rs
@@ -4,7 +4,77 @@
 //! meet the needs of humans when looking at data returned from Elasticsearch,
 //! formatting it as compact, column aligned text, making it easier on human eyes.
 //!
-//! # Headers
+//! # Plain text responses
+//!
+//! By default, all Cat APIs are configured to send requests with `text/plain` content-type
+//! and accept headers, returning plain text responses
+//!
+//! ```rust,no_run
+//! # use elasticsearch;
+//! # use elasticsearch::{Elasticsearch, Error, SearchParts};
+//! # use url::Url;
+//! # use elasticsearch::auth::Credentials;
+//! # use serde_json::{json, Value};
+//! # async fn run() -> Result<(), Error> {
+//! # let client = Elasticsearch::default();
+//! let response = client
+//!     .cat()
+//!     .nodes()
+//!     .send()
+//!     .await?;
+//!
+//! let response_body = response.read_body_as_text().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # JSON responses
+//!
+//! JSON responses can be returned from Cat APIs either by using `.format("json")`
+//!
+//! ```rust,no_run
+//! # use elasticsearch;
+//! # use elasticsearch::{Elasticsearch, Error, SearchParts};
+//! # use url::Url;
+//! # use elasticsearch::auth::Credentials;
+//! # use serde_json::{json, Value};
+//! # async fn run() -> Result<(), Error> {
+//! # let client = Elasticsearch::default();
+//! let response = client
+//!     .cat()
+//!     .nodes()
+//!     .format("json")
+//!     .send()
+//!     .await?;
+//!
+//! let response_body = response.read_body::<Value>().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Or by setting an accept header using `.headers()`
+//!
+//! ```rust,no_run
+//! # use elasticsearch;
+//! # use elasticsearch::{Elasticsearch, Error, SearchParts, http::headers::{HeaderValue, DEFAULT_ACCEPT, ACCEPT}};
+//! # use url::Url;
+//! # use elasticsearch::auth::Credentials;
+//! # use serde_json::{json, Value};
+//! # async fn run() -> Result<(), Error> {
+//! # let client = Elasticsearch::default();
+//! let response = client
+//!     .cat()
+//!     .nodes()
+//!     .header(ACCEPT, HeaderValue::from_static(DEFAULT_ACCEPT))
+//!     .send()
+//!     .await?;
+//!
+//! let response_body = response.read_body::<Value>().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Column Headers
 //!
 //! The column headers to return can be controlled with `.h()`
 //!

--- a/elasticsearch/src/cert.rs
+++ b/elasticsearch/src/cert.rs
@@ -19,7 +19,9 @@ pub use reqwest::Certificate;
 /// With Elasticsearch running at `https://example.com`, configured to use a certificate generated
 /// with your own Certificate Authority (CA), and where the certificate contains a CommonName (CN)
 /// or Subject Alternative Name (SAN) that matches the hostname of Elasticsearch
-#[cfg_attr(any(feature = "native-tls", feature = "rustls-tls"), doc = r##"
+#[cfg_attr(
+    any(feature = "native-tls", feature = "rustls-tls"),
+    doc = r##"
 ```rust,norun
 # use elasticsearch::{
 #     auth::Credentials,
@@ -48,14 +50,17 @@ let _response = client.ping().send().await?;
 # Ok(())
 # }
 ```
-"##)]
+"##
+)]
 /// ## Certificate validation
 ///
 /// This requires the `native-tls` feature to be enabled.
 ///
 /// With Elasticsearch running at `https://example.com`, configured to use a certificate generated
 /// with your own Certificate Authority (CA)
-#[cfg_attr(feature = "native-tls", doc = r##"
+#[cfg_attr(
+    feature = "native-tls",
+    doc = r##"
 ```rust,norun
 # use elasticsearch::{
 #     auth::Credentials,
@@ -83,7 +88,8 @@ let _response = client.ping().send().await?;
 # Ok(())
 # }
 ```
-"##)]
+"##
+)]
 /// ## No validation
 ///
 /// No validation is performed on the certificate provided by the server.

--- a/elasticsearch/src/generated/namespace_clients/cat.rs
+++ b/elasticsearch/src/generated/namespace_clients/cat.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -72,10 +72,13 @@ pub struct CatAliases<'a, 'b> {
 impl<'a, 'b> CatAliases<'a, 'b> {
     #[doc = "Creates a new instance of [CatAliases] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatAliasesParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatAliases {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,
@@ -253,10 +256,13 @@ pub struct CatAllocation<'a, 'b> {
 impl<'a, 'b> CatAllocation<'a, 'b> {
     #[doc = "Creates a new instance of [CatAllocation] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatAllocationParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatAllocation {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             bytes: None,
             error_trace: None,
             filter_path: None,
@@ -449,10 +455,13 @@ pub struct CatCount<'a, 'b> {
 impl<'a, 'b> CatCount<'a, 'b> {
     #[doc = "Creates a new instance of [CatCount] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatCountParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatCount {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,
@@ -620,10 +629,13 @@ pub struct CatFielddata<'a, 'b> {
 impl<'a, 'b> CatFielddata<'a, 'b> {
     #[doc = "Creates a new instance of [CatFielddata] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatFielddataParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatFielddata {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             bytes: None,
             error_trace: None,
             fields: None,
@@ -800,10 +812,13 @@ pub struct CatHealth<'a, 'b> {
 impl<'a, 'b> CatHealth<'a, 'b> {
     #[doc = "Creates a new instance of [CatHealth]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatHealth {
             client,
             parts: CatHealthParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,
@@ -975,10 +990,13 @@ pub struct CatHelp<'a, 'b> {
 impl<'a, 'b> CatHelp<'a, 'b> {
     #[doc = "Creates a new instance of [CatHelp]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatHelp {
             client,
             parts: CatHelpParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             help: None,
@@ -1124,10 +1142,13 @@ pub struct CatIndices<'a, 'b> {
 impl<'a, 'b> CatIndices<'a, 'b> {
     #[doc = "Creates a new instance of [CatIndices] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatIndicesParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatIndices {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             bytes: None,
             error_trace: None,
             filter_path: None,
@@ -1349,10 +1370,13 @@ pub struct CatMaster<'a, 'b> {
 impl<'a, 'b> CatMaster<'a, 'b> {
     #[doc = "Creates a new instance of [CatMaster]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatMaster {
             client,
             parts: CatMasterParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,
@@ -1529,10 +1553,13 @@ pub struct CatNodeattrs<'a, 'b> {
 impl<'a, 'b> CatNodeattrs<'a, 'b> {
     #[doc = "Creates a new instance of [CatNodeattrs]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatNodeattrs {
             client,
             parts: CatNodeattrsParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,
@@ -1712,10 +1739,13 @@ pub struct CatNodes<'a, 'b> {
 impl<'a, 'b> CatNodes<'a, 'b> {
     #[doc = "Creates a new instance of [CatNodes]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatNodes {
             client,
             parts: CatNodesParts::None,
-            headers: HeaderMap::new(),
+            headers,
             bytes: None,
             error_trace: None,
             filter_path: None,
@@ -1920,10 +1950,13 @@ pub struct CatPendingTasks<'a, 'b> {
 impl<'a, 'b> CatPendingTasks<'a, 'b> {
     #[doc = "Creates a new instance of [CatPendingTasks]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatPendingTasks {
             client,
             parts: CatPendingTasksParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,
@@ -2109,10 +2142,13 @@ pub struct CatPlugins<'a, 'b> {
 impl<'a, 'b> CatPlugins<'a, 'b> {
     #[doc = "Creates a new instance of [CatPlugins]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatPlugins {
             client,
             parts: CatPluginsParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,
@@ -2301,10 +2337,13 @@ pub struct CatRecovery<'a, 'b> {
 impl<'a, 'b> CatRecovery<'a, 'b> {
     #[doc = "Creates a new instance of [CatRecovery] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatRecoveryParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatRecovery {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             active_only: None,
             bytes: None,
             detailed: None,
@@ -2508,10 +2547,13 @@ pub struct CatRepositories<'a, 'b> {
 impl<'a, 'b> CatRepositories<'a, 'b> {
     #[doc = "Creates a new instance of [CatRepositories]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatRepositories {
             client,
             parts: CatRepositoriesParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,
@@ -2696,10 +2738,13 @@ pub struct CatSegments<'a, 'b> {
 impl<'a, 'b> CatSegments<'a, 'b> {
     #[doc = "Creates a new instance of [CatSegments] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatSegmentsParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatSegments {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             bytes: None,
             error_trace: None,
             filter_path: None,
@@ -2878,10 +2923,13 @@ pub struct CatShards<'a, 'b> {
 impl<'a, 'b> CatShards<'a, 'b> {
     #[doc = "Creates a new instance of [CatShards] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatShardsParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatShards {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             bytes: None,
             error_trace: None,
             filter_path: None,
@@ -3086,10 +3134,13 @@ pub struct CatSnapshots<'a, 'b> {
 impl<'a, 'b> CatSnapshots<'a, 'b> {
     #[doc = "Creates a new instance of [CatSnapshots] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatSnapshotsParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatSnapshots {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,
@@ -3278,10 +3329,13 @@ pub struct CatTasks<'a, 'b> {
 impl<'a, 'b> CatTasks<'a, 'b> {
     #[doc = "Creates a new instance of [CatTasks]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatTasks {
             client,
             parts: CatTasksParts::None,
-            headers: HeaderMap::new(),
+            headers,
             actions: None,
             detailed: None,
             error_trace: None,
@@ -3499,10 +3553,13 @@ pub struct CatTemplates<'a, 'b> {
 impl<'a, 'b> CatTemplates<'a, 'b> {
     #[doc = "Creates a new instance of [CatTemplates] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatTemplatesParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatTemplates {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,
@@ -3689,10 +3746,13 @@ pub struct CatThreadPool<'a, 'b> {
 impl<'a, 'b> CatThreadPool<'a, 'b> {
     #[doc = "Creates a new instance of [CatThreadPool] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CatThreadPoolParts<'b>) -> Self {
+        let mut headers = HeaderMap::with_capacity(2);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatThreadPool {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             format: None,

--- a/elasticsearch/src/generated/namespace_clients/ccr.rs
+++ b/elasticsearch/src/generated/namespace_clients/ccr.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -62,10 +62,11 @@ pub struct CcrDeleteAutoFollowPattern<'a, 'b> {
 impl<'a, 'b> CcrDeleteAutoFollowPattern<'a, 'b> {
     #[doc = "Creates a new instance of [CcrDeleteAutoFollowPattern] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrDeleteAutoFollowPatternParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrDeleteAutoFollowPattern {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -183,10 +184,11 @@ where
 {
     #[doc = "Creates a new instance of [CcrFollow] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrFollowParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrFollow {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -328,10 +330,11 @@ pub struct CcrFollowInfo<'a, 'b> {
 impl<'a, 'b> CcrFollowInfo<'a, 'b> {
     #[doc = "Creates a new instance of [CcrFollowInfo] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrFollowInfoParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrFollowInfo {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -445,10 +448,11 @@ pub struct CcrFollowStats<'a, 'b> {
 impl<'a, 'b> CcrFollowStats<'a, 'b> {
     #[doc = "Creates a new instance of [CcrFollowStats] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrFollowStatsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrFollowStats {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -565,10 +569,11 @@ where
 {
     #[doc = "Creates a new instance of [CcrForgetFollower] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrForgetFollowerParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrForgetFollower {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -701,10 +706,11 @@ pub struct CcrGetAutoFollowPattern<'a, 'b> {
 impl<'a, 'b> CcrGetAutoFollowPattern<'a, 'b> {
     #[doc = "Creates a new instance of [CcrGetAutoFollowPattern] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrGetAutoFollowPatternParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrGetAutoFollowPattern {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -821,10 +827,11 @@ where
 {
     #[doc = "Creates a new instance of [CcrPauseAutoFollowPattern] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrPauseAutoFollowPatternParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrPauseAutoFollowPattern {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -959,10 +966,11 @@ where
 {
     #[doc = "Creates a new instance of [CcrPauseFollow] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrPauseFollowParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrPauseFollow {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1096,10 +1104,11 @@ where
 {
     #[doc = "Creates a new instance of [CcrPutAutoFollowPattern] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrPutAutoFollowPatternParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrPutAutoFollowPattern {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1234,10 +1243,11 @@ where
 {
     #[doc = "Creates a new instance of [CcrResumeAutoFollowPattern] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrResumeAutoFollowPatternParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrResumeAutoFollowPattern {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1372,10 +1382,11 @@ where
 {
     #[doc = "Creates a new instance of [CcrResumeFollow] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrResumeFollowParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrResumeFollow {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1500,10 +1511,11 @@ pub struct CcrStats<'a, 'b> {
 impl<'a, 'b> CcrStats<'a, 'b> {
     #[doc = "Creates a new instance of [CcrStats]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         CcrStats {
             client,
             parts: CcrStatsParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1620,10 +1632,11 @@ where
 {
     #[doc = "Creates a new instance of [CcrUnfollow] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CcrUnfollowParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         CcrUnfollow {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/generated/namespace_clients/cluster.rs
+++ b/elasticsearch/src/generated/namespace_clients/cluster.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -63,10 +63,11 @@ where
 {
     #[doc = "Creates a new instance of [ClusterAllocationExplain]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         ClusterAllocationExplain {
             client,
             parts: ClusterAllocationExplainParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -218,10 +219,11 @@ pub struct ClusterGetSettings<'a, 'b> {
 impl<'a, 'b> ClusterGetSettings<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterGetSettings]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         ClusterGetSettings {
             client,
             parts: ClusterGetSettingsParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             flat_settings: None,
@@ -384,10 +386,11 @@ pub struct ClusterHealth<'a, 'b> {
 impl<'a, 'b> ClusterHealth<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterHealth] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: ClusterHealthParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         ClusterHealth {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             expand_wildcards: None,
             filter_path: None,
@@ -598,10 +601,11 @@ pub struct ClusterPendingTasks<'a, 'b> {
 impl<'a, 'b> ClusterPendingTasks<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterPendingTasks]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         ClusterPendingTasks {
             client,
             parts: ClusterPendingTasksParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -733,10 +737,11 @@ where
 {
     #[doc = "Creates a new instance of [ClusterPutSettings]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         ClusterPutSettings {
             client,
             parts: ClusterPutSettingsParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -891,10 +896,11 @@ pub struct ClusterRemoteInfo<'a, 'b> {
 impl<'a, 'b> ClusterRemoteInfo<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterRemoteInfo]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         ClusterRemoteInfo {
             client,
             parts: ClusterRemoteInfoParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1011,10 +1017,11 @@ where
 {
     #[doc = "Creates a new instance of [ClusterReroute]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         ClusterReroute {
             client,
             parts: ClusterRerouteParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             dry_run: None,
             error_trace: None,
@@ -1228,10 +1235,11 @@ pub struct ClusterState<'a, 'b> {
 impl<'a, 'b> ClusterState<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterState] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: ClusterStateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         ClusterState {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -1421,10 +1429,11 @@ pub struct ClusterStats<'a, 'b> {
 impl<'a, 'b> ClusterStats<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterStats] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: ClusterStatsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         ClusterStats {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             flat_settings: None,

--- a/elasticsearch/src/generated/namespace_clients/enrich.rs
+++ b/elasticsearch/src/generated/namespace_clients/enrich.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -62,10 +62,11 @@ pub struct EnrichDeletePolicy<'a, 'b> {
 impl<'a, 'b> EnrichDeletePolicy<'a, 'b> {
     #[doc = "Creates a new instance of [EnrichDeletePolicy] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: EnrichDeletePolicyParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         EnrichDeletePolicy {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -183,10 +184,11 @@ where
 {
     #[doc = "Creates a new instance of [EnrichExecutePolicy] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: EnrichExecutePolicyParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         EnrichExecutePolicy {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -330,10 +332,11 @@ pub struct EnrichGetPolicy<'a, 'b> {
 impl<'a, 'b> EnrichGetPolicy<'a, 'b> {
     #[doc = "Creates a new instance of [EnrichGetPolicy] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: EnrichGetPolicyParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         EnrichGetPolicy {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -449,10 +452,11 @@ where
 {
     #[doc = "Creates a new instance of [EnrichPutPolicy] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: EnrichPutPolicyParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         EnrichPutPolicy {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -577,10 +581,11 @@ pub struct EnrichStats<'a, 'b> {
 impl<'a, 'b> EnrichStats<'a, 'b> {
     #[doc = "Creates a new instance of [EnrichStats]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         EnrichStats {
             client,
             parts: EnrichStatsParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,

--- a/elasticsearch/src/generated/namespace_clients/graph.rs
+++ b/elasticsearch/src/generated/namespace_clients/graph.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -83,10 +83,11 @@ where
 {
     #[doc = "Creates a new instance of [GraphExplore] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: GraphExploreParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         GraphExplore {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/generated/namespace_clients/ilm.rs
+++ b/elasticsearch/src/generated/namespace_clients/ilm.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -62,10 +62,11 @@ pub struct IlmDeleteLifecycle<'a, 'b> {
 impl<'a, 'b> IlmDeleteLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [IlmDeleteLifecycle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IlmDeleteLifecycleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IlmDeleteLifecycle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -180,10 +181,11 @@ pub struct IlmExplainLifecycle<'a, 'b> {
 impl<'a, 'b> IlmExplainLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [IlmExplainLifecycle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IlmExplainLifecycleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IlmExplainLifecycle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -316,10 +318,11 @@ pub struct IlmGetLifecycle<'a, 'b> {
 impl<'a, 'b> IlmGetLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [IlmGetLifecycle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IlmGetLifecycleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IlmGetLifecycle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -426,10 +429,11 @@ pub struct IlmGetStatus<'a, 'b> {
 impl<'a, 'b> IlmGetStatus<'a, 'b> {
     #[doc = "Creates a new instance of [IlmGetStatus]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         IlmGetStatus {
             client,
             parts: IlmGetStatusParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -545,10 +549,11 @@ where
 {
     #[doc = "Creates a new instance of [IlmMoveToStep] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IlmMoveToStepParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IlmMoveToStep {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -682,10 +687,11 @@ where
 {
     #[doc = "Creates a new instance of [IlmPutLifecycle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IlmPutLifecycleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IlmPutLifecycle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -820,10 +826,11 @@ where
 {
     #[doc = "Creates a new instance of [IlmRemovePolicy] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IlmRemovePolicyParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IlmRemovePolicy {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -958,10 +965,11 @@ where
 {
     #[doc = "Creates a new instance of [IlmRetry] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IlmRetryParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IlmRetry {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1090,10 +1098,11 @@ where
 {
     #[doc = "Creates a new instance of [IlmStart]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         IlmStart {
             client,
             parts: IlmStartParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1222,10 +1231,11 @@ where
 {
     #[doc = "Creates a new instance of [IlmStop]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         IlmStop {
             client,
             parts: IlmStopParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/generated/namespace_clients/indices.rs
+++ b/elasticsearch/src/generated/namespace_clients/indices.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -71,10 +71,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesAnalyze] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesAnalyzeParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesAnalyze {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -234,10 +235,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesClearCache] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesClearCacheParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesClearCache {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -456,10 +458,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesClone] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesCloneParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesClone {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -631,10 +634,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesClose] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesCloseParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesClose {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -832,10 +836,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesCreate] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesCreateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesCreate {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1011,10 +1016,11 @@ pub struct IndicesDelete<'a, 'b> {
 impl<'a, 'b> IndicesDelete<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesDelete] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesDeleteParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesDelete {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -1177,10 +1183,11 @@ pub struct IndicesDeleteAlias<'a, 'b> {
 impl<'a, 'b> IndicesDeleteAlias<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesDeleteAlias] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesDeleteAliasParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesDeleteAlias {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1312,10 +1319,11 @@ pub struct IndicesDeleteTemplate<'a, 'b> {
 impl<'a, 'b> IndicesDeleteTemplate<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesDeleteTemplate] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesDeleteTemplateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesDeleteTemplate {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1452,10 +1460,11 @@ pub struct IndicesExists<'a, 'b> {
 impl<'a, 'b> IndicesExists<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExists] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesExistsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesExists {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -1638,10 +1647,11 @@ pub struct IndicesExistsAlias<'a, 'b> {
 impl<'a, 'b> IndicesExistsAlias<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExistsAlias] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesExistsAliasParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesExistsAlias {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -1793,10 +1803,11 @@ pub struct IndicesExistsTemplate<'a, 'b> {
 impl<'a, 'b> IndicesExistsTemplate<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExistsTemplate] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesExistsTemplateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesExistsTemplate {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             flat_settings: None,
@@ -1943,10 +1954,11 @@ pub struct IndicesExistsType<'a, 'b> {
 impl<'a, 'b> IndicesExistsType<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExistsType] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesExistsTypeParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesExistsType {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -2108,10 +2120,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesFlush] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesFlushParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesFlush {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -2306,10 +2319,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesFlushSynced] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesFlushSyncedParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesFlushSynced {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -2487,10 +2501,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesForcemerge] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesForcemergeParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesForcemerge {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -2691,10 +2706,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesFreeze] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesFreezeParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesFreeze {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -2893,10 +2909,11 @@ pub struct IndicesGet<'a, 'b> {
 impl<'a, 'b> IndicesGet<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGet] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesGetParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesGet {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -3110,10 +3127,11 @@ pub struct IndicesGetAlias<'a, 'b> {
 impl<'a, 'b> IndicesGetAlias<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetAlias] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesGetAliasParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesGetAlias {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -3309,10 +3327,11 @@ pub struct IndicesGetFieldMapping<'a, 'b> {
 impl<'a, 'b> IndicesGetFieldMapping<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetFieldMapping] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesGetFieldMappingParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesGetFieldMapping {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -3510,10 +3529,11 @@ pub struct IndicesGetMapping<'a, 'b> {
 impl<'a, 'b> IndicesGetMapping<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetMapping] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesGetMappingParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesGetMapping {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -3712,10 +3732,11 @@ pub struct IndicesGetSettings<'a, 'b> {
 impl<'a, 'b> IndicesGetSettings<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetSettings] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesGetSettingsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesGetSettings {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -3898,10 +3919,11 @@ pub struct IndicesGetTemplate<'a, 'b> {
 impl<'a, 'b> IndicesGetTemplate<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetTemplate] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesGetTemplateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesGetTemplate {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             flat_settings: None,
@@ -4057,10 +4079,11 @@ pub struct IndicesGetUpgrade<'a, 'b> {
 impl<'a, 'b> IndicesGetUpgrade<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetUpgrade] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesGetUpgradeParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesGetUpgrade {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -4211,10 +4234,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesOpen] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesOpenParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesOpen {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -4413,10 +4437,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesPutAlias] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesPutAliasParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesPutAlias {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -4598,10 +4623,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesPutMapping] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesPutMappingParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesPutMapping {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -4807,10 +4833,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesPutSettings] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesPutSettingsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesPutSettings {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -5020,10 +5047,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesPutTemplate] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesPutTemplateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesPutTemplate {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             create: None,
             error_trace: None,
@@ -5220,10 +5248,11 @@ pub struct IndicesRecovery<'a, 'b> {
 impl<'a, 'b> IndicesRecovery<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesRecovery] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesRecoveryParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesRecovery {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             active_only: None,
             detailed: None,
             error_trace: None,
@@ -5365,10 +5394,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesRefresh] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesRefreshParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesRefresh {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -5540,10 +5570,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesReloadSearchAnalyzers] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesReloadSearchAnalyzersParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesReloadSearchAnalyzers {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -5726,10 +5757,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesRollover] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesRolloverParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesRollover {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             dry_run: None,
             error_trace: None,
@@ -5918,10 +5950,11 @@ pub struct IndicesSegments<'a, 'b> {
 impl<'a, 'b> IndicesSegments<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesSegments] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesSegmentsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesSegments {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -6078,10 +6111,11 @@ pub struct IndicesShardStores<'a, 'b> {
 impl<'a, 'b> IndicesShardStores<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesShardStores] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesShardStoresParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesShardStores {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             error_trace: None,
             expand_wildcards: None,
@@ -6239,10 +6273,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesShrink] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesShrinkParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesShrink {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             copy_settings: None,
             error_trace: None,
@@ -6422,10 +6457,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesSplit] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesSplitParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesSplit {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             copy_settings: None,
             error_trace: None,
@@ -6631,10 +6667,11 @@ pub struct IndicesStats<'a, 'b> {
 impl<'a, 'b> IndicesStats<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesStats] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesStatsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesStats {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             completion_fields: None,
             error_trace: None,
             expand_wildcards: None,
@@ -6853,10 +6890,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesUnfreeze] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesUnfreezeParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesUnfreeze {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -7047,10 +7085,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesUpdateAliases]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         IndicesUpdateAliases {
             client,
             parts: IndicesUpdateAliasesParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -7214,10 +7253,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesUpgrade] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesUpgradeParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesUpgrade {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -7431,10 +7471,11 @@ where
 {
     #[doc = "Creates a new instance of [IndicesValidateQuery] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndicesValidateQueryParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IndicesValidateQuery {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             all_shards: None,
             allow_no_indices: None,
             analyze_wildcard: None,

--- a/elasticsearch/src/generated/namespace_clients/ingest.rs
+++ b/elasticsearch/src/generated/namespace_clients/ingest.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -64,10 +64,11 @@ pub struct IngestDeletePipeline<'a, 'b> {
 impl<'a, 'b> IngestDeletePipeline<'a, 'b> {
     #[doc = "Creates a new instance of [IngestDeletePipeline] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IngestDeletePipelineParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IngestDeletePipeline {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -201,10 +202,11 @@ pub struct IngestGetPipeline<'a, 'b> {
 impl<'a, 'b> IngestGetPipeline<'a, 'b> {
     #[doc = "Creates a new instance of [IngestGetPipeline] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IngestGetPipelineParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IngestGetPipeline {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -320,10 +322,11 @@ pub struct IngestProcessorGrok<'a, 'b> {
 impl<'a, 'b> IngestProcessorGrok<'a, 'b> {
     #[doc = "Creates a new instance of [IngestProcessorGrok]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         IngestProcessorGrok {
             client,
             parts: IngestProcessorGrokParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -441,10 +444,11 @@ where
 {
     #[doc = "Creates a new instance of [IngestPutPipeline] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IngestPutPipelineParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IngestPutPipeline {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -603,10 +607,11 @@ where
 {
     #[doc = "Creates a new instance of [IngestSimulate] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IngestSimulateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         IngestSimulate {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/generated/namespace_clients/license.rs
+++ b/elasticsearch/src/generated/namespace_clients/license.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -57,10 +57,11 @@ pub struct LicenseDelete<'a, 'b> {
 impl<'a, 'b> LicenseDelete<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseDelete]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         LicenseDelete {
             client,
             parts: LicenseDeleteParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -169,10 +170,11 @@ pub struct LicenseGet<'a, 'b> {
 impl<'a, 'b> LicenseGet<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseGet]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         LicenseGet {
             client,
             parts: LicenseGetParts::None,
-            headers: HeaderMap::new(),
+            headers,
             accept_enterprise: None,
             error_trace: None,
             filter_path: None,
@@ -297,10 +299,11 @@ pub struct LicenseGetBasicStatus<'a, 'b> {
 impl<'a, 'b> LicenseGetBasicStatus<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseGetBasicStatus]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         LicenseGetBasicStatus {
             client,
             parts: LicenseGetBasicStatusParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -407,10 +410,11 @@ pub struct LicenseGetTrialStatus<'a, 'b> {
 impl<'a, 'b> LicenseGetTrialStatus<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseGetTrialStatus]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         LicenseGetTrialStatus {
             client,
             parts: LicenseGetTrialStatusParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -522,10 +526,11 @@ where
 {
     #[doc = "Creates a new instance of [LicensePost]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         LicensePost {
             client,
             parts: LicensePostParts::None,
-            headers: HeaderMap::new(),
+            headers,
             acknowledge: None,
             body: None,
             error_trace: None,
@@ -665,10 +670,11 @@ where
 {
     #[doc = "Creates a new instance of [LicensePostStartBasic]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         LicensePostStartBasic {
             client,
             parts: LicensePostStartBasicParts::None,
-            headers: HeaderMap::new(),
+            headers,
             acknowledge: None,
             body: None,
             error_trace: None,
@@ -809,10 +815,11 @@ where
 {
     #[doc = "Creates a new instance of [LicensePostStartTrial]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         LicensePostStartTrial {
             client,
             parts: LicensePostStartTrialParts::None,
-            headers: HeaderMap::new(),
+            headers,
             acknowledge: None,
             body: None,
             error_trace: None,

--- a/elasticsearch/src/generated/namespace_clients/migration.rs
+++ b/elasticsearch/src/generated/namespace_clients/migration.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -66,10 +66,11 @@ pub struct MigrationDeprecations<'a, 'b> {
 impl<'a, 'b> MigrationDeprecations<'a, 'b> {
     #[doc = "Creates a new instance of [MigrationDeprecations] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MigrationDeprecationsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MigrationDeprecations {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,

--- a/elasticsearch/src/generated/namespace_clients/ml.rs
+++ b/elasticsearch/src/generated/namespace_clients/ml.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -70,10 +70,11 @@ where
 {
     #[doc = "Creates a new instance of [MlCloseJob] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlCloseJobParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlCloseJob {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_jobs: None,
             body: None,
             error_trace: None,
@@ -233,10 +234,11 @@ pub struct MlDeleteCalendar<'a, 'b> {
 impl<'a, 'b> MlDeleteCalendar<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteCalendar] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlDeleteCalendarParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlDeleteCalendar {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -350,10 +352,11 @@ pub struct MlDeleteCalendarEvent<'a, 'b> {
 impl<'a, 'b> MlDeleteCalendarEvent<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteCalendarEvent] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlDeleteCalendarEventParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlDeleteCalendarEvent {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -467,10 +470,11 @@ pub struct MlDeleteCalendarJob<'a, 'b> {
 impl<'a, 'b> MlDeleteCalendarJob<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteCalendarJob] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlDeleteCalendarJobParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlDeleteCalendarJob {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -583,10 +587,11 @@ pub struct MlDeleteDatafeed<'a, 'b> {
 impl<'a, 'b> MlDeleteDatafeed<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteDatafeed] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlDeleteDatafeedParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlDeleteDatafeed {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             force: None,
@@ -702,10 +707,11 @@ pub struct MlDeleteExpiredData<'a, 'b> {
 impl<'a, 'b> MlDeleteExpiredData<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteExpiredData]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         MlDeleteExpiredData {
             client,
             parts: MlDeleteExpiredDataParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -817,10 +823,11 @@ pub struct MlDeleteFilter<'a, 'b> {
 impl<'a, 'b> MlDeleteFilter<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteFilter] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlDeleteFilterParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlDeleteFilter {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -945,10 +952,11 @@ pub struct MlDeleteForecast<'a, 'b> {
 impl<'a, 'b> MlDeleteForecast<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteForecast] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlDeleteForecastParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlDeleteForecast {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_forecasts: None,
             error_trace: None,
             filter_path: None,
@@ -1080,10 +1088,11 @@ pub struct MlDeleteJob<'a, 'b> {
 impl<'a, 'b> MlDeleteJob<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteJob] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlDeleteJobParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlDeleteJob {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             force: None,
@@ -1215,10 +1224,11 @@ pub struct MlDeleteModelSnapshot<'a, 'b> {
 impl<'a, 'b> MlDeleteModelSnapshot<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteModelSnapshot] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlDeleteModelSnapshotParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlDeleteModelSnapshot {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1340,10 +1350,11 @@ where
 {
     #[doc = "Creates a new instance of [MlFlushJob] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlFlushJobParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlFlushJob {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             advance_time: None,
             body: None,
             calc_interim: None,
@@ -1530,10 +1541,11 @@ where
 {
     #[doc = "Creates a new instance of [MlForecast] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlForecastParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlForecast {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             duration: None,
             error_trace: None,
@@ -1707,10 +1719,11 @@ where
 {
     #[doc = "Creates a new instance of [MlGetBuckets] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetBucketsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetBuckets {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             anomaly_score: None,
             body: None,
             desc: None,
@@ -1939,10 +1952,11 @@ pub struct MlGetCalendarEvents<'a, 'b> {
 impl<'a, 'b> MlGetCalendarEvents<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetCalendarEvents] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetCalendarEventsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetCalendarEvents {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             end: None,
             error_trace: None,
             filter_path: None,
@@ -2108,10 +2122,11 @@ where
 {
     #[doc = "Creates a new instance of [MlGetCalendars] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetCalendarsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetCalendars {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -2282,10 +2297,11 @@ where
 {
     #[doc = "Creates a new instance of [MlGetCategories] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetCategoriesParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetCategories {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -2443,10 +2459,11 @@ pub struct MlGetDatafeedStats<'a, 'b> {
 impl<'a, 'b> MlGetDatafeedStats<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetDatafeedStats] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetDatafeedStatsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetDatafeedStats {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_datafeeds: None,
             error_trace: None,
             filter_path: None,
@@ -2571,10 +2588,11 @@ pub struct MlGetDatafeeds<'a, 'b> {
 impl<'a, 'b> MlGetDatafeeds<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetDatafeeds] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetDatafeedsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetDatafeeds {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_datafeeds: None,
             error_trace: None,
             filter_path: None,
@@ -2700,10 +2718,11 @@ pub struct MlGetFilters<'a, 'b> {
 impl<'a, 'b> MlGetFilters<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetFilters] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetFiltersParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetFilters {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             from: None,
@@ -2846,10 +2865,11 @@ where
 {
     #[doc = "Creates a new instance of [MlGetInfluencers] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetInfluencersParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetInfluencers {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             desc: None,
             end: None,
@@ -3067,10 +3087,11 @@ pub struct MlGetJobStats<'a, 'b> {
 impl<'a, 'b> MlGetJobStats<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetJobStats] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetJobStatsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetJobStats {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_jobs: None,
             error_trace: None,
             filter_path: None,
@@ -3195,10 +3216,11 @@ pub struct MlGetJobs<'a, 'b> {
 impl<'a, 'b> MlGetJobs<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetJobs] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetJobsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetJobs {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_jobs: None,
             error_trace: None,
             filter_path: None,
@@ -3340,10 +3362,11 @@ where
 {
     #[doc = "Creates a new instance of [MlGetModelSnapshots] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetModelSnapshotsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetModelSnapshots {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             desc: None,
             end: None,
@@ -3548,10 +3571,11 @@ where
 {
     #[doc = "Creates a new instance of [MlGetOverallBuckets] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetOverallBucketsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetOverallBuckets {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_jobs: None,
             body: None,
             bucket_span: None,
@@ -3767,10 +3791,11 @@ where
 {
     #[doc = "Creates a new instance of [MlGetRecords] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlGetRecordsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlGetRecords {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             desc: None,
             end: None,
@@ -3977,10 +4002,11 @@ pub struct MlInfo<'a, 'b> {
 impl<'a, 'b> MlInfo<'a, 'b> {
     #[doc = "Creates a new instance of [MlInfo]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         MlInfo {
             client,
             parts: MlInfoParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -4097,10 +4123,11 @@ where
 {
     #[doc = "Creates a new instance of [MlOpenJob] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlOpenJobParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlOpenJob {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -4235,10 +4262,11 @@ where
 {
     #[doc = "Creates a new instance of [MlPostCalendarEvents] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlPostCalendarEventsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlPostCalendarEvents {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -4375,10 +4403,11 @@ where
 {
     #[doc = "Creates a new instance of [MlPostData] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlPostDataParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlPostData {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -4529,10 +4558,11 @@ pub struct MlPreviewDatafeed<'a, 'b> {
 impl<'a, 'b> MlPreviewDatafeed<'a, 'b> {
     #[doc = "Creates a new instance of [MlPreviewDatafeed] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlPreviewDatafeedParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlPreviewDatafeed {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -4648,10 +4678,11 @@ where
 {
     #[doc = "Creates a new instance of [MlPutCalendar] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlPutCalendarParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlPutCalendar {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -4787,10 +4818,11 @@ where
 {
     #[doc = "Creates a new instance of [MlPutCalendarJob] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlPutCalendarJobParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlPutCalendarJob {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -4924,10 +4956,11 @@ where
 {
     #[doc = "Creates a new instance of [MlPutDatafeed] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlPutDatafeedParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlPutDatafeed {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -5061,10 +5094,11 @@ where
 {
     #[doc = "Creates a new instance of [MlPutFilter] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlPutFilterParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlPutFilter {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -5198,10 +5232,11 @@ where
 {
     #[doc = "Creates a new instance of [MlPutJob] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlPutJobParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlPutJob {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -5339,10 +5374,11 @@ where
 {
     #[doc = "Creates a new instance of [MlRevertModelSnapshot] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlRevertModelSnapshotParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlRevertModelSnapshot {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             delete_intervening_results: None,
             error_trace: None,
@@ -5483,10 +5519,11 @@ where
 {
     #[doc = "Creates a new instance of [MlSetUpgradeMode]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         MlSetUpgradeMode {
             client,
             parts: MlSetUpgradeModeParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             enabled: None,
             error_trace: None,
@@ -5644,10 +5681,11 @@ where
 {
     #[doc = "Creates a new instance of [MlStartDatafeed] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlStartDatafeedParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlStartDatafeed {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             end: None,
             error_trace: None,
@@ -5815,10 +5853,11 @@ where
 {
     #[doc = "Creates a new instance of [MlStopDatafeed] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlStopDatafeedParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlStopDatafeed {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_datafeeds: None,
             body: None,
             error_trace: None,
@@ -5983,10 +6022,11 @@ where
 {
     #[doc = "Creates a new instance of [MlUpdateDatafeed] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlUpdateDatafeedParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlUpdateDatafeed {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -6121,10 +6161,11 @@ where
 {
     #[doc = "Creates a new instance of [MlUpdateFilter] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlUpdateFilterParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlUpdateFilter {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -6259,10 +6300,11 @@ where
 {
     #[doc = "Creates a new instance of [MlUpdateJob] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlUpdateJobParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlUpdateJob {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -6399,10 +6441,11 @@ where
 {
     #[doc = "Creates a new instance of [MlUpdateModelSnapshot] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MlUpdateModelSnapshotParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MlUpdateModelSnapshot {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -6531,10 +6574,11 @@ where
 {
     #[doc = "Creates a new instance of [MlValidate]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         MlValidate {
             client,
             parts: MlValidateParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -6663,10 +6707,11 @@ where
 {
     #[doc = "Creates a new instance of [MlValidateDetector]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         MlValidateDetector {
             client,
             parts: MlValidateDetectorParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/generated/namespace_clients/nodes.rs
+++ b/elasticsearch/src/generated/namespace_clients/nodes.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -73,10 +73,11 @@ pub struct NodesHotThreads<'a, 'b> {
 impl<'a, 'b> NodesHotThreads<'a, 'b> {
     #[doc = "Creates a new instance of [NodesHotThreads] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: NodesHotThreadsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         NodesHotThreads {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -269,10 +270,11 @@ pub struct NodesInfo<'a, 'b> {
 impl<'a, 'b> NodesInfo<'a, 'b> {
     #[doc = "Creates a new instance of [NodesInfo] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: NodesInfoParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         NodesInfo {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             flat_settings: None,
@@ -412,10 +414,11 @@ where
 {
     #[doc = "Creates a new instance of [NodesReloadSecureSettings] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: NodesReloadSecureSettingsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         NodesReloadSecureSettings {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -619,10 +622,11 @@ pub struct NodesStats<'a, 'b> {
 impl<'a, 'b> NodesStats<'a, 'b> {
     #[doc = "Creates a new instance of [NodesStats] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: NodesStatsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         NodesStats {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             completion_fields: None,
             error_trace: None,
             fielddata_fields: None,
@@ -839,10 +843,11 @@ pub struct NodesUsage<'a, 'b> {
 impl<'a, 'b> NodesUsage<'a, 'b> {
     #[doc = "Creates a new instance of [NodesUsage] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: NodesUsageParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         NodesUsage {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,

--- a/elasticsearch/src/generated/namespace_clients/security.rs
+++ b/elasticsearch/src/generated/namespace_clients/security.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -57,10 +57,11 @@ pub struct SecurityAuthenticate<'a, 'b> {
 impl<'a, 'b> SecurityAuthenticate<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityAuthenticate]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SecurityAuthenticate {
             client,
             parts: SecurityAuthenticateParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -181,10 +182,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityChangePassword] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityChangePasswordParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityChangePassword {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -331,10 +333,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityClearCachedRealms] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityClearCachedRealmsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityClearCachedRealms {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -483,10 +486,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityClearCachedRoles] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityClearCachedRolesParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityClearCachedRoles {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -616,10 +620,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityCreateApiKey]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SecurityCreateApiKey {
             client,
             parts: SecurityCreateApiKeyParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -762,10 +767,11 @@ pub struct SecurityDeletePrivileges<'a, 'b> {
 impl<'a, 'b> SecurityDeletePrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeletePrivileges] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityDeletePrivilegesParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityDeletePrivileges {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -887,10 +893,11 @@ pub struct SecurityDeleteRole<'a, 'b> {
 impl<'a, 'b> SecurityDeleteRole<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeleteRole] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityDeleteRoleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityDeleteRole {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1012,10 +1019,11 @@ pub struct SecurityDeleteRoleMapping<'a, 'b> {
 impl<'a, 'b> SecurityDeleteRoleMapping<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeleteRoleMapping] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityDeleteRoleMappingParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityDeleteRoleMapping {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1137,10 +1145,11 @@ pub struct SecurityDeleteUser<'a, 'b> {
 impl<'a, 'b> SecurityDeleteUser<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeleteUser] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityDeleteUserParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityDeleteUser {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1267,10 +1276,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityDisableUser] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityDisableUserParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityDisableUser {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1416,10 +1426,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityEnableUser] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityEnableUserParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityEnableUser {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1559,10 +1570,11 @@ pub struct SecurityGetApiKey<'a, 'b> {
 impl<'a, 'b> SecurityGetApiKey<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetApiKey]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SecurityGetApiKey {
             client,
             parts: SecurityGetApiKeyParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1714,10 +1726,11 @@ pub struct SecurityGetBuiltinPrivileges<'a, 'b> {
 impl<'a, 'b> SecurityGetBuiltinPrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetBuiltinPrivileges]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SecurityGetBuiltinPrivileges {
             client,
             parts: SecurityGetBuiltinPrivilegesParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1842,10 +1855,11 @@ pub struct SecurityGetPrivileges<'a, 'b> {
 impl<'a, 'b> SecurityGetPrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetPrivileges] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityGetPrivilegesParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityGetPrivileges {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1960,10 +1974,11 @@ pub struct SecurityGetRole<'a, 'b> {
 impl<'a, 'b> SecurityGetRole<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetRole] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityGetRoleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityGetRole {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -2078,10 +2093,11 @@ pub struct SecurityGetRoleMapping<'a, 'b> {
 impl<'a, 'b> SecurityGetRoleMapping<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetRoleMapping] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityGetRoleMappingParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityGetRoleMapping {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -2192,10 +2208,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityGetToken]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SecurityGetToken {
             client,
             parts: SecurityGetTokenParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -2329,10 +2346,11 @@ pub struct SecurityGetUser<'a, 'b> {
 impl<'a, 'b> SecurityGetUser<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetUser] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityGetUserParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityGetUser {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -2439,10 +2457,11 @@ pub struct SecurityGetUserPrivileges<'a, 'b> {
 impl<'a, 'b> SecurityGetUserPrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetUserPrivileges]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SecurityGetUserPrivileges {
             client,
             parts: SecurityGetUserPrivilegesParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -2562,10 +2581,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityHasPrivileges] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityHasPrivilegesParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityHasPrivileges {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -2697,10 +2717,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityInvalidateApiKey]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SecurityInvalidateApiKey {
             client,
             parts: SecurityInvalidateApiKeyParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -2829,10 +2850,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityInvalidateToken]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SecurityInvalidateToken {
             client,
             parts: SecurityInvalidateTokenParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -2962,10 +2984,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityPutPrivileges]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SecurityPutPrivileges {
             client,
             parts: SecurityPutPrivilegesParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -3110,10 +3133,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityPutRole] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityPutRoleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityPutRole {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -3258,10 +3282,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityPutRoleMapping] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityPutRoleMappingParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityPutRoleMapping {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -3406,10 +3431,11 @@ where
 {
     #[doc = "Creates a new instance of [SecurityPutUser] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SecurityPutUserParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SecurityPutUser {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/generated/namespace_clients/slm.rs
+++ b/elasticsearch/src/generated/namespace_clients/slm.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -62,10 +62,11 @@ pub struct SlmDeleteLifecycle<'a, 'b> {
 impl<'a, 'b> SlmDeleteLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [SlmDeleteLifecycle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SlmDeleteLifecycleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SlmDeleteLifecycle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -182,10 +183,11 @@ where
 {
     #[doc = "Creates a new instance of [SlmExecuteLifecycle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SlmExecuteLifecycleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SlmExecuteLifecycle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -314,10 +316,11 @@ where
 {
     #[doc = "Creates a new instance of [SlmExecuteRetention]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SlmExecuteRetention {
             client,
             parts: SlmExecuteRetentionParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -451,10 +454,11 @@ pub struct SlmGetLifecycle<'a, 'b> {
 impl<'a, 'b> SlmGetLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [SlmGetLifecycle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SlmGetLifecycleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SlmGetLifecycle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -561,10 +565,11 @@ pub struct SlmGetStats<'a, 'b> {
 impl<'a, 'b> SlmGetStats<'a, 'b> {
     #[doc = "Creates a new instance of [SlmGetStats]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SlmGetStats {
             client,
             parts: SlmGetStatsParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -671,10 +676,11 @@ pub struct SlmGetStatus<'a, 'b> {
 impl<'a, 'b> SlmGetStatus<'a, 'b> {
     #[doc = "Creates a new instance of [SlmGetStatus]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SlmGetStatus {
             client,
             parts: SlmGetStatusParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -790,10 +796,11 @@ where
 {
     #[doc = "Creates a new instance of [SlmPutLifecycle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SlmPutLifecycleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SlmPutLifecycle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -922,10 +929,11 @@ where
 {
     #[doc = "Creates a new instance of [SlmStart]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SlmStart {
             client,
             parts: SlmStartParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1054,10 +1062,11 @@ where
 {
     #[doc = "Creates a new instance of [SlmStop]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SlmStop {
             client,
             parts: SlmStopParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/generated/namespace_clients/snapshot.rs
+++ b/elasticsearch/src/generated/namespace_clients/snapshot.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -69,10 +69,11 @@ where
 {
     #[doc = "Creates a new instance of [SnapshotCleanupRepository] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SnapshotCleanupRepositoryParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SnapshotCleanupRepository {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -230,10 +231,11 @@ where
 {
     #[doc = "Creates a new instance of [SnapshotCreate] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SnapshotCreateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SnapshotCreate {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -390,10 +392,11 @@ where
 {
     #[doc = "Creates a new instance of [SnapshotCreateRepository] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SnapshotCreateRepositoryParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SnapshotCreateRepository {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -556,10 +559,11 @@ pub struct SnapshotDelete<'a, 'b> {
 impl<'a, 'b> SnapshotDelete<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotDelete] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SnapshotDeleteParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SnapshotDelete {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -683,10 +687,11 @@ pub struct SnapshotDeleteRepository<'a, 'b> {
 impl<'a, 'b> SnapshotDeleteRepository<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotDeleteRepository] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SnapshotDeleteRepositoryParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SnapshotDeleteRepository {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -822,10 +827,11 @@ pub struct SnapshotGet<'a, 'b> {
 impl<'a, 'b> SnapshotGet<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotGet] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SnapshotGetParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SnapshotGet {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -970,10 +976,11 @@ pub struct SnapshotGetRepository<'a, 'b> {
 impl<'a, 'b> SnapshotGetRepository<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotGetRepository] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SnapshotGetRepositoryParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SnapshotGetRepository {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1112,10 +1119,11 @@ where
 {
     #[doc = "Creates a new instance of [SnapshotRestore] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SnapshotRestoreParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SnapshotRestore {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1283,10 +1291,11 @@ pub struct SnapshotStatus<'a, 'b> {
 impl<'a, 'b> SnapshotStatus<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotStatus] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SnapshotStatusParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SnapshotStatus {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1423,10 +1432,11 @@ where
 {
     #[doc = "Creates a new instance of [SnapshotVerifyRepository] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SnapshotVerifyRepositoryParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SnapshotVerifyRepository {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/generated/namespace_clients/sql.rs
+++ b/elasticsearch/src/generated/namespace_clients/sql.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -61,10 +61,11 @@ where
 {
     #[doc = "Creates a new instance of [SqlClearCursor]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SqlClearCursor {
             client,
             parts: SqlClearCursorParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -194,10 +195,11 @@ where
 {
     #[doc = "Creates a new instance of [SqlQuery]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SqlQuery {
             client,
             parts: SqlQueryParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -339,10 +341,11 @@ where
 {
     #[doc = "Creates a new instance of [SqlTranslate]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SqlTranslate {
             client,
             parts: SqlTranslateParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/generated/namespace_clients/ssl.rs
+++ b/elasticsearch/src/generated/namespace_clients/ssl.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -57,10 +57,11 @@ pub struct SslCertificates<'a, 'b> {
 impl<'a, 'b> SslCertificates<'a, 'b> {
     #[doc = "Creates a new instance of [SslCertificates]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         SslCertificates {
             client,
             parts: SslCertificatesParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,

--- a/elasticsearch/src/generated/namespace_clients/tasks.rs
+++ b/elasticsearch/src/generated/namespace_clients/tasks.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -73,10 +73,11 @@ where
 {
     #[doc = "Creates a new instance of [TasksCancel] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: TasksCancelParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         TasksCancel {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             actions: None,
             body: None,
             error_trace: None,
@@ -241,10 +242,11 @@ pub struct TasksGet<'a, 'b> {
 impl<'a, 'b> TasksGet<'a, 'b> {
     #[doc = "Creates a new instance of [TasksGet] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: TasksGetParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         TasksGet {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -376,10 +378,11 @@ pub struct TasksList<'a, 'b> {
 impl<'a, 'b> TasksList<'a, 'b> {
     #[doc = "Creates a new instance of [TasksList]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         TasksList {
             client,
             parts: TasksListParts::None,
-            headers: HeaderMap::new(),
+            headers,
             actions: None,
             detailed: None,
             error_trace: None,

--- a/elasticsearch/src/generated/namespace_clients/watcher.rs
+++ b/elasticsearch/src/generated/namespace_clients/watcher.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -78,10 +78,11 @@ where
 {
     #[doc = "Creates a new instance of [WatcherAckWatch] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: WatcherAckWatchParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         WatcherAckWatch {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -216,10 +217,11 @@ where
 {
     #[doc = "Creates a new instance of [WatcherActivateWatch] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: WatcherActivateWatchParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         WatcherActivateWatch {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -354,10 +356,11 @@ where
 {
     #[doc = "Creates a new instance of [WatcherDeactivateWatch] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: WatcherDeactivateWatchParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         WatcherDeactivateWatch {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -487,10 +490,11 @@ pub struct WatcherDeleteWatch<'a, 'b> {
 impl<'a, 'b> WatcherDeleteWatch<'a, 'b> {
     #[doc = "Creates a new instance of [WatcherDeleteWatch] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: WatcherDeleteWatchParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         WatcherDeleteWatch {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -611,10 +615,11 @@ where
 {
     #[doc = "Creates a new instance of [WatcherExecuteWatch] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: WatcherExecuteWatchParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         WatcherExecuteWatch {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             debug: None,
             error_trace: None,
@@ -754,10 +759,11 @@ pub struct WatcherGetWatch<'a, 'b> {
 impl<'a, 'b> WatcherGetWatch<'a, 'b> {
     #[doc = "Creates a new instance of [WatcherGetWatch] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: WatcherGetWatchParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         WatcherGetWatch {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -877,10 +883,11 @@ where
 {
     #[doc = "Creates a new instance of [WatcherPutWatch] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: WatcherPutWatchParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         WatcherPutWatch {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             active: None,
             body: None,
             error_trace: None,
@@ -1049,10 +1056,11 @@ where
 {
     #[doc = "Creates a new instance of [WatcherStart]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         WatcherStart {
             client,
             parts: WatcherStartParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1188,10 +1196,11 @@ pub struct WatcherStats<'a, 'b> {
 impl<'a, 'b> WatcherStats<'a, 'b> {
     #[doc = "Creates a new instance of [WatcherStats] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: WatcherStatsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         WatcherStats {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             emit_stacktraces: None,
             error_trace: None,
             filter_path: None,
@@ -1320,10 +1329,11 @@ where
 {
     #[doc = "Creates a new instance of [WatcherStop]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         WatcherStop {
             client,
             parts: WatcherStopParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/generated/namespace_clients/xpack.rs
+++ b/elasticsearch/src/generated/namespace_clients/xpack.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -58,10 +58,11 @@ pub struct XpackInfo<'a, 'b> {
 impl<'a, 'b> XpackInfo<'a, 'b> {
     #[doc = "Creates a new instance of [XpackInfo]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         XpackInfo {
             client,
             parts: XpackInfoParts::None,
-            headers: HeaderMap::new(),
+            headers,
             categories: None,
             error_trace: None,
             filter_path: None,
@@ -181,10 +182,11 @@ pub struct XpackUsage<'a, 'b> {
 impl<'a, 'b> XpackUsage<'a, 'b> {
     #[doc = "Creates a new instance of [XpackUsage]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         XpackUsage {
             client,
             parts: XpackUsageParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,

--- a/elasticsearch/src/generated/root.rs
+++ b/elasticsearch/src/generated/root.rs
@@ -19,7 +19,7 @@ use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
-        headers::{HeaderMap, HeaderName, HeaderValue},
+        headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody},
         response::Response,
         Method,
@@ -90,10 +90,11 @@ where
 {
     #[doc = "Creates a new instance of [Bulk] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: BulkParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Bulk {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -330,10 +331,11 @@ where
 {
     #[doc = "Creates a new instance of [ClearScroll] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: ClearScrollParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         ClearScroll {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -499,10 +501,11 @@ where
 {
     #[doc = "Creates a new instance of [Count] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CountParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Count {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             analyze_wildcard: None,
             analyzer: None,
@@ -804,10 +807,11 @@ where
 {
     #[doc = "Creates a new instance of [Create] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: CreateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Create {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1029,10 +1033,11 @@ pub struct Delete<'a, 'b> {
 impl<'a, 'b> Delete<'a, 'b> {
     #[doc = "Creates a new instance of [Delete] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: DeleteParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Delete {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -1268,10 +1273,11 @@ where
 {
     #[doc = "Creates a new instance of [DeleteByQuery] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: DeleteByQueryParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         DeleteByQuery {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -1749,10 +1755,11 @@ where
 {
     #[doc = "Creates a new instance of [DeleteByQueryRethrottle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: DeleteByQueryRethrottleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         DeleteByQueryRethrottle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -1894,10 +1901,11 @@ pub struct DeleteScript<'a, 'b> {
 impl<'a, 'b> DeleteScript<'a, 'b> {
     #[doc = "Creates a new instance of [DeleteScript] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: DeleteScriptParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         DeleteScript {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -2051,10 +2059,11 @@ pub struct Exists<'a, 'b> {
 impl<'a, 'b> Exists<'a, 'b> {
     #[doc = "Creates a new instance of [Exists] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: ExistsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Exists {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -2292,10 +2301,11 @@ pub struct ExistsSource<'a, 'b> {
 impl<'a, 'b> ExistsSource<'a, 'b> {
     #[doc = "Creates a new instance of [ExistsSource] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: ExistsSourceParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         ExistsSource {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -2528,10 +2538,11 @@ where
 {
     #[doc = "Creates a new instance of [Explain] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: ExplainParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Explain {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -2810,10 +2821,11 @@ where
 {
     #[doc = "Creates a new instance of [FieldCaps] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: FieldCapsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         FieldCaps {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -3020,10 +3032,11 @@ pub struct Get<'a, 'b> {
 impl<'a, 'b> Get<'a, 'b> {
     #[doc = "Creates a new instance of [Get] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: GetParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Get {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -3238,10 +3251,11 @@ pub struct GetScript<'a, 'b> {
 impl<'a, 'b> GetScript<'a, 'b> {
     #[doc = "Creates a new instance of [GetScript] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: GetScriptParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         GetScript {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -3386,10 +3400,11 @@ pub struct GetSource<'a, 'b> {
 impl<'a, 'b> GetSource<'a, 'b> {
     #[doc = "Creates a new instance of [GetSource] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: GetSourceParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         GetSource {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -3638,10 +3653,11 @@ where
 {
     #[doc = "Creates a new instance of [Index] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: IndexParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Index {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -3866,10 +3882,11 @@ pub struct Info<'a, 'b> {
 impl<'a, 'b> Info<'a, 'b> {
     #[doc = "Creates a new instance of [Info]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         Info {
             client,
             parts: InfoParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -4008,10 +4025,11 @@ where
 {
     #[doc = "Creates a new instance of [Mget] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MgetParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Mget {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -4265,10 +4283,11 @@ where
 {
     #[doc = "Creates a new instance of [Msearch] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MsearchParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Msearch {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             ccs_minimize_roundtrips: None,
             error_trace: None,
@@ -4498,10 +4517,11 @@ where
 {
     #[doc = "Creates a new instance of [MsearchTemplate] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MsearchTemplateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         MsearchTemplate {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             ccs_minimize_roundtrips: None,
             error_trace: None,
@@ -4715,10 +4735,11 @@ where
 {
     #[doc = "Creates a new instance of [Mtermvectors] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: MtermvectorsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Mtermvectors {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             field_statistics: None,
@@ -4966,10 +4987,11 @@ pub struct Ping<'a, 'b> {
 impl<'a, 'b> Ping<'a, 'b> {
     #[doc = "Creates a new instance of [Ping]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         Ping {
             client,
             parts: PingParts::None,
-            headers: HeaderMap::new(),
+            headers,
             error_trace: None,
             filter_path: None,
             human: None,
@@ -5098,10 +5120,11 @@ where
 {
     #[doc = "Creates a new instance of [PutScript] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: PutScriptParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         PutScript {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             context: None,
             error_trace: None,
@@ -5268,10 +5291,11 @@ where
 {
     #[doc = "Creates a new instance of [Reindex]"]
     pub fn new(client: &'a Elasticsearch) -> Self {
+        let headers = HeaderMap::new();
         Reindex {
             client,
             parts: ReindexParts::None,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -5487,10 +5511,11 @@ where
 {
     #[doc = "Creates a new instance of [ReindexRethrottle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: ReindexRethrottleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         ReindexRethrottle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -5637,10 +5662,11 @@ where
 {
     #[doc = "Creates a new instance of [RenderSearchTemplate] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: RenderSearchTemplateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         RenderSearchTemplate {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -5783,10 +5809,11 @@ where
 {
     #[doc = "Creates a new instance of [Scroll] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: ScrollParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Scroll {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,
@@ -6013,10 +6040,11 @@ where
 {
     #[doc = "Creates a new instance of [Search] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SearchParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Search {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -6602,10 +6630,11 @@ where
 {
     #[doc = "Creates a new instance of [SearchShards] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SearchShardsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SearchShards {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             error_trace: None,
@@ -6833,10 +6862,11 @@ where
 {
     #[doc = "Creates a new instance of [SearchTemplate] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: SearchTemplateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         SearchTemplate {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             allow_no_indices: None,
             body: None,
             ccs_minimize_roundtrips: None,
@@ -7152,10 +7182,11 @@ where
 {
     #[doc = "Creates a new instance of [Termvectors] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: TermvectorsParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Termvectors {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             field_statistics: None,
@@ -7428,10 +7459,11 @@ where
 {
     #[doc = "Creates a new instance of [Update] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: UpdateParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         Update {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -7734,10 +7766,11 @@ where
 {
     #[doc = "Creates a new instance of [UpdateByQuery] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: UpdateByQueryParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         UpdateByQuery {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             _source: None,
             _source_excludes: None,
             _source_includes: None,
@@ -8235,10 +8268,11 @@ where
 {
     #[doc = "Creates a new instance of [UpdateByQueryRethrottle] with the specified API parts"]
     pub fn new(client: &'a Elasticsearch, parts: UpdateByQueryRethrottleParts<'b>) -> Self {
+        let headers = HeaderMap::new();
         UpdateByQueryRethrottle {
             client,
             parts,
-            headers: HeaderMap::new(),
+            headers,
             body: None,
             error_trace: None,
             filter_path: None,

--- a/elasticsearch/src/http/response.rs
+++ b/elasticsearch/src/http/response.rs
@@ -42,12 +42,22 @@ impl Response {
         self.0.headers()
     }
 
-    /// Asynchronously read the response body
+    /// Asynchronously reads the response body as JSON
+    ///
+    /// Reading the response body consumes `self`
     pub async fn read_body<B>(self) -> Result<B, Error>
     where
         B: DeserializeOwned,
     {
         let body = self.0.json::<B>().await?;
+        Ok(body)
+    }
+
+    /// Asynchronously reads the response body as plain text
+    ///
+    /// Reading the response body consumes `self`
+    pub async fn read_body_as_text(self) -> Result<String, Error> {
+        let body = self.0.text().await?;
         Ok(body)
     }
 }


### PR DESCRIPTION
This commit updates the api_generator to set text/plain
content-type and accept headers by default for all cat APIs.

It also introduces a read_body_as_text async fn on Response
to be able to treat the response body as plain text

Closes #71