### PR TITLE
Add note about tokio runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ and to attribute async main function with `#[tokio::main]`
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // your code ...
+    Ok(())
 }
 ```
 
@@ -98,6 +99,7 @@ and attribute test functions with `#[tokio::test]`
 #[tokio::test]
 async fn my_test() -> Result<(), Box<dyn std::error::Error>> {
     // your code ...
+    Ok(())
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,38 @@ serde = "~1"
 serde_json = "~1"
 ```
 
+----
+
+#### Async support with tokio
+
+The client uses [`reqwest`](https://crates.io/crates/reqwest) to make HTTP calls, which internally uses 
+the [`tokio`](https://crates.io/crates/tokio) runtime for async support. As such, you may require to take a dependency on `tokio`
+in order to use the client. For example, in Cargo.toml, you may need the following dependency,
+
+```toml
+tokio = { version = "*", features = ["full"] }
+```
+
+and to attribute async main function with `#[tokio::main]`
+
+```rust,norun
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // your code ...
+}
+```
+
+and attribute test functions with `#[tokio::test]`
+
+```rust,norun
+#[tokio::test]
+async fn my_test() -> Result<(), Box<dyn std::error::Error>> {
+    // your code ...
+}
+```
+
+----
+
 ### Create a client
 
 Build a transport to make API requests to Elasticsearch using the `TransportBuilder`, 


### PR DESCRIPTION
This commit adds a note about the use of tokio runtime
for async support.

Closes #80