### PR TITLE
Fixing examples based on necessary imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ other transport related settings.
 To create a client to make API calls to Elasticsearch running on `http://localhost:9200`
 
 ```rust,no_run
-use elasticsearch::{Elasticsearch};
+use elasticsearch::Elasticsearch;
 
 fn main() {
     let client = Elasticsearch::default();
@@ -90,8 +90,8 @@ Alternatively, you can create a client to make API calls against Elasticsearch r
 
 ```rust,no_run
 use elasticsearch::{
-    Error, Elasticsearch,
-    http::transport::{Transport}
+    Elasticsearch, Error, 
+    http::transport::Transport
 };
 
 fn main() -> Result<(), Error> {
@@ -108,7 +108,7 @@ fn main() -> Result<(), Error> {
 ```rust,no_run
 use elasticsearch::{
     auth::Credentials,
-    Error, Elasticsearch,
+    Elasticsearch, Error,
     http::transport::Transport,
 };
 

--- a/README.md
+++ b/README.md
@@ -80,23 +80,23 @@ other transport related settings.
 To create a client to make API calls to Elasticsearch running on `http://localhost:9200`
 
 ```rust,no_run
-use elasticsearch::{Error, Elasticsearch};
+use elasticsearch::{Elasticsearch};
 
-fn run() {
-    let client = Elasticsearch::default();
+fn main() {
+    let _client = Elasticsearch::default();
 }
 ```
 Alternatively, you can create a client to make API calls against Elasticsearch running on a specific url
 
 ```rust,no_run
 use elasticsearch::{
-    Error, Elasticsearch, 
-    http::transport::{Transport, SingleNodeConnectionPool}
+    Error, Elasticsearch,
+    http::transport::{Transport}
 };
 
-fn run() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
     let transport = Transport::single_node("https://example.com")?;
-    let client = Elasticsearch::new(transport);
+    let _client = Elasticsearch::new(transport);
     Ok(())
 }
 ```
@@ -108,17 +108,16 @@ fn run() -> Result<(), Error> {
 ```rust,no_run
 use elasticsearch::{
     auth::Credentials,
-    Error, Elasticsearch, 
+    Error, Elasticsearch,
     http::transport::Transport,
 };
-use url::Url;
 
-fn run() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
     let cloud_id = "cluster_name:Y2xvdWQtZW5kcG9pbnQuZXhhbXBsZSQzZGFkZjgyM2YwNTM4ODQ5N2VhNjg0MjM2ZDkxOGExYQ==";
     // can use other types of Credentials too, like Bearer or ApiKey
     let credentials = Credentials::Basic("<username>".into(), "<password>".into());
     let transport = Transport::cloud(cloud_id, credentials)?;
-    let client = Elasticsearch::new(transport);
+    let _client = Elasticsearch::new(transport);
     Ok(())
 }
 ```
@@ -128,18 +127,17 @@ fn run() -> Result<(), Error> {
  passing it to `Elasticsearch::new()` create a new instance of `Elasticsearch`
 
 ```rust,no_run
+use url::Url;
 use elasticsearch::{
-    auth::Credentials,
-    Error, Elasticsearch, 
+    Error, Elasticsearch,
     http::transport::{TransportBuilder,SingleNodeConnectionPool},
 };
-use url::Url;
 
-fn run() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
     let url = Url::parse("https://example.com")?;
     let conn_pool = SingleNodeConnectionPool::new(url);
     let transport = TransportBuilder::new(conn_pool).disable_proxy().build()?;
-    let client = Elasticsearch::new(transport);
+    let _client = Elasticsearch::new(transport);
     Ok(())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To create a client to make API calls to Elasticsearch running on `http://localho
 use elasticsearch::{Elasticsearch};
 
 fn main() {
-    let _client = Elasticsearch::default();
+    let client = Elasticsearch::default();
 }
 ```
 Alternatively, you can create a client to make API calls against Elasticsearch running on a specific url
@@ -96,7 +96,7 @@ use elasticsearch::{
 
 fn main() -> Result<(), Error> {
     let transport = Transport::single_node("https://example.com")?;
-    let _client = Elasticsearch::new(transport);
+    let client = Elasticsearch::new(transport);
     Ok(())
 }
 ```
@@ -117,7 +117,7 @@ fn main() -> Result<(), Error> {
     // can use other types of Credentials too, like Bearer or ApiKey
     let credentials = Credentials::Basic("<username>".into(), "<password>".into());
     let transport = Transport::cloud(cloud_id, credentials)?;
-    let _client = Elasticsearch::new(transport);
+    let client = Elasticsearch::new(transport);
     Ok(())
 }
 ```
@@ -137,7 +137,7 @@ fn main() -> Result<(), Error> {
     let url = Url::parse("https://example.com")?;
     let conn_pool = SingleNodeConnectionPool::new(url);
     let transport = TransportBuilder::new(conn_pool).disable_proxy().build()?;
-    let _client = Elasticsearch::new(transport);
+    let client = Elasticsearch::new(transport);
     Ok(())
 }
 ```


### PR DESCRIPTION
In some examples the Error or the url crate were imported even when they were not needed.