### PR TITLE
Encode values passed to Parts enums

### DIFF
--- a/api_generator/src/api_generator/code_gen/mod.rs
+++ b/api_generator/src/api_generator/code_gen/mod.rs
@@ -12,7 +12,7 @@ use std::str;
 /// use declarations common across builders
 pub fn use_declarations() -> Tokens {
     quote!(
-        #[allow(unused_imports)]
+        #![allow(unused_imports)]
         use crate::{
             client::{Elasticsearch},
             params::*,
@@ -20,11 +20,12 @@ pub fn use_declarations() -> Tokens {
             http::{
                 headers::{HeaderName, HeaderMap, HeaderValue, CONTENT_TYPE, ACCEPT},
                 Method,
-                request::{Body, NdBody, JsonBody},
+                request::{Body, NdBody, JsonBody, PARTS_ENCODED},
                 response::Response,
             },
         };
         use std::borrow::Cow;
+        use percent_encoding::percent_encode;
         use serde::Serialize;
     )
 }

--- a/api_generator/src/api_generator/code_gen/url/enum_builder.rs
+++ b/api_generator/src/api_generator/code_gen/url/enum_builder.rs
@@ -388,20 +388,23 @@ mod tests {
                         SearchParts::None => "/_search".into(),
                         SearchParts::Index(ref index) => {
                             let index_str = index.join(",");
-                            let mut p = String::with_capacity(9usize + index_str.len());
+                            let encoded_index: Cow<str> = percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                            let mut p = String::with_capacity(9usize + encoded_index.len());
                             p.push_str("/");
-                            p.push_str(index_str.as_ref());
+                            p.push_str(encoded_index.as_ref());
                             p.push_str("/_search");
                             p.into()
                         }
                         SearchParts::IndexType(ref index, ref ty) => {
                             let index_str = index.join(",");
                             let ty_str = ty.join(",");
-                            let mut p = String::with_capacity(10usize + index_str.len() + ty_str.len());
+                            let encoded_index: Cow<str> = percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                            let encoded_ty: Cow<str> = percent_encode(ty_str.as_bytes(), PARTS_ENCODED).into();
+                            let mut p = String::with_capacity(10usize + encoded_index.len() + encoded_ty.len());
                             p.push_str("/");
-                            p.push_str(index_str.as_ref());
+                            p.push_str(encoded_index.as_ref());
                             p.push_str("/");
-                            p.push_str(ty_str.as_ref());
+                            p.push_str(encoded_ty.as_ref());
                             p.push_str("/_search");
                             p.into()
                         }

--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -25,6 +25,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 base64 = "^0.11"
 bytes = "^0.5"
 dyn-clone = "~1"
+percent-encoding = "2.1.0"
 reqwest = { version = "~0.10", default-features = false, features = ["default-tls", "gzip", "json"] }
 url = "^2.1"
 serde = { version = "~1", features = ["derive"] }

--- a/elasticsearch/src/generated/namespace_clients/async_search.rs
+++ b/elasticsearch/src/generated/namespace_clients/async_search.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -39,9 +40,10 @@ impl<'b> AsyncSearchDeleteParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             AsyncSearchDeleteParts::Id(ref id) => {
-                let mut p = String::with_capacity(15usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_id.len());
                 p.push_str("/_async_search/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.into()
             }
         }
@@ -155,9 +157,10 @@ impl<'b> AsyncSearchGetParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             AsyncSearchGetParts::Id(ref id) => {
-                let mut p = String::with_capacity(15usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_id.len());
                 p.push_str("/_async_search/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.into()
             }
         }
@@ -305,9 +308,11 @@ impl<'b> AsyncSearchSubmitParts<'b> {
             AsyncSearchSubmitParts::None => "/_async_search".into(),
             AsyncSearchSubmitParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(15usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_async_search");
                 p.into()
             }

--- a/elasticsearch/src/generated/namespace_clients/cat.rs
+++ b/elasticsearch/src/generated/namespace_clients/cat.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -43,9 +44,11 @@ impl<'b> CatAliasesParts<'b> {
             CatAliasesParts::None => "/_cat/aliases".into(),
             CatAliasesParts::Name(ref name) => {
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(14usize + name_str.len());
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(14usize + encoded_name.len());
                 p.push_str("/_cat/aliases/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -235,9 +238,11 @@ impl<'b> CatAllocationParts<'b> {
             CatAllocationParts::None => "/_cat/allocation".into(),
             CatAllocationParts::NodeId(ref node_id) => {
                 let node_id_str = node_id.join(",");
-                let mut p = String::with_capacity(17usize + node_id_str.len());
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(17usize + encoded_node_id.len());
                 p.push_str("/_cat/allocation/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.into()
             }
         }
@@ -437,9 +442,11 @@ impl<'b> CatCountParts<'b> {
             CatCountParts::None => "/_cat/count".into(),
             CatCountParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(12usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(12usize + encoded_index.len());
                 p.push_str("/_cat/count/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -609,9 +616,11 @@ impl<'b> CatFielddataParts<'b> {
             CatFielddataParts::None => "/_cat/fielddata".into(),
             CatFielddataParts::Fields(ref fields) => {
                 let fields_str = fields.join(",");
-                let mut p = String::with_capacity(16usize + fields_str.len());
+                let encoded_fields: Cow<str> =
+                    percent_encode(fields_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_fields.len());
                 p.push_str("/_cat/fielddata/");
-                p.push_str(fields_str.as_ref());
+                p.push_str(encoded_fields.as_ref());
                 p.into()
             }
         }
@@ -1117,9 +1126,11 @@ impl<'b> CatIndicesParts<'b> {
             CatIndicesParts::None => "/_cat/indices".into(),
             CatIndicesParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(14usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(14usize + encoded_index.len());
                 p.push_str("/_cat/indices/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -1551,9 +1562,10 @@ impl<'b> CatMlDataFrameAnalyticsParts<'b> {
         match self {
             CatMlDataFrameAnalyticsParts::None => "/_cat/ml/data_frame/analytics".into(),
             CatMlDataFrameAnalyticsParts::Id(ref id) => {
-                let mut p = String::with_capacity(30usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(30usize + encoded_id.len());
                 p.push_str("/_cat/ml/data_frame/analytics/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.into()
             }
         }
@@ -1752,9 +1764,11 @@ impl<'b> CatMlDatafeedsParts<'b> {
         match self {
             CatMlDatafeedsParts::None => "/_cat/ml/datafeeds".into(),
             CatMlDatafeedsParts::DatafeedId(ref datafeed_id) => {
-                let mut p = String::with_capacity(19usize + datafeed_id.len());
+                let encoded_datafeed_id: Cow<str> =
+                    percent_encode(datafeed_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(19usize + encoded_datafeed_id.len());
                 p.push_str("/_cat/ml/datafeeds/");
-                p.push_str(datafeed_id.as_ref());
+                p.push_str(encoded_datafeed_id.as_ref());
                 p.into()
             }
         }
@@ -1943,9 +1957,11 @@ impl<'b> CatMlJobsParts<'b> {
         match self {
             CatMlJobsParts::None => "/_cat/ml/anomaly_detectors".into(),
             CatMlJobsParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(27usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(27usize + encoded_job_id.len());
                 p.push_str("/_cat/ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.into()
             }
         }
@@ -2144,9 +2160,11 @@ impl<'b> CatMlTrainedModelsParts<'b> {
         match self {
             CatMlTrainedModelsParts::None => "/_cat/ml/trained_models".into(),
             CatMlTrainedModelsParts::ModelId(ref model_id) => {
-                let mut p = String::with_capacity(24usize + model_id.len());
+                let encoded_model_id: Cow<str> =
+                    percent_encode(model_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(24usize + encoded_model_id.len());
                 p.push_str("/_cat/ml/trained_models/");
-                p.push_str(model_id.as_ref());
+                p.push_str(encoded_model_id.as_ref());
                 p.into()
             }
         }
@@ -3138,9 +3156,11 @@ impl<'b> CatRecoveryParts<'b> {
             CatRecoveryParts::None => "/_cat/recovery".into(),
             CatRecoveryParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(15usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_index.len());
                 p.push_str("/_cat/recovery/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -3543,9 +3563,11 @@ impl<'b> CatSegmentsParts<'b> {
             CatSegmentsParts::None => "/_cat/segments".into(),
             CatSegmentsParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(15usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_index.len());
                 p.push_str("/_cat/segments/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -3725,9 +3747,11 @@ impl<'b> CatShardsParts<'b> {
             CatShardsParts::None => "/_cat/shards".into(),
             CatShardsParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(13usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_index.len());
                 p.push_str("/_cat/shards/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -3937,9 +3961,11 @@ impl<'b> CatSnapshotsParts<'b> {
             CatSnapshotsParts::None => "/_cat/snapshots".into(),
             CatSnapshotsParts::Repository(ref repository) => {
                 let repository_str = repository.join(",");
-                let mut p = String::with_capacity(16usize + repository_str.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_repository.len());
                 p.push_str("/_cat/snapshots/");
-                p.push_str(repository_str.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.into()
             }
         }
@@ -4357,9 +4383,10 @@ impl<'b> CatTemplatesParts<'b> {
         match self {
             CatTemplatesParts::None => "/_cat/templates".into(),
             CatTemplatesParts::Name(ref name) => {
-                let mut p = String::with_capacity(16usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_name.len());
                 p.push_str("/_cat/templates/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -4549,9 +4576,11 @@ impl<'b> CatThreadPoolParts<'b> {
             CatThreadPoolParts::None => "/_cat/thread_pool".into(),
             CatThreadPoolParts::ThreadPoolPatterns(ref thread_pool_patterns) => {
                 let thread_pool_patterns_str = thread_pool_patterns.join(",");
-                let mut p = String::with_capacity(18usize + thread_pool_patterns_str.len());
+                let encoded_thread_pool_patterns: Cow<str> =
+                    percent_encode(thread_pool_patterns_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(18usize + encoded_thread_pool_patterns.len());
                 p.push_str("/_cat/thread_pool/");
-                p.push_str(thread_pool_patterns_str.as_ref());
+                p.push_str(encoded_thread_pool_patterns.as_ref());
                 p.into()
             }
         }
@@ -4750,9 +4779,11 @@ impl<'b> CatTransformsParts<'b> {
         match self {
             CatTransformsParts::None => "/_cat/transforms".into(),
             CatTransformsParts::TransformId(ref transform_id) => {
-                let mut p = String::with_capacity(17usize + transform_id.len());
+                let encoded_transform_id: Cow<str> =
+                    percent_encode(transform_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(17usize + encoded_transform_id.len());
                 p.push_str("/_cat/transforms/");
-                p.push_str(transform_id.as_ref());
+                p.push_str(encoded_transform_id.as_ref());
                 p.into()
             }
         }

--- a/elasticsearch/src/generated/namespace_clients/ccr.rs
+++ b/elasticsearch/src/generated/namespace_clients/ccr.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -39,9 +40,10 @@ impl<'b> CcrDeleteAutoFollowPatternParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CcrDeleteAutoFollowPatternParts::Name(ref name) => {
-                let mut p = String::with_capacity(18usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(18usize + encoded_name.len());
                 p.push_str("/_ccr/auto_follow/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -155,9 +157,11 @@ impl<'b> CcrFollowParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CcrFollowParts::Index(ref index) => {
-                let mut p = String::with_capacity(13usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_ccr/follow");
                 p.into()
             }
@@ -306,9 +310,11 @@ impl<'b> CcrFollowInfoParts<'b> {
         match self {
             CcrFollowInfoParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(11usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_ccr/info");
                 p.into()
             }
@@ -424,9 +430,11 @@ impl<'b> CcrFollowStatsParts<'b> {
         match self {
             CcrFollowStatsParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(12usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(12usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_ccr/stats");
                 p.into()
             }
@@ -541,9 +549,11 @@ impl<'b> CcrForgetFollowerParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CcrForgetFollowerParts::Index(ref index) => {
-                let mut p = String::with_capacity(22usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(22usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_ccr/forget_follower");
                 p.into()
             }
@@ -683,9 +693,10 @@ impl<'b> CcrGetAutoFollowPatternParts<'b> {
         match self {
             CcrGetAutoFollowPatternParts::None => "/_ccr/auto_follow".into(),
             CcrGetAutoFollowPatternParts::Name(ref name) => {
-                let mut p = String::with_capacity(18usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(18usize + encoded_name.len());
                 p.push_str("/_ccr/auto_follow/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -799,9 +810,10 @@ impl<'b> CcrPauseAutoFollowPatternParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CcrPauseAutoFollowPatternParts::Name(ref name) => {
-                let mut p = String::with_capacity(24usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(24usize + encoded_name.len());
                 p.push_str("/_ccr/auto_follow/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.push_str("/pause");
                 p.into()
             }
@@ -938,9 +950,11 @@ impl<'b> CcrPauseFollowParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CcrPauseFollowParts::Index(ref index) => {
-                let mut p = String::with_capacity(19usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(19usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_ccr/pause_follow");
                 p.into()
             }
@@ -1077,9 +1091,10 @@ impl<'b> CcrPutAutoFollowPatternParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CcrPutAutoFollowPatternParts::Name(ref name) => {
-                let mut p = String::with_capacity(18usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(18usize + encoded_name.len());
                 p.push_str("/_ccr/auto_follow/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -1215,9 +1230,10 @@ impl<'b> CcrResumeAutoFollowPatternParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CcrResumeAutoFollowPatternParts::Name(ref name) => {
-                let mut p = String::with_capacity(25usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(25usize + encoded_name.len());
                 p.push_str("/_ccr/auto_follow/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.push_str("/resume");
                 p.into()
             }
@@ -1354,9 +1370,11 @@ impl<'b> CcrResumeFollowParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CcrResumeFollowParts::Index(ref index) => {
-                let mut p = String::with_capacity(20usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(20usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_ccr/resume_follow");
                 p.into()
             }
@@ -1604,9 +1622,11 @@ impl<'b> CcrUnfollowParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             CcrUnfollowParts::Index(ref index) => {
-                let mut p = String::with_capacity(15usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_ccr/unfollow");
                 p.into()
             }

--- a/elasticsearch/src/generated/namespace_clients/cluster.rs
+++ b/elasticsearch/src/generated/namespace_clients/cluster.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -352,9 +353,11 @@ impl<'b> ClusterHealthParts<'b> {
             ClusterHealthParts::None => "/_cluster/health".into(),
             ClusterHealthParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(17usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(17usize + encoded_index.len());
                 p.push_str("/_cluster/health/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -1194,19 +1197,26 @@ impl<'b> ClusterStateParts<'b> {
             ClusterStateParts::None => "/_cluster/state".into(),
             ClusterStateParts::Metric(ref metric) => {
                 let metric_str = metric.join(",");
-                let mut p = String::with_capacity(16usize + metric_str.len());
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_metric.len());
                 p.push_str("/_cluster/state/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.into()
             }
             ClusterStateParts::MetricIndex(ref metric, ref index) => {
                 let metric_str = metric.join(",");
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(17usize + metric_str.len() + index_str.len());
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(17usize + encoded_metric.len() + encoded_index.len());
                 p.push_str("/_cluster/state/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -1404,9 +1414,11 @@ impl<'b> ClusterStatsParts<'b> {
             ClusterStatsParts::None => "/_cluster/stats".into(),
             ClusterStatsParts::NodeId(ref node_id) => {
                 let node_id_str = node_id.join(",");
-                let mut p = String::with_capacity(22usize + node_id_str.len());
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(22usize + encoded_node_id.len());
                 p.push_str("/_cluster/stats/nodes/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.into()
             }
         }

--- a/elasticsearch/src/generated/namespace_clients/enrich.rs
+++ b/elasticsearch/src/generated/namespace_clients/enrich.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -39,9 +40,10 @@ impl<'b> EnrichDeletePolicyParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             EnrichDeletePolicyParts::Name(ref name) => {
-                let mut p = String::with_capacity(16usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_name.len());
                 p.push_str("/_enrich/policy/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -155,9 +157,10 @@ impl<'b> EnrichExecutePolicyParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             EnrichExecutePolicyParts::Name(ref name) => {
-                let mut p = String::with_capacity(25usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(25usize + encoded_name.len());
                 p.push_str("/_enrich/policy/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.push_str("/_execute");
                 p.into()
             }
@@ -308,9 +311,11 @@ impl<'b> EnrichGetPolicyParts<'b> {
         match self {
             EnrichGetPolicyParts::Name(ref name) => {
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(16usize + name_str.len());
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_name.len());
                 p.push_str("/_enrich/policy/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
             EnrichGetPolicyParts::None => "/_enrich/policy/".into(),
@@ -425,9 +430,10 @@ impl<'b> EnrichPutPolicyParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             EnrichPutPolicyParts::Name(ref name) => {
-                let mut p = String::with_capacity(16usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_name.len());
                 p.push_str("/_enrich/policy/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }

--- a/elasticsearch/src/generated/namespace_clients/graph.rs
+++ b/elasticsearch/src/generated/namespace_clients/graph.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -42,20 +43,25 @@ impl<'b> GraphExploreParts<'b> {
         match self {
             GraphExploreParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(16usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_graph/explore");
                 p.into()
             }
             GraphExploreParts::IndexType(ref index, ref ty) => {
                 let index_str = index.join(",");
                 let ty_str = ty.join(",");
-                let mut p = String::with_capacity(17usize + index_str.len() + ty_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_ty: Cow<str> = percent_encode(ty_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(17usize + encoded_index.len() + encoded_ty.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/");
-                p.push_str(ty_str.as_ref());
+                p.push_str(encoded_ty.as_ref());
                 p.push_str("/_graph/explore");
                 p.into()
             }

--- a/elasticsearch/src/generated/namespace_clients/ilm.rs
+++ b/elasticsearch/src/generated/namespace_clients/ilm.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -39,9 +40,11 @@ impl<'b> IlmDeleteLifecycleParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IlmDeleteLifecycleParts::Policy(ref policy) => {
-                let mut p = String::with_capacity(13usize + policy.len());
+                let encoded_policy: Cow<str> =
+                    percent_encode(policy.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_policy.len());
                 p.push_str("/_ilm/policy/");
-                p.push_str(policy.as_ref());
+                p.push_str(encoded_policy.as_ref());
                 p.into()
             }
         }
@@ -155,9 +158,11 @@ impl<'b> IlmExplainLifecycleParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IlmExplainLifecycleParts::Index(ref index) => {
-                let mut p = String::with_capacity(14usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(14usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_ilm/explain");
                 p.into()
             }
@@ -294,9 +299,11 @@ impl<'b> IlmGetLifecycleParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IlmGetLifecycleParts::Policy(ref policy) => {
-                let mut p = String::with_capacity(13usize + policy.len());
+                let encoded_policy: Cow<str> =
+                    percent_encode(policy.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_policy.len());
                 p.push_str("/_ilm/policy/");
-                p.push_str(policy.as_ref());
+                p.push_str(encoded_policy.as_ref());
                 p.into()
             }
             IlmGetLifecycleParts::None => "/_ilm/policy".into(),
@@ -522,9 +529,11 @@ impl<'b> IlmMoveToStepParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IlmMoveToStepParts::Index(ref index) => {
-                let mut p = String::with_capacity(11usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index.len());
                 p.push_str("/_ilm/move/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -660,9 +669,11 @@ impl<'b> IlmPutLifecycleParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IlmPutLifecycleParts::Policy(ref policy) => {
-                let mut p = String::with_capacity(13usize + policy.len());
+                let encoded_policy: Cow<str> =
+                    percent_encode(policy.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_policy.len());
                 p.push_str("/_ilm/policy/");
-                p.push_str(policy.as_ref());
+                p.push_str(encoded_policy.as_ref());
                 p.into()
             }
         }
@@ -798,9 +809,11 @@ impl<'b> IlmRemovePolicyParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IlmRemovePolicyParts::Index(ref index) => {
-                let mut p = String::with_capacity(13usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_ilm/remove");
                 p.into()
             }
@@ -937,9 +950,11 @@ impl<'b> IlmRetryParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IlmRetryParts::Index(ref index) => {
-                let mut p = String::with_capacity(12usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(12usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_ilm/retry");
                 p.into()
             }

--- a/elasticsearch/src/generated/namespace_clients/indices.rs
+++ b/elasticsearch/src/generated/namespace_clients/indices.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -42,9 +43,11 @@ impl<'b> IndicesAnalyzeParts<'b> {
         match self {
             IndicesAnalyzeParts::None => "/_analyze".into(),
             IndicesAnalyzeParts::Index(ref index) => {
-                let mut p = String::with_capacity(10usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(10usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_analyze");
                 p.into()
             }
@@ -199,9 +202,11 @@ impl<'b> IndicesClearCacheParts<'b> {
             IndicesClearCacheParts::None => "/_cache/clear".into(),
             IndicesClearCacheParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(14usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(14usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_cache/clear");
                 p.into()
             }
@@ -426,11 +431,16 @@ impl<'b> IndicesCloneParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesCloneParts::IndexTarget(ref index, ref target) => {
-                let mut p = String::with_capacity(9usize + index.len() + target.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let encoded_target: Cow<str> =
+                    percent_encode(target.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(9usize + encoded_index.len() + encoded_target.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_clone/");
-                p.push_str(target.as_ref());
+                p.push_str(encoded_target.as_ref());
                 p.into()
             }
         }
@@ -600,9 +610,11 @@ impl<'b> IndicesCloseParts<'b> {
         match self {
             IndicesCloseParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(8usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(8usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_close");
                 p.into()
             }
@@ -805,9 +817,11 @@ impl<'b> IndicesCreateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesCreateParts::Index(ref index) => {
-                let mut p = String::with_capacity(1usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(1usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -988,9 +1002,11 @@ impl<'b> IndicesDeleteParts<'b> {
         match self {
             IndicesDeleteParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(1usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(1usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -1156,11 +1172,16 @@ impl<'b> IndicesDeleteAliasParts<'b> {
             IndicesDeleteAliasParts::IndexName(ref index, ref name) => {
                 let index_str = index.join(",");
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(9usize + index_str.len() + name_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(9usize + encoded_index.len() + encoded_name.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_alias/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -1294,9 +1315,10 @@ impl<'b> IndicesDeleteTemplateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesDeleteTemplateParts::Name(ref name) => {
-                let mut p = String::with_capacity(11usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_name.len());
                 p.push_str("/_template/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -1431,9 +1453,11 @@ impl<'b> IndicesExistsParts<'b> {
         match self {
             IndicesExistsParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(1usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(1usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -1610,19 +1634,26 @@ impl<'b> IndicesExistsAliasParts<'b> {
         match self {
             IndicesExistsAliasParts::Name(ref name) => {
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(8usize + name_str.len());
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(8usize + encoded_name.len());
                 p.push_str("/_alias/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
             IndicesExistsAliasParts::IndexName(ref index, ref name) => {
                 let index_str = index.join(",");
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(9usize + index_str.len() + name_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(9usize + encoded_index.len() + encoded_name.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_alias/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -1777,9 +1808,11 @@ impl<'b> IndicesExistsTemplateParts<'b> {
         match self {
             IndicesExistsTemplateParts::Name(ref name) => {
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(11usize + name_str.len());
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_name.len());
                 p.push_str("/_template/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -1925,11 +1958,14 @@ impl<'b> IndicesExistsTypeParts<'b> {
             IndicesExistsTypeParts::IndexType(ref index, ref ty) => {
                 let index_str = index.join(",");
                 let ty_str = ty.join(",");
-                let mut p = String::with_capacity(11usize + index_str.len() + ty_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_ty: Cow<str> = percent_encode(ty_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index.len() + encoded_ty.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_mapping/");
-                p.push_str(ty_str.as_ref());
+                p.push_str(encoded_ty.as_ref());
                 p.into()
             }
         }
@@ -2087,9 +2123,11 @@ impl<'b> IndicesFlushParts<'b> {
             IndicesFlushParts::None => "/_flush".into(),
             IndicesFlushParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(8usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(8usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_flush");
                 p.into()
             }
@@ -2288,9 +2326,11 @@ impl<'b> IndicesFlushSyncedParts<'b> {
             IndicesFlushSyncedParts::None => "/_flush/synced".into(),
             IndicesFlushSyncedParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(15usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_flush/synced");
                 p.into()
             }
@@ -2467,9 +2507,11 @@ impl<'b> IndicesForcemergeParts<'b> {
             IndicesForcemergeParts::None => "/_forcemerge".into(),
             IndicesForcemergeParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(13usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_forcemerge");
                 p.into()
             }
@@ -2672,9 +2714,11 @@ impl<'b> IndicesFreezeParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesFreezeParts::Index(ref index) => {
-                let mut p = String::with_capacity(9usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(9usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_freeze");
                 p.into()
             }
@@ -2878,9 +2922,11 @@ impl<'b> IndicesGetParts<'b> {
         match self {
             IndicesGetParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(1usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(1usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.into()
             }
         }
@@ -3082,26 +3128,35 @@ impl<'b> IndicesGetAliasParts<'b> {
             IndicesGetAliasParts::None => "/_alias".into(),
             IndicesGetAliasParts::Name(ref name) => {
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(8usize + name_str.len());
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(8usize + encoded_name.len());
                 p.push_str("/_alias/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
             IndicesGetAliasParts::IndexName(ref index, ref name) => {
                 let index_str = index.join(",");
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(9usize + index_str.len() + name_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(9usize + encoded_index.len() + encoded_name.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_alias/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
             IndicesGetAliasParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(8usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(8usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_alias");
                 p.into()
             }
@@ -3263,44 +3318,60 @@ impl<'b> IndicesGetFieldMappingParts<'b> {
         match self {
             IndicesGetFieldMappingParts::Fields(ref fields) => {
                 let fields_str = fields.join(",");
-                let mut p = String::with_capacity(16usize + fields_str.len());
+                let encoded_fields: Cow<str> =
+                    percent_encode(fields_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_fields.len());
                 p.push_str("/_mapping/field/");
-                p.push_str(fields_str.as_ref());
+                p.push_str(encoded_fields.as_ref());
                 p.into()
             }
             IndicesGetFieldMappingParts::IndexFields(ref index, ref fields) => {
                 let index_str = index.join(",");
                 let fields_str = fields.join(",");
-                let mut p = String::with_capacity(17usize + index_str.len() + fields_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_fields: Cow<str> =
+                    percent_encode(fields_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(17usize + encoded_index.len() + encoded_fields.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_mapping/field/");
-                p.push_str(fields_str.as_ref());
+                p.push_str(encoded_fields.as_ref());
                 p.into()
             }
             IndicesGetFieldMappingParts::TypeFields(ref ty, ref fields) => {
                 let ty_str = ty.join(",");
                 let fields_str = fields.join(",");
-                let mut p = String::with_capacity(17usize + ty_str.len() + fields_str.len());
+                let encoded_ty: Cow<str> = percent_encode(ty_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_fields: Cow<str> =
+                    percent_encode(fields_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(17usize + encoded_ty.len() + encoded_fields.len());
                 p.push_str("/_mapping/");
-                p.push_str(ty_str.as_ref());
+                p.push_str(encoded_ty.as_ref());
                 p.push_str("/field/");
-                p.push_str(fields_str.as_ref());
+                p.push_str(encoded_fields.as_ref());
                 p.into()
             }
             IndicesGetFieldMappingParts::IndexTypeFields(ref index, ref ty, ref fields) => {
                 let index_str = index.join(",");
                 let ty_str = ty.join(",");
                 let fields_str = fields.join(",");
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_ty: Cow<str> = percent_encode(ty_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_fields: Cow<str> =
+                    percent_encode(fields_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(
-                    18usize + index_str.len() + ty_str.len() + fields_str.len(),
+                    18usize + encoded_index.len() + encoded_ty.len() + encoded_fields.len(),
                 );
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_mapping/");
-                p.push_str(ty_str.as_ref());
+                p.push_str(encoded_ty.as_ref());
                 p.push_str("/field/");
-                p.push_str(fields_str.as_ref());
+                p.push_str(encoded_fields.as_ref());
                 p.into()
             }
         }
@@ -3482,27 +3553,33 @@ impl<'b> IndicesGetMappingParts<'b> {
             IndicesGetMappingParts::None => "/_mapping".into(),
             IndicesGetMappingParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(10usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(10usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_mapping");
                 p.into()
             }
             IndicesGetMappingParts::Type(ref ty) => {
                 let ty_str = ty.join(",");
-                let mut p = String::with_capacity(10usize + ty_str.len());
+                let encoded_ty: Cow<str> = percent_encode(ty_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(10usize + encoded_ty.len());
                 p.push_str("/_mapping/");
-                p.push_str(ty_str.as_ref());
+                p.push_str(encoded_ty.as_ref());
                 p.into()
             }
             IndicesGetMappingParts::IndexType(ref index, ref ty) => {
                 let index_str = index.join(",");
                 let ty_str = ty.join(",");
-                let mut p = String::with_capacity(11usize + index_str.len() + ty_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_ty: Cow<str> = percent_encode(ty_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index.len() + encoded_ty.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_mapping/");
-                p.push_str(ty_str.as_ref());
+                p.push_str(encoded_ty.as_ref());
                 p.into()
             }
         }
@@ -3684,27 +3761,36 @@ impl<'b> IndicesGetSettingsParts<'b> {
             IndicesGetSettingsParts::None => "/_settings".into(),
             IndicesGetSettingsParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(11usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_settings");
                 p.into()
             }
             IndicesGetSettingsParts::IndexName(ref index, ref name) => {
                 let index_str = index.join(",");
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(12usize + index_str.len() + name_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(12usize + encoded_index.len() + encoded_name.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_settings/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
             IndicesGetSettingsParts::Name(ref name) => {
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(11usize + name_str.len());
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_name.len());
                 p.push_str("/_settings/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -3892,9 +3978,11 @@ impl<'b> IndicesGetTemplateParts<'b> {
             IndicesGetTemplateParts::None => "/_template".into(),
             IndicesGetTemplateParts::Name(ref name) => {
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(11usize + name_str.len());
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_name.len());
                 p.push_str("/_template/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -4052,9 +4140,11 @@ impl<'b> IndicesGetUpgradeParts<'b> {
             IndicesGetUpgradeParts::None => "/_upgrade".into(),
             IndicesGetUpgradeParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(10usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(10usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_upgrade");
                 p.into()
             }
@@ -4200,9 +4290,11 @@ impl<'b> IndicesOpenParts<'b> {
         match self {
             IndicesOpenParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(7usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(7usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_open");
                 p.into()
             }
@@ -4406,11 +4498,15 @@ impl<'b> IndicesPutAliasParts<'b> {
         match self {
             IndicesPutAliasParts::IndexName(ref index, ref name) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(9usize + index_str.len() + name.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(9usize + encoded_index.len() + encoded_name.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_alias/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -4573,26 +4669,32 @@ impl<'b> IndicesPutMappingParts<'b> {
         match self {
             IndicesPutMappingParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(10usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(10usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_mapping");
                 p.into()
             }
             IndicesPutMappingParts::IndexType(ref index, ref ty) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(11usize + index_str.len() + ty.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_ty: Cow<str> = percent_encode(ty.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index.len() + encoded_ty.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/");
-                p.push_str(ty.as_ref());
+                p.push_str(encoded_ty.as_ref());
                 p.push_str("/_mapping");
                 p.into()
             }
             IndicesPutMappingParts::Type(ref ty) => {
-                let mut p = String::with_capacity(11usize + ty.len());
+                let encoded_ty: Cow<str> = percent_encode(ty.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_ty.len());
                 p.push_str("/_mappings/");
-                p.push_str(ty.as_ref());
+                p.push_str(encoded_ty.as_ref());
                 p.into()
             }
         }
@@ -4798,9 +4900,11 @@ impl<'b> IndicesPutSettingsParts<'b> {
             IndicesPutSettingsParts::None => "/_settings".into(),
             IndicesPutSettingsParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(11usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_settings");
                 p.into()
             }
@@ -5014,9 +5118,10 @@ impl<'b> IndicesPutTemplateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesPutTemplateParts::Name(ref name) => {
-                let mut p = String::with_capacity(11usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_name.len());
                 p.push_str("/_template/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -5200,9 +5305,11 @@ impl<'b> IndicesRecoveryParts<'b> {
             IndicesRecoveryParts::None => "/_recovery".into(),
             IndicesRecoveryParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(11usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_recovery");
                 p.into()
             }
@@ -5341,9 +5448,11 @@ impl<'b> IndicesRefreshParts<'b> {
             IndicesRefreshParts::None => "/_refresh".into(),
             IndicesRefreshParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(10usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(10usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_refresh");
                 p.into()
             }
@@ -5517,9 +5626,11 @@ impl<'b> IndicesReloadSearchAnalyzersParts<'b> {
         match self {
             IndicesReloadSearchAnalyzersParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(26usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(26usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_reload_search_analyzers");
                 p.into()
             }
@@ -5694,18 +5805,25 @@ impl<'b> IndicesRolloverParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesRolloverParts::Alias(ref alias) => {
-                let mut p = String::with_capacity(11usize + alias.len());
+                let encoded_alias: Cow<str> =
+                    percent_encode(alias.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_alias.len());
                 p.push_str("/");
-                p.push_str(alias.as_ref());
+                p.push_str(encoded_alias.as_ref());
                 p.push_str("/_rollover");
                 p.into()
             }
             IndicesRolloverParts::AliasNewIndex(ref alias, ref new_index) => {
-                let mut p = String::with_capacity(12usize + alias.len() + new_index.len());
+                let encoded_alias: Cow<str> =
+                    percent_encode(alias.as_bytes(), PARTS_ENCODED).into();
+                let encoded_new_index: Cow<str> =
+                    percent_encode(new_index.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(12usize + encoded_alias.len() + encoded_new_index.len());
                 p.push_str("/");
-                p.push_str(alias.as_ref());
+                p.push_str(encoded_alias.as_ref());
                 p.push_str("/_rollover/");
-                p.push_str(new_index.as_ref());
+                p.push_str(encoded_new_index.as_ref());
                 p.into()
             }
         }
@@ -5900,9 +6018,11 @@ impl<'b> IndicesSegmentsParts<'b> {
             IndicesSegmentsParts::None => "/_segments".into(),
             IndicesSegmentsParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(11usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_segments");
                 p.into()
             }
@@ -6061,9 +6181,11 @@ impl<'b> IndicesShardStoresParts<'b> {
             IndicesShardStoresParts::None => "/_shard_stores".into(),
             IndicesShardStoresParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(15usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_shard_stores");
                 p.into()
             }
@@ -6218,11 +6340,16 @@ impl<'b> IndicesShrinkParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesShrinkParts::IndexTarget(ref index, ref target) => {
-                let mut p = String::with_capacity(10usize + index.len() + target.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let encoded_target: Cow<str> =
+                    percent_encode(target.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(10usize + encoded_index.len() + encoded_target.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_shrink/");
-                p.push_str(target.as_ref());
+                p.push_str(encoded_target.as_ref());
                 p.into()
             }
         }
@@ -6402,11 +6529,16 @@ impl<'b> IndicesSplitParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesSplitParts::IndexTarget(ref index, ref target) => {
-                let mut p = String::with_capacity(9usize + index.len() + target.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let encoded_target: Cow<str> =
+                    percent_encode(target.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(9usize + encoded_index.len() + encoded_target.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_split/");
-                p.push_str(target.as_ref());
+                p.push_str(encoded_target.as_ref());
                 p.into()
             }
         }
@@ -6594,27 +6726,36 @@ impl<'b> IndicesStatsParts<'b> {
             IndicesStatsParts::None => "/_stats".into(),
             IndicesStatsParts::Metric(ref metric) => {
                 let metric_str = metric.join(",");
-                let mut p = String::with_capacity(8usize + metric_str.len());
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(8usize + encoded_metric.len());
                 p.push_str("/_stats/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.into()
             }
             IndicesStatsParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(8usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(8usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_stats");
                 p.into()
             }
             IndicesStatsParts::IndexMetric(ref index, ref metric) => {
                 let index_str = index.join(",");
                 let metric_str = metric.join(",");
-                let mut p = String::with_capacity(9usize + index_str.len() + metric_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(9usize + encoded_index.len() + encoded_metric.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_stats/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.into()
             }
         }
@@ -6834,9 +6975,11 @@ impl<'b> IndicesUnfreezeParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IndicesUnfreezeParts::Index(ref index) => {
-                let mut p = String::with_capacity(11usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_unfreeze");
                 p.into()
             }
@@ -7198,9 +7341,11 @@ impl<'b> IndicesUpgradeParts<'b> {
             IndicesUpgradeParts::None => "/_upgrade".into(),
             IndicesUpgradeParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(10usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(10usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_upgrade");
                 p.into()
             }
@@ -7398,20 +7543,25 @@ impl<'b> IndicesValidateQueryParts<'b> {
             IndicesValidateQueryParts::None => "/_validate/query".into(),
             IndicesValidateQueryParts::Index(ref index) => {
                 let index_str = index.join(",");
-                let mut p = String::with_capacity(17usize + index_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(17usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_validate/query");
                 p.into()
             }
             IndicesValidateQueryParts::IndexType(ref index, ref ty) => {
                 let index_str = index.join(",");
                 let ty_str = ty.join(",");
-                let mut p = String::with_capacity(18usize + index_str.len() + ty_str.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_ty: Cow<str> = percent_encode(ty_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(18usize + encoded_index.len() + encoded_ty.len());
                 p.push_str("/");
-                p.push_str(index_str.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/");
-                p.push_str(ty_str.as_ref());
+                p.push_str(encoded_ty.as_ref());
                 p.push_str("/_validate/query");
                 p.into()
             }

--- a/elasticsearch/src/generated/namespace_clients/ingest.rs
+++ b/elasticsearch/src/generated/namespace_clients/ingest.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -39,9 +40,10 @@ impl<'b> IngestDeletePipelineParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IngestDeletePipelineParts::Id(ref id) => {
-                let mut p = String::with_capacity(18usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(18usize + encoded_id.len());
                 p.push_str("/_ingest/pipeline/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.into()
             }
         }
@@ -178,9 +180,10 @@ impl<'b> IngestGetPipelineParts<'b> {
         match self {
             IngestGetPipelineParts::None => "/_ingest/pipeline".into(),
             IngestGetPipelineParts::Id(ref id) => {
-                let mut p = String::with_capacity(18usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(18usize + encoded_id.len());
                 p.push_str("/_ingest/pipeline/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.into()
             }
         }
@@ -415,9 +418,10 @@ impl<'b> IngestPutPipelineParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             IngestPutPipelineParts::Id(ref id) => {
-                let mut p = String::with_capacity(18usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(18usize + encoded_id.len());
                 p.push_str("/_ingest/pipeline/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.into()
             }
         }
@@ -578,9 +582,10 @@ impl<'b> IngestSimulateParts<'b> {
         match self {
             IngestSimulateParts::None => "/_ingest/pipeline/_simulate".into(),
             IngestSimulateParts::Id(ref id) => {
-                let mut p = String::with_capacity(28usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(28usize + encoded_id.len());
                 p.push_str("/_ingest/pipeline/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.push_str("/_simulate");
                 p.into()
             }

--- a/elasticsearch/src/generated/namespace_clients/license.rs
+++ b/elasticsearch/src/generated/namespace_clients/license.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]

--- a/elasticsearch/src/generated/namespace_clients/migration.rs
+++ b/elasticsearch/src/generated/namespace_clients/migration.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -42,9 +43,11 @@ impl<'b> MigrationDeprecationsParts<'b> {
         match self {
             MigrationDeprecationsParts::None => "/_migration/deprecations".into(),
             MigrationDeprecationsParts::Index(ref index) => {
-                let mut p = String::with_capacity(25usize + index.len());
+                let encoded_index: Cow<str> =
+                    percent_encode(index.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(25usize + encoded_index.len());
                 p.push_str("/");
-                p.push_str(index.as_ref());
+                p.push_str(encoded_index.as_ref());
                 p.push_str("/_migration/deprecations");
                 p.into()
             }

--- a/elasticsearch/src/generated/namespace_clients/ml.rs
+++ b/elasticsearch/src/generated/namespace_clients/ml.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -39,9 +40,11 @@ impl<'b> MlCloseJobParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlCloseJobParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(30usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(30usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/_close");
                 p.into()
             }
@@ -211,9 +214,11 @@ impl<'b> MlDeleteCalendarParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlDeleteCalendarParts::CalendarId(ref calendar_id) => {
-                let mut p = String::with_capacity(15usize + calendar_id.len());
+                let encoded_calendar_id: Cow<str> =
+                    percent_encode(calendar_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_calendar_id.len());
                 p.push_str("/_ml/calendars/");
-                p.push_str(calendar_id.as_ref());
+                p.push_str(encoded_calendar_id.as_ref());
                 p.into()
             }
         }
@@ -327,11 +332,17 @@ impl<'b> MlDeleteCalendarEventParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlDeleteCalendarEventParts::CalendarIdEventId(ref calendar_id, ref event_id) => {
-                let mut p = String::with_capacity(23usize + calendar_id.len() + event_id.len());
+                let encoded_calendar_id: Cow<str> =
+                    percent_encode(calendar_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_event_id: Cow<str> =
+                    percent_encode(event_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    23usize + encoded_calendar_id.len() + encoded_event_id.len(),
+                );
                 p.push_str("/_ml/calendars/");
-                p.push_str(calendar_id.as_ref());
+                p.push_str(encoded_calendar_id.as_ref());
                 p.push_str("/events/");
-                p.push_str(event_id.as_ref());
+                p.push_str(encoded_event_id.as_ref());
                 p.into()
             }
         }
@@ -445,11 +456,17 @@ impl<'b> MlDeleteCalendarJobParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlDeleteCalendarJobParts::CalendarIdJobId(ref calendar_id, ref job_id) => {
-                let mut p = String::with_capacity(21usize + calendar_id.len() + job_id.len());
+                let encoded_calendar_id: Cow<str> =
+                    percent_encode(calendar_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    21usize + encoded_calendar_id.len() + encoded_job_id.len(),
+                );
                 p.push_str("/_ml/calendars/");
-                p.push_str(calendar_id.as_ref());
+                p.push_str(encoded_calendar_id.as_ref());
                 p.push_str("/jobs/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.into()
             }
         }
@@ -563,9 +580,11 @@ impl<'b> MlDeleteDatafeedParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlDeleteDatafeedParts::DatafeedId(ref datafeed_id) => {
-                let mut p = String::with_capacity(15usize + datafeed_id.len());
+                let encoded_datafeed_id: Cow<str> =
+                    percent_encode(datafeed_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_datafeed_id.len());
                 p.push_str("/_ml/datafeeds/");
-                p.push_str(datafeed_id.as_ref());
+                p.push_str(encoded_datafeed_id.as_ref());
                 p.into()
             }
         }
@@ -800,9 +819,11 @@ impl<'b> MlDeleteFilterParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlDeleteFilterParts::FilterId(ref filter_id) => {
-                let mut p = String::with_capacity(13usize + filter_id.len());
+                let encoded_filter_id: Cow<str> =
+                    percent_encode(filter_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_filter_id.len());
                 p.push_str("/_ml/filters/");
-                p.push_str(filter_id.as_ref());
+                p.push_str(encoded_filter_id.as_ref());
                 p.into()
             }
         }
@@ -918,18 +939,26 @@ impl<'b> MlDeleteForecastParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlDeleteForecastParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(33usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(33usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/_forecast");
                 p.into()
             }
             MlDeleteForecastParts::JobIdForecastId(ref job_id, ref forecast_id) => {
-                let mut p = String::with_capacity(34usize + job_id.len() + forecast_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_forecast_id: Cow<str> =
+                    percent_encode(forecast_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    34usize + encoded_job_id.len() + encoded_forecast_id.len(),
+                );
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/_forecast/");
-                p.push_str(forecast_id.as_ref());
+                p.push_str(encoded_forecast_id.as_ref());
                 p.into()
             }
         }
@@ -1063,9 +1092,11 @@ impl<'b> MlDeleteJobParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlDeleteJobParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(23usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(23usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.into()
             }
         }
@@ -1199,11 +1230,17 @@ impl<'b> MlDeleteModelSnapshotParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlDeleteModelSnapshotParts::JobIdSnapshotId(ref job_id, ref snapshot_id) => {
-                let mut p = String::with_capacity(40usize + job_id.len() + snapshot_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_snapshot_id: Cow<str> =
+                    percent_encode(snapshot_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    40usize + encoded_job_id.len() + encoded_snapshot_id.len(),
+                );
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/model_snapshots/");
-                p.push_str(snapshot_id.as_ref());
+                p.push_str(encoded_snapshot_id.as_ref());
                 p.into()
             }
         }
@@ -1452,9 +1489,11 @@ impl<'b> MlFlushJobParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlFlushJobParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(30usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(30usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/_flush");
                 p.into()
             }
@@ -1646,9 +1685,11 @@ impl<'b> MlForecastParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlForecastParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(33usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(33usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/_forecast");
                 p.into()
             }
@@ -1809,17 +1850,24 @@ impl<'b> MlGetBucketsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlGetBucketsParts::JobIdTimestamp(ref job_id, ref timestamp) => {
-                let mut p = String::with_capacity(40usize + job_id.len() + timestamp.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_timestamp: Cow<str> =
+                    percent_encode(timestamp.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(40usize + encoded_job_id.len() + encoded_timestamp.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/results/buckets/");
-                p.push_str(timestamp.as_ref());
+                p.push_str(encoded_timestamp.as_ref());
                 p.into()
             }
             MlGetBucketsParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(39usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(39usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/results/buckets");
                 p.into()
             }
@@ -2058,9 +2106,11 @@ impl<'b> MlGetCalendarEventsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlGetCalendarEventsParts::CalendarId(ref calendar_id) => {
-                let mut p = String::with_capacity(22usize + calendar_id.len());
+                let encoded_calendar_id: Cow<str> =
+                    percent_encode(calendar_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(22usize + encoded_calendar_id.len());
                 p.push_str("/_ml/calendars/");
-                p.push_str(calendar_id.as_ref());
+                p.push_str(encoded_calendar_id.as_ref());
                 p.push_str("/events");
                 p.into()
             }
@@ -2228,9 +2278,11 @@ impl<'b> MlGetCalendarsParts<'b> {
         match self {
             MlGetCalendarsParts::None => "/_ml/calendars".into(),
             MlGetCalendarsParts::CalendarId(ref calendar_id) => {
-                let mut p = String::with_capacity(15usize + calendar_id.len());
+                let encoded_calendar_id: Cow<str> =
+                    percent_encode(calendar_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_calendar_id.len());
                 p.push_str("/_ml/calendars/");
-                p.push_str(calendar_id.as_ref());
+                p.push_str(encoded_calendar_id.as_ref());
                 p.into()
             }
         }
@@ -2394,17 +2446,25 @@ impl<'b> MlGetCategoriesParts<'b> {
         match self {
             MlGetCategoriesParts::JobIdCategoryId(ref job_id, ref category_id) => {
                 let category_id_str = category_id.to_string();
-                let mut p = String::with_capacity(43usize + job_id.len() + category_id_str.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_category_id: Cow<str> =
+                    percent_encode(category_id_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    43usize + encoded_job_id.len() + encoded_category_id.len(),
+                );
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/results/categories/");
-                p.push_str(category_id_str.as_ref());
+                p.push_str(encoded_category_id.as_ref());
                 p.into()
             }
             MlGetCategoriesParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(43usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(43usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/results/categories/");
                 p.into()
             }
@@ -2568,9 +2628,11 @@ impl<'b> MlGetDatafeedStatsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlGetDatafeedStatsParts::DatafeedId(ref datafeed_id) => {
-                let mut p = String::with_capacity(22usize + datafeed_id.len());
+                let encoded_datafeed_id: Cow<str> =
+                    percent_encode(datafeed_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(22usize + encoded_datafeed_id.len());
                 p.push_str("/_ml/datafeeds/");
-                p.push_str(datafeed_id.as_ref());
+                p.push_str(encoded_datafeed_id.as_ref());
                 p.push_str("/_stats");
                 p.into()
             }
@@ -2698,9 +2760,11 @@ impl<'b> MlGetDatafeedsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlGetDatafeedsParts::DatafeedId(ref datafeed_id) => {
-                let mut p = String::with_capacity(15usize + datafeed_id.len());
+                let encoded_datafeed_id: Cow<str> =
+                    percent_encode(datafeed_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_datafeed_id.len());
                 p.push_str("/_ml/datafeeds/");
-                p.push_str(datafeed_id.as_ref());
+                p.push_str(encoded_datafeed_id.as_ref());
                 p.into()
             }
             MlGetDatafeedsParts::None => "/_ml/datafeeds".into(),
@@ -2828,9 +2892,11 @@ impl<'b> MlGetFiltersParts<'b> {
         match self {
             MlGetFiltersParts::None => "/_ml/filters".into(),
             MlGetFiltersParts::FilterId(ref filter_id) => {
-                let mut p = String::with_capacity(13usize + filter_id.len());
+                let encoded_filter_id: Cow<str> =
+                    percent_encode(filter_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_filter_id.len());
                 p.push_str("/_ml/filters/");
-                p.push_str(filter_id.as_ref());
+                p.push_str(encoded_filter_id.as_ref());
                 p.into()
             }
         }
@@ -2964,9 +3030,11 @@ impl<'b> MlGetInfluencersParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlGetInfluencersParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(43usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(43usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/results/influencers");
                 p.into()
             }
@@ -3197,9 +3265,11 @@ impl<'b> MlGetJobStatsParts<'b> {
         match self {
             MlGetJobStatsParts::None => "/_ml/anomaly_detectors/_stats".into(),
             MlGetJobStatsParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(30usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(30usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/_stats");
                 p.into()
             }
@@ -3326,9 +3396,11 @@ impl<'b> MlGetJobsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlGetJobsParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(23usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(23usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.into()
             }
             MlGetJobsParts::None => "/_ml/anomaly_detectors".into(),
@@ -3455,17 +3527,25 @@ impl<'b> MlGetModelSnapshotsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlGetModelSnapshotsParts::JobIdSnapshotId(ref job_id, ref snapshot_id) => {
-                let mut p = String::with_capacity(40usize + job_id.len() + snapshot_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_snapshot_id: Cow<str> =
+                    percent_encode(snapshot_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    40usize + encoded_job_id.len() + encoded_snapshot_id.len(),
+                );
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/model_snapshots/");
-                p.push_str(snapshot_id.as_ref());
+                p.push_str(encoded_snapshot_id.as_ref());
                 p.into()
             }
             MlGetModelSnapshotsParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(39usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(39usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/model_snapshots");
                 p.into()
             }
@@ -3671,9 +3751,11 @@ impl<'b> MlGetOverallBucketsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlGetOverallBucketsParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(47usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(47usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/results/overall_buckets");
                 p.into()
             }
@@ -3890,9 +3972,11 @@ impl<'b> MlGetRecordsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlGetRecordsParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(39usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(39usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/results/records");
                 p.into()
             }
@@ -4231,9 +4315,11 @@ impl<'b> MlOpenJobParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlOpenJobParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(29usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(29usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/_open");
                 p.into()
             }
@@ -4370,9 +4456,11 @@ impl<'b> MlPostCalendarEventsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlPostCalendarEventsParts::CalendarId(ref calendar_id) => {
-                let mut p = String::with_capacity(22usize + calendar_id.len());
+                let encoded_calendar_id: Cow<str> =
+                    percent_encode(calendar_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(22usize + encoded_calendar_id.len());
                 p.push_str("/_ml/calendars/");
-                p.push_str(calendar_id.as_ref());
+                p.push_str(encoded_calendar_id.as_ref());
                 p.push_str("/events");
                 p.into()
             }
@@ -4509,9 +4597,11 @@ impl<'b> MlPostDataParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlPostDataParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(29usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(29usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/_data");
                 p.into()
             }
@@ -4670,9 +4760,11 @@ impl<'b> MlPreviewDatafeedParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlPreviewDatafeedParts::DatafeedId(ref datafeed_id) => {
-                let mut p = String::with_capacity(24usize + datafeed_id.len());
+                let encoded_datafeed_id: Cow<str> =
+                    percent_encode(datafeed_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(24usize + encoded_datafeed_id.len());
                 p.push_str("/_ml/datafeeds/");
-                p.push_str(datafeed_id.as_ref());
+                p.push_str(encoded_datafeed_id.as_ref());
                 p.push_str("/_preview");
                 p.into()
             }
@@ -4787,9 +4879,11 @@ impl<'b> MlPutCalendarParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlPutCalendarParts::CalendarId(ref calendar_id) => {
-                let mut p = String::with_capacity(15usize + calendar_id.len());
+                let encoded_calendar_id: Cow<str> =
+                    percent_encode(calendar_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_calendar_id.len());
                 p.push_str("/_ml/calendars/");
-                p.push_str(calendar_id.as_ref());
+                p.push_str(encoded_calendar_id.as_ref());
                 p.into()
             }
         }
@@ -4925,11 +5019,17 @@ impl<'b> MlPutCalendarJobParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlPutCalendarJobParts::CalendarIdJobId(ref calendar_id, ref job_id) => {
-                let mut p = String::with_capacity(21usize + calendar_id.len() + job_id.len());
+                let encoded_calendar_id: Cow<str> =
+                    percent_encode(calendar_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    21usize + encoded_calendar_id.len() + encoded_job_id.len(),
+                );
                 p.push_str("/_ml/calendars/");
-                p.push_str(calendar_id.as_ref());
+                p.push_str(encoded_calendar_id.as_ref());
                 p.push_str("/jobs/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.into()
             }
         }
@@ -5065,9 +5165,11 @@ impl<'b> MlPutDatafeedParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlPutDatafeedParts::DatafeedId(ref datafeed_id) => {
-                let mut p = String::with_capacity(15usize + datafeed_id.len());
+                let encoded_datafeed_id: Cow<str> =
+                    percent_encode(datafeed_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(15usize + encoded_datafeed_id.len());
                 p.push_str("/_ml/datafeeds/");
-                p.push_str(datafeed_id.as_ref());
+                p.push_str(encoded_datafeed_id.as_ref());
                 p.into()
             }
         }
@@ -5247,9 +5349,11 @@ impl<'b> MlPutFilterParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlPutFilterParts::FilterId(ref filter_id) => {
-                let mut p = String::with_capacity(13usize + filter_id.len());
+                let encoded_filter_id: Cow<str> =
+                    percent_encode(filter_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_filter_id.len());
                 p.push_str("/_ml/filters/");
-                p.push_str(filter_id.as_ref());
+                p.push_str(encoded_filter_id.as_ref());
                 p.into()
             }
         }
@@ -5385,9 +5489,11 @@ impl<'b> MlPutJobParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlPutJobParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(23usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(23usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.into()
             }
         }
@@ -5523,11 +5629,17 @@ impl<'b> MlRevertModelSnapshotParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlRevertModelSnapshotParts::JobIdSnapshotId(ref job_id, ref snapshot_id) => {
-                let mut p = String::with_capacity(48usize + job_id.len() + snapshot_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_snapshot_id: Cow<str> =
+                    percent_encode(snapshot_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    48usize + encoded_job_id.len() + encoded_snapshot_id.len(),
+                );
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/model_snapshots/");
-                p.push_str(snapshot_id.as_ref());
+                p.push_str(encoded_snapshot_id.as_ref());
                 p.push_str("/_revert");
                 p.into()
             }
@@ -5830,9 +5942,11 @@ impl<'b> MlStartDatafeedParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlStartDatafeedParts::DatafeedId(ref datafeed_id) => {
-                let mut p = String::with_capacity(22usize + datafeed_id.len());
+                let encoded_datafeed_id: Cow<str> =
+                    percent_encode(datafeed_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(22usize + encoded_datafeed_id.len());
                 p.push_str("/_ml/datafeeds/");
-                p.push_str(datafeed_id.as_ref());
+                p.push_str(encoded_datafeed_id.as_ref());
                 p.push_str("/_start");
                 p.into()
             }
@@ -6002,9 +6116,11 @@ impl<'b> MlStopDatafeedParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlStopDatafeedParts::DatafeedId(ref datafeed_id) => {
-                let mut p = String::with_capacity(21usize + datafeed_id.len());
+                let encoded_datafeed_id: Cow<str> =
+                    percent_encode(datafeed_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(21usize + encoded_datafeed_id.len());
                 p.push_str("/_ml/datafeeds/");
-                p.push_str(datafeed_id.as_ref());
+                p.push_str(encoded_datafeed_id.as_ref());
                 p.push_str("/_stop");
                 p.into()
             }
@@ -6174,9 +6290,11 @@ impl<'b> MlUpdateDatafeedParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlUpdateDatafeedParts::DatafeedId(ref datafeed_id) => {
-                let mut p = String::with_capacity(23usize + datafeed_id.len());
+                let encoded_datafeed_id: Cow<str> =
+                    percent_encode(datafeed_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(23usize + encoded_datafeed_id.len());
                 p.push_str("/_ml/datafeeds/");
-                p.push_str(datafeed_id.as_ref());
+                p.push_str(encoded_datafeed_id.as_ref());
                 p.push_str("/_update");
                 p.into()
             }
@@ -6357,9 +6475,11 @@ impl<'b> MlUpdateFilterParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlUpdateFilterParts::FilterId(ref filter_id) => {
-                let mut p = String::with_capacity(21usize + filter_id.len());
+                let encoded_filter_id: Cow<str> =
+                    percent_encode(filter_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(21usize + encoded_filter_id.len());
                 p.push_str("/_ml/filters/");
-                p.push_str(filter_id.as_ref());
+                p.push_str(encoded_filter_id.as_ref());
                 p.push_str("/_update");
                 p.into()
             }
@@ -6496,9 +6616,11 @@ impl<'b> MlUpdateJobParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlUpdateJobParts::JobId(ref job_id) => {
-                let mut p = String::with_capacity(31usize + job_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(31usize + encoded_job_id.len());
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/_update");
                 p.into()
             }
@@ -6635,11 +6757,17 @@ impl<'b> MlUpdateModelSnapshotParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             MlUpdateModelSnapshotParts::JobIdSnapshotId(ref job_id, ref snapshot_id) => {
-                let mut p = String::with_capacity(48usize + job_id.len() + snapshot_id.len());
+                let encoded_job_id: Cow<str> =
+                    percent_encode(job_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_snapshot_id: Cow<str> =
+                    percent_encode(snapshot_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    48usize + encoded_job_id.len() + encoded_snapshot_id.len(),
+                );
                 p.push_str("/_ml/anomaly_detectors/");
-                p.push_str(job_id.as_ref());
+                p.push_str(encoded_job_id.as_ref());
                 p.push_str("/model_snapshots/");
-                p.push_str(snapshot_id.as_ref());
+                p.push_str(encoded_snapshot_id.as_ref());
                 p.push_str("/_update");
                 p.into()
             }

--- a/elasticsearch/src/generated/namespace_clients/nodes.rs
+++ b/elasticsearch/src/generated/namespace_clients/nodes.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -43,9 +44,11 @@ impl<'b> NodesHotThreadsParts<'b> {
             NodesHotThreadsParts::None => "/_nodes/hot_threads".into(),
             NodesHotThreadsParts::NodeId(ref node_id) => {
                 let node_id_str = node_id.join(",");
-                let mut p = String::with_capacity(20usize + node_id_str.len());
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(20usize + encoded_node_id.len());
                 p.push_str("/_nodes/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.push_str("/hot_threads");
                 p.into()
             }
@@ -228,26 +231,35 @@ impl<'b> NodesInfoParts<'b> {
             NodesInfoParts::None => "/_nodes".into(),
             NodesInfoParts::NodeId(ref node_id) => {
                 let node_id_str = node_id.join(",");
-                let mut p = String::with_capacity(8usize + node_id_str.len());
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(8usize + encoded_node_id.len());
                 p.push_str("/_nodes/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.into()
             }
             NodesInfoParts::Metric(ref metric) => {
                 let metric_str = metric.join(",");
-                let mut p = String::with_capacity(8usize + metric_str.len());
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(8usize + encoded_metric.len());
                 p.push_str("/_nodes/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.into()
             }
             NodesInfoParts::NodeIdMetric(ref node_id, ref metric) => {
                 let node_id_str = node_id.join(",");
                 let metric_str = metric.join(",");
-                let mut p = String::with_capacity(9usize + node_id_str.len() + metric_str.len());
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(9usize + encoded_node_id.len() + encoded_metric.len());
                 p.push_str("/_nodes/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.push_str("/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.into()
             }
         }
@@ -385,9 +397,11 @@ impl<'b> NodesReloadSecureSettingsParts<'b> {
             NodesReloadSecureSettingsParts::None => "/_nodes/reload_secure_settings".into(),
             NodesReloadSecureSettingsParts::NodeId(ref node_id) => {
                 let node_id_str = node_id.join(",");
-                let mut p = String::with_capacity(31usize + node_id_str.len());
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(31usize + encoded_node_id.len());
                 p.push_str("/_nodes/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.push_str("/reload_secure_settings");
                 p.into()
             }
@@ -547,53 +561,76 @@ impl<'b> NodesStatsParts<'b> {
             NodesStatsParts::None => "/_nodes/stats".into(),
             NodesStatsParts::NodeId(ref node_id) => {
                 let node_id_str = node_id.join(",");
-                let mut p = String::with_capacity(14usize + node_id_str.len());
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(14usize + encoded_node_id.len());
                 p.push_str("/_nodes/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.push_str("/stats");
                 p.into()
             }
             NodesStatsParts::Metric(ref metric) => {
                 let metric_str = metric.join(",");
-                let mut p = String::with_capacity(14usize + metric_str.len());
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(14usize + encoded_metric.len());
                 p.push_str("/_nodes/stats/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.into()
             }
             NodesStatsParts::NodeIdMetric(ref node_id, ref metric) => {
                 let node_id_str = node_id.join(",");
                 let metric_str = metric.join(",");
-                let mut p = String::with_capacity(15usize + node_id_str.len() + metric_str.len());
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(15usize + encoded_node_id.len() + encoded_metric.len());
                 p.push_str("/_nodes/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.push_str("/stats/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.into()
             }
             NodesStatsParts::MetricIndexMetric(ref metric, ref index_metric) => {
                 let metric_str = metric.join(",");
                 let index_metric_str = index_metric.join(",");
-                let mut p =
-                    String::with_capacity(15usize + metric_str.len() + index_metric_str.len());
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_index_metric: Cow<str> =
+                    percent_encode(index_metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    15usize + encoded_metric.len() + encoded_index_metric.len(),
+                );
                 p.push_str("/_nodes/stats/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.push_str("/");
-                p.push_str(index_metric_str.as_ref());
+                p.push_str(encoded_index_metric.as_ref());
                 p.into()
             }
             NodesStatsParts::NodeIdMetricIndexMetric(ref node_id, ref metric, ref index_metric) => {
                 let node_id_str = node_id.join(",");
                 let metric_str = metric.join(",");
                 let index_metric_str = index_metric.join(",");
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_index_metric: Cow<str> =
+                    percent_encode(index_metric_str.as_bytes(), PARTS_ENCODED).into();
                 let mut p = String::with_capacity(
-                    16usize + node_id_str.len() + metric_str.len() + index_metric_str.len(),
+                    16usize
+                        + encoded_node_id.len()
+                        + encoded_metric.len()
+                        + encoded_index_metric.len(),
                 );
                 p.push_str("/_nodes/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.push_str("/stats/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.push_str("/");
-                p.push_str(index_metric_str.as_ref());
+                p.push_str(encoded_index_metric.as_ref());
                 p.into()
             }
         }
@@ -801,27 +838,36 @@ impl<'b> NodesUsageParts<'b> {
             NodesUsageParts::None => "/_nodes/usage".into(),
             NodesUsageParts::NodeId(ref node_id) => {
                 let node_id_str = node_id.join(",");
-                let mut p = String::with_capacity(14usize + node_id_str.len());
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(14usize + encoded_node_id.len());
                 p.push_str("/_nodes/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.push_str("/usage");
                 p.into()
             }
             NodesUsageParts::Metric(ref metric) => {
                 let metric_str = metric.join(",");
-                let mut p = String::with_capacity(14usize + metric_str.len());
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(14usize + encoded_metric.len());
                 p.push_str("/_nodes/usage/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.into()
             }
             NodesUsageParts::NodeIdMetric(ref node_id, ref metric) => {
                 let node_id_str = node_id.join(",");
                 let metric_str = metric.join(",");
-                let mut p = String::with_capacity(15usize + node_id_str.len() + metric_str.len());
+                let encoded_node_id: Cow<str> =
+                    percent_encode(node_id_str.as_bytes(), PARTS_ENCODED).into();
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(15usize + encoded_node_id.len() + encoded_metric.len());
                 p.push_str("/_nodes/");
-                p.push_str(node_id_str.as_ref());
+                p.push_str(encoded_node_id.as_ref());
                 p.push_str("/usage/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.into()
             }
         }

--- a/elasticsearch/src/generated/namespace_clients/security.rs
+++ b/elasticsearch/src/generated/namespace_clients/security.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -152,9 +153,11 @@ impl<'b> SecurityChangePasswordParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityChangePasswordParts::Username(ref username) => {
-                let mut p = String::with_capacity(26usize + username.len());
+                let encoded_username: Cow<str> =
+                    percent_encode(username.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(26usize + encoded_username.len());
                 p.push_str("/_security/user/");
-                p.push_str(username.as_ref());
+                p.push_str(encoded_username.as_ref());
                 p.push_str("/_password");
                 p.into()
             }
@@ -304,9 +307,11 @@ impl<'b> SecurityClearCachedRealmsParts<'b> {
         match self {
             SecurityClearCachedRealmsParts::Realms(ref realms) => {
                 let realms_str = realms.join(",");
-                let mut p = String::with_capacity(30usize + realms_str.len());
+                let encoded_realms: Cow<str> =
+                    percent_encode(realms_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(30usize + encoded_realms.len());
                 p.push_str("/_security/realm/");
-                p.push_str(realms_str.as_ref());
+                p.push_str(encoded_realms.as_ref());
                 p.push_str("/_clear_cache");
                 p.into()
             }
@@ -458,9 +463,11 @@ impl<'b> SecurityClearCachedRolesParts<'b> {
         match self {
             SecurityClearCachedRolesParts::Name(ref name) => {
                 let name_str = name.join(",");
-                let mut p = String::with_capacity(29usize + name_str.len());
+                let encoded_name: Cow<str> =
+                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(29usize + encoded_name.len());
                 p.push_str("/_security/role/");
-                p.push_str(name_str.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.push_str("/_clear_cache");
                 p.into()
             }
@@ -741,11 +748,15 @@ impl<'b> SecurityDeletePrivilegesParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityDeletePrivilegesParts::ApplicationName(ref application, ref name) => {
-                let mut p = String::with_capacity(22usize + application.len() + name.len());
+                let encoded_application: Cow<str> =
+                    percent_encode(application.as_bytes(), PARTS_ENCODED).into();
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(22usize + encoded_application.len() + encoded_name.len());
                 p.push_str("/_security/privilege/");
-                p.push_str(application.as_ref());
+                p.push_str(encoded_application.as_ref());
                 p.push_str("/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -869,9 +880,10 @@ impl<'b> SecurityDeleteRoleParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityDeleteRoleParts::Name(ref name) => {
-                let mut p = String::with_capacity(16usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_name.len());
                 p.push_str("/_security/role/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -995,9 +1007,10 @@ impl<'b> SecurityDeleteRoleMappingParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityDeleteRoleMappingParts::Name(ref name) => {
-                let mut p = String::with_capacity(24usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(24usize + encoded_name.len());
                 p.push_str("/_security/role_mapping/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -1121,9 +1134,11 @@ impl<'b> SecurityDeleteUserParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityDeleteUserParts::Username(ref username) => {
-                let mut p = String::with_capacity(16usize + username.len());
+                let encoded_username: Cow<str> =
+                    percent_encode(username.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_username.len());
                 p.push_str("/_security/user/");
-                p.push_str(username.as_ref());
+                p.push_str(encoded_username.as_ref());
                 p.into()
             }
         }
@@ -1247,9 +1262,11 @@ impl<'b> SecurityDisableUserParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityDisableUserParts::Username(ref username) => {
-                let mut p = String::with_capacity(25usize + username.len());
+                let encoded_username: Cow<str> =
+                    percent_encode(username.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(25usize + encoded_username.len());
                 p.push_str("/_security/user/");
-                p.push_str(username.as_ref());
+                p.push_str(encoded_username.as_ref());
                 p.push_str("/_disable");
                 p.into()
             }
@@ -1397,9 +1414,11 @@ impl<'b> SecurityEnableUserParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityEnableUserParts::Username(ref username) => {
-                let mut p = String::with_capacity(24usize + username.len());
+                let encoded_username: Cow<str> =
+                    percent_encode(username.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(24usize + encoded_username.len());
                 p.push_str("/_security/user/");
-                p.push_str(username.as_ref());
+                p.push_str(encoded_username.as_ref());
                 p.push_str("/_enable");
                 p.into()
             }
@@ -1824,17 +1843,23 @@ impl<'b> SecurityGetPrivilegesParts<'b> {
         match self {
             SecurityGetPrivilegesParts::None => "/_security/privilege".into(),
             SecurityGetPrivilegesParts::Application(ref application) => {
-                let mut p = String::with_capacity(21usize + application.len());
+                let encoded_application: Cow<str> =
+                    percent_encode(application.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(21usize + encoded_application.len());
                 p.push_str("/_security/privilege/");
-                p.push_str(application.as_ref());
+                p.push_str(encoded_application.as_ref());
                 p.into()
             }
             SecurityGetPrivilegesParts::ApplicationName(ref application, ref name) => {
-                let mut p = String::with_capacity(22usize + application.len() + name.len());
+                let encoded_application: Cow<str> =
+                    percent_encode(application.as_bytes(), PARTS_ENCODED).into();
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p =
+                    String::with_capacity(22usize + encoded_application.len() + encoded_name.len());
                 p.push_str("/_security/privilege/");
-                p.push_str(application.as_ref());
+                p.push_str(encoded_application.as_ref());
                 p.push_str("/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -1950,9 +1975,10 @@ impl<'b> SecurityGetRoleParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityGetRoleParts::Name(ref name) => {
-                let mut p = String::with_capacity(16usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_name.len());
                 p.push_str("/_security/role/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
             SecurityGetRoleParts::None => "/_security/role".into(),
@@ -2069,9 +2095,10 @@ impl<'b> SecurityGetRoleMappingParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityGetRoleMappingParts::Name(ref name) => {
-                let mut p = String::with_capacity(24usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(24usize + encoded_name.len());
                 p.push_str("/_security/role_mapping/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
             SecurityGetRoleMappingParts::None => "/_security/role_mapping".into(),
@@ -2322,9 +2349,11 @@ impl<'b> SecurityGetUserParts<'b> {
         match self {
             SecurityGetUserParts::Username(ref username) => {
                 let username_str = username.join(",");
-                let mut p = String::with_capacity(16usize + username_str.len());
+                let encoded_username: Cow<str> =
+                    percent_encode(username_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_username.len());
                 p.push_str("/_security/user/");
-                p.push_str(username_str.as_ref());
+                p.push_str(encoded_username.as_ref());
                 p.into()
             }
             SecurityGetUserParts::None => "/_security/user".into(),
@@ -2553,9 +2582,10 @@ impl<'b> SecurityHasPrivilegesParts<'b> {
         match self {
             SecurityHasPrivilegesParts::None => "/_security/user/_has_privileges".into(),
             SecurityHasPrivilegesParts::User(ref user) => {
-                let mut p = String::with_capacity(32usize + user.len());
+                let encoded_user: Cow<str> = percent_encode(user.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(32usize + encoded_user.len());
                 p.push_str("/_security/user/");
-                p.push_str(user.as_ref());
+                p.push_str(encoded_user.as_ref());
                 p.push_str("/_has_privileges");
                 p.into()
             }
@@ -3105,9 +3135,10 @@ impl<'b> SecurityPutRoleParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityPutRoleParts::Name(ref name) => {
-                let mut p = String::with_capacity(16usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_name.len());
                 p.push_str("/_security/role/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -3254,9 +3285,10 @@ impl<'b> SecurityPutRoleMappingParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityPutRoleMappingParts::Name(ref name) => {
-                let mut p = String::with_capacity(24usize + name.len());
+                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(24usize + encoded_name.len());
                 p.push_str("/_security/role_mapping/");
-                p.push_str(name.as_ref());
+                p.push_str(encoded_name.as_ref());
                 p.into()
             }
         }
@@ -3403,9 +3435,11 @@ impl<'b> SecurityPutUserParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SecurityPutUserParts::Username(ref username) => {
-                let mut p = String::with_capacity(16usize + username.len());
+                let encoded_username: Cow<str> =
+                    percent_encode(username.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_username.len());
                 p.push_str("/_security/user/");
-                p.push_str(username.as_ref());
+                p.push_str(encoded_username.as_ref());
                 p.into()
             }
         }

--- a/elasticsearch/src/generated/namespace_clients/slm.rs
+++ b/elasticsearch/src/generated/namespace_clients/slm.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -39,9 +40,11 @@ impl<'b> SlmDeleteLifecycleParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SlmDeleteLifecycleParts::PolicyId(ref policy_id) => {
-                let mut p = String::with_capacity(13usize + policy_id.len());
+                let encoded_policy_id: Cow<str> =
+                    percent_encode(policy_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_policy_id.len());
                 p.push_str("/_slm/policy/");
-                p.push_str(policy_id.as_ref());
+                p.push_str(encoded_policy_id.as_ref());
                 p.into()
             }
         }
@@ -155,9 +158,11 @@ impl<'b> SlmExecuteLifecycleParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SlmExecuteLifecycleParts::PolicyId(ref policy_id) => {
-                let mut p = String::with_capacity(22usize + policy_id.len());
+                let encoded_policy_id: Cow<str> =
+                    percent_encode(policy_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(22usize + encoded_policy_id.len());
                 p.push_str("/_slm/policy/");
-                p.push_str(policy_id.as_ref());
+                p.push_str(encoded_policy_id.as_ref());
                 p.push_str("/_execute");
                 p.into()
             }
@@ -430,9 +435,11 @@ impl<'b> SlmGetLifecycleParts<'b> {
         match self {
             SlmGetLifecycleParts::PolicyId(ref policy_id) => {
                 let policy_id_str = policy_id.join(",");
-                let mut p = String::with_capacity(13usize + policy_id_str.len());
+                let encoded_policy_id: Cow<str> =
+                    percent_encode(policy_id_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_policy_id.len());
                 p.push_str("/_slm/policy/");
-                p.push_str(policy_id_str.as_ref());
+                p.push_str(encoded_policy_id.as_ref());
                 p.into()
             }
             SlmGetLifecycleParts::None => "/_slm/policy".into(),
@@ -769,9 +776,11 @@ impl<'b> SlmPutLifecycleParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SlmPutLifecycleParts::PolicyId(ref policy_id) => {
-                let mut p = String::with_capacity(13usize + policy_id.len());
+                let encoded_policy_id: Cow<str> =
+                    percent_encode(policy_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(13usize + encoded_policy_id.len());
                 p.push_str("/_slm/policy/");
-                p.push_str(policy_id.as_ref());
+                p.push_str(encoded_policy_id.as_ref());
                 p.into()
             }
         }

--- a/elasticsearch/src/generated/namespace_clients/snapshot.rs
+++ b/elasticsearch/src/generated/namespace_clients/snapshot.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -39,9 +40,11 @@ impl<'b> SnapshotCleanupRepositoryParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SnapshotCleanupRepositoryParts::Repository(ref repository) => {
-                let mut p = String::with_capacity(20usize + repository.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(20usize + encoded_repository.len());
                 p.push_str("/_snapshot/");
-                p.push_str(repository.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.push_str("/_cleanup");
                 p.into()
             }
@@ -200,11 +203,17 @@ impl<'b> SnapshotCreateParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SnapshotCreateParts::RepositorySnapshot(ref repository, ref snapshot) => {
-                let mut p = String::with_capacity(12usize + repository.len() + snapshot.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
+                let encoded_snapshot: Cow<str> =
+                    percent_encode(snapshot.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    12usize + encoded_repository.len() + encoded_snapshot.len(),
+                );
                 p.push_str("/_snapshot/");
-                p.push_str(repository.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.push_str("/");
-                p.push_str(snapshot.as_ref());
+                p.push_str(encoded_snapshot.as_ref());
                 p.into()
             }
         }
@@ -362,9 +371,11 @@ impl<'b> SnapshotCreateRepositoryParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SnapshotCreateRepositoryParts::Repository(ref repository) => {
-                let mut p = String::with_capacity(11usize + repository.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_repository.len());
                 p.push_str("/_snapshot/");
-                p.push_str(repository.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.into()
             }
         }
@@ -533,11 +544,17 @@ impl<'b> SnapshotDeleteParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SnapshotDeleteParts::RepositorySnapshot(ref repository, ref snapshot) => {
-                let mut p = String::with_capacity(12usize + repository.len() + snapshot.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
+                let encoded_snapshot: Cow<str> =
+                    percent_encode(snapshot.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    12usize + encoded_repository.len() + encoded_snapshot.len(),
+                );
                 p.push_str("/_snapshot/");
-                p.push_str(repository.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.push_str("/");
-                p.push_str(snapshot.as_ref());
+                p.push_str(encoded_snapshot.as_ref());
                 p.into()
             }
         }
@@ -662,9 +679,11 @@ impl<'b> SnapshotDeleteRepositoryParts<'b> {
         match self {
             SnapshotDeleteRepositoryParts::Repository(ref repository) => {
                 let repository_str = repository.join(",");
-                let mut p = String::with_capacity(11usize + repository_str.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_repository.len());
                 p.push_str("/_snapshot/");
-                p.push_str(repository_str.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.into()
             }
         }
@@ -799,11 +818,17 @@ impl<'b> SnapshotGetParts<'b> {
         match self {
             SnapshotGetParts::RepositorySnapshot(ref repository, ref snapshot) => {
                 let snapshot_str = snapshot.join(",");
-                let mut p = String::with_capacity(12usize + repository.len() + snapshot_str.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
+                let encoded_snapshot: Cow<str> =
+                    percent_encode(snapshot_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    12usize + encoded_repository.len() + encoded_snapshot.len(),
+                );
                 p.push_str("/_snapshot/");
-                p.push_str(repository.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.push_str("/");
-                p.push_str(snapshot_str.as_ref());
+                p.push_str(encoded_snapshot.as_ref());
                 p.into()
             }
         }
@@ -951,9 +976,11 @@ impl<'b> SnapshotGetRepositoryParts<'b> {
             SnapshotGetRepositoryParts::None => "/_snapshot".into(),
             SnapshotGetRepositoryParts::Repository(ref repository) => {
                 let repository_str = repository.join(",");
-                let mut p = String::with_capacity(11usize + repository_str.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_repository.len());
                 p.push_str("/_snapshot/");
-                p.push_str(repository_str.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.into()
             }
         }
@@ -1087,11 +1114,17 @@ impl<'b> SnapshotRestoreParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SnapshotRestoreParts::RepositorySnapshot(ref repository, ref snapshot) => {
-                let mut p = String::with_capacity(21usize + repository.len() + snapshot.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
+                let encoded_snapshot: Cow<str> =
+                    percent_encode(snapshot.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    21usize + encoded_repository.len() + encoded_snapshot.len(),
+                );
                 p.push_str("/_snapshot/");
-                p.push_str(repository.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.push_str("/");
-                p.push_str(snapshot.as_ref());
+                p.push_str(encoded_snapshot.as_ref());
                 p.push_str("/_restore");
                 p.into()
             }
@@ -1255,19 +1288,27 @@ impl<'b> SnapshotStatusParts<'b> {
         match self {
             SnapshotStatusParts::None => "/_snapshot/_status".into(),
             SnapshotStatusParts::Repository(ref repository) => {
-                let mut p = String::with_capacity(19usize + repository.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(19usize + encoded_repository.len());
                 p.push_str("/_snapshot/");
-                p.push_str(repository.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.push_str("/_status");
                 p.into()
             }
             SnapshotStatusParts::RepositorySnapshot(ref repository, ref snapshot) => {
                 let snapshot_str = snapshot.join(",");
-                let mut p = String::with_capacity(20usize + repository.len() + snapshot_str.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
+                let encoded_snapshot: Cow<str> =
+                    percent_encode(snapshot_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    20usize + encoded_repository.len() + encoded_snapshot.len(),
+                );
                 p.push_str("/_snapshot/");
-                p.push_str(repository.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.push_str("/");
-                p.push_str(snapshot_str.as_ref());
+                p.push_str(encoded_snapshot.as_ref());
                 p.push_str("/_status");
                 p.into()
             }
@@ -1402,9 +1443,11 @@ impl<'b> SnapshotVerifyRepositoryParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             SnapshotVerifyRepositoryParts::Repository(ref repository) => {
-                let mut p = String::with_capacity(19usize + repository.len());
+                let encoded_repository: Cow<str> =
+                    percent_encode(repository.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(19usize + encoded_repository.len());
                 p.push_str("/_snapshot/");
-                p.push_str(repository.as_ref());
+                p.push_str(encoded_repository.as_ref());
                 p.push_str("/_verify");
                 p.into()
             }

--- a/elasticsearch/src/generated/namespace_clients/sql.rs
+++ b/elasticsearch/src/generated/namespace_clients/sql.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]

--- a/elasticsearch/src/generated/namespace_clients/ssl.rs
+++ b/elasticsearch/src/generated/namespace_clients/ssl.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]

--- a/elasticsearch/src/generated/namespace_clients/tasks.rs
+++ b/elasticsearch/src/generated/namespace_clients/tasks.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -42,9 +43,11 @@ impl<'b> TasksCancelParts<'b> {
         match self {
             TasksCancelParts::None => "/_tasks/_cancel".into(),
             TasksCancelParts::TaskId(ref task_id) => {
-                let mut p = String::with_capacity(16usize + task_id.len());
+                let encoded_task_id: Cow<str> =
+                    percent_encode(task_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_task_id.len());
                 p.push_str("/_tasks/");
-                p.push_str(task_id.as_ref());
+                p.push_str(encoded_task_id.as_ref());
                 p.push_str("/_cancel");
                 p.into()
             }
@@ -217,9 +220,11 @@ impl<'b> TasksGetParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             TasksGetParts::TaskId(ref task_id) => {
-                let mut p = String::with_capacity(8usize + task_id.len());
+                let encoded_task_id: Cow<str> =
+                    percent_encode(task_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(8usize + encoded_task_id.len());
                 p.push_str("/_tasks/");
-                p.push_str(task_id.as_ref());
+                p.push_str(encoded_task_id.as_ref());
                 p.into()
             }
         }

--- a/elasticsearch/src/generated/namespace_clients/transform.rs
+++ b/elasticsearch/src/generated/namespace_clients/transform.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -39,9 +40,11 @@ impl<'b> TransformDeleteTransformParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             TransformDeleteTransformParts::TransformId(ref transform_id) => {
-                let mut p = String::with_capacity(12usize + transform_id.len());
+                let encoded_transform_id: Cow<str> =
+                    percent_encode(transform_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(12usize + encoded_transform_id.len());
                 p.push_str("/_transform/");
-                p.push_str(transform_id.as_ref());
+                p.push_str(encoded_transform_id.as_ref());
                 p.into()
             }
         }
@@ -167,9 +170,11 @@ impl<'b> TransformGetTransformParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             TransformGetTransformParts::TransformId(ref transform_id) => {
-                let mut p = String::with_capacity(12usize + transform_id.len());
+                let encoded_transform_id: Cow<str> =
+                    percent_encode(transform_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(12usize + encoded_transform_id.len());
                 p.push_str("/_transform/");
-                p.push_str(transform_id.as_ref());
+                p.push_str(encoded_transform_id.as_ref());
                 p.into()
             }
             TransformGetTransformParts::None => "/_transform".into(),
@@ -314,9 +319,11 @@ impl<'b> TransformGetTransformStatsParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             TransformGetTransformStatsParts::TransformId(ref transform_id) => {
-                let mut p = String::with_capacity(19usize + transform_id.len());
+                let encoded_transform_id: Cow<str> =
+                    percent_encode(transform_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(19usize + encoded_transform_id.len());
                 p.push_str("/_transform/");
-                p.push_str(transform_id.as_ref());
+                p.push_str(encoded_transform_id.as_ref());
                 p.push_str("/_stats");
                 p.into()
             }
@@ -594,9 +601,11 @@ impl<'b> TransformPutTransformParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             TransformPutTransformParts::TransformId(ref transform_id) => {
-                let mut p = String::with_capacity(12usize + transform_id.len());
+                let encoded_transform_id: Cow<str> =
+                    percent_encode(transform_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(12usize + encoded_transform_id.len());
                 p.push_str("/_transform/");
-                p.push_str(transform_id.as_ref());
+                p.push_str(encoded_transform_id.as_ref());
                 p.into()
             }
         }
@@ -743,9 +752,11 @@ impl<'b> TransformStartTransformParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             TransformStartTransformParts::TransformId(ref transform_id) => {
-                let mut p = String::with_capacity(19usize + transform_id.len());
+                let encoded_transform_id: Cow<str> =
+                    percent_encode(transform_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(19usize + encoded_transform_id.len());
                 p.push_str("/_transform/");
-                p.push_str(transform_id.as_ref());
+                p.push_str(encoded_transform_id.as_ref());
                 p.push_str("/_start");
                 p.into()
             }
@@ -893,9 +904,11 @@ impl<'b> TransformStopTransformParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             TransformStopTransformParts::TransformId(ref transform_id) => {
-                let mut p = String::with_capacity(18usize + transform_id.len());
+                let encoded_transform_id: Cow<str> =
+                    percent_encode(transform_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(18usize + encoded_transform_id.len());
                 p.push_str("/_transform/");
-                p.push_str(transform_id.as_ref());
+                p.push_str(encoded_transform_id.as_ref());
                 p.push_str("/_stop");
                 p.into()
             }
@@ -1087,9 +1100,11 @@ impl<'b> TransformUpdateTransformParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             TransformUpdateTransformParts::TransformId(ref transform_id) => {
-                let mut p = String::with_capacity(20usize + transform_id.len());
+                let encoded_transform_id: Cow<str> =
+                    percent_encode(transform_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(20usize + encoded_transform_id.len());
                 p.push_str("/_transform/");
-                p.push_str(transform_id.as_ref());
+                p.push_str(encoded_transform_id.as_ref());
                 p.push_str("/_update");
                 p.into()
             }

--- a/elasticsearch/src/generated/namespace_clients/watcher.rs
+++ b/elasticsearch/src/generated/namespace_clients/watcher.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
@@ -41,19 +42,27 @@ impl<'b> WatcherAckWatchParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             WatcherAckWatchParts::WatchId(ref watch_id) => {
-                let mut p = String::with_capacity(21usize + watch_id.len());
+                let encoded_watch_id: Cow<str> =
+                    percent_encode(watch_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(21usize + encoded_watch_id.len());
                 p.push_str("/_watcher/watch/");
-                p.push_str(watch_id.as_ref());
+                p.push_str(encoded_watch_id.as_ref());
                 p.push_str("/_ack");
                 p.into()
             }
             WatcherAckWatchParts::WatchIdActionId(ref watch_id, ref action_id) => {
                 let action_id_str = action_id.join(",");
-                let mut p = String::with_capacity(22usize + watch_id.len() + action_id_str.len());
+                let encoded_watch_id: Cow<str> =
+                    percent_encode(watch_id.as_bytes(), PARTS_ENCODED).into();
+                let encoded_action_id: Cow<str> =
+                    percent_encode(action_id_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(
+                    22usize + encoded_watch_id.len() + encoded_action_id.len(),
+                );
                 p.push_str("/_watcher/watch/");
-                p.push_str(watch_id.as_ref());
+                p.push_str(encoded_watch_id.as_ref());
                 p.push_str("/_ack/");
-                p.push_str(action_id_str.as_ref());
+                p.push_str(encoded_action_id.as_ref());
                 p.into()
             }
         }
@@ -189,9 +198,11 @@ impl<'b> WatcherActivateWatchParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             WatcherActivateWatchParts::WatchId(ref watch_id) => {
-                let mut p = String::with_capacity(26usize + watch_id.len());
+                let encoded_watch_id: Cow<str> =
+                    percent_encode(watch_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(26usize + encoded_watch_id.len());
                 p.push_str("/_watcher/watch/");
-                p.push_str(watch_id.as_ref());
+                p.push_str(encoded_watch_id.as_ref());
                 p.push_str("/_activate");
                 p.into()
             }
@@ -328,9 +339,11 @@ impl<'b> WatcherDeactivateWatchParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             WatcherDeactivateWatchParts::WatchId(ref watch_id) => {
-                let mut p = String::with_capacity(28usize + watch_id.len());
+                let encoded_watch_id: Cow<str> =
+                    percent_encode(watch_id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(28usize + encoded_watch_id.len());
                 p.push_str("/_watcher/watch/");
-                p.push_str(watch_id.as_ref());
+                p.push_str(encoded_watch_id.as_ref());
                 p.push_str("/_deactivate");
                 p.into()
             }
@@ -467,9 +480,10 @@ impl<'b> WatcherDeleteWatchParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             WatcherDeleteWatchParts::Id(ref id) => {
-                let mut p = String::with_capacity(16usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_id.len());
                 p.push_str("/_watcher/watch/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.into()
             }
         }
@@ -585,9 +599,10 @@ impl<'b> WatcherExecuteWatchParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             WatcherExecuteWatchParts::Id(ref id) => {
-                let mut p = String::with_capacity(25usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(25usize + encoded_id.len());
                 p.push_str("/_watcher/watch/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.push_str("/_execute");
                 p.into()
             }
@@ -736,9 +751,10 @@ impl<'b> WatcherGetWatchParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             WatcherGetWatchParts::Id(ref id) => {
-                let mut p = String::with_capacity(16usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_id.len());
                 p.push_str("/_watcher/watch/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.into()
             }
         }
@@ -852,9 +868,10 @@ impl<'b> WatcherPutWatchParts<'b> {
     pub fn url(self) -> Cow<'static, str> {
         match self {
             WatcherPutWatchParts::Id(ref id) => {
-                let mut p = String::with_capacity(16usize + id.len());
+                let encoded_id: Cow<str> = percent_encode(id.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_id.len());
                 p.push_str("/_watcher/watch/");
-                p.push_str(id.as_ref());
+                p.push_str(encoded_id.as_ref());
                 p.into()
             }
         }
@@ -1171,9 +1188,11 @@ impl<'b> WatcherStatsParts<'b> {
             WatcherStatsParts::None => "/_watcher/stats".into(),
             WatcherStatsParts::Metric(ref metric) => {
                 let metric_str = metric.join(",");
-                let mut p = String::with_capacity(16usize + metric_str.len());
+                let encoded_metric: Cow<str> =
+                    percent_encode(metric_str.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(16usize + encoded_metric.len());
                 p.push_str("/_watcher/stats/");
-                p.push_str(metric_str.as_ref());
+                p.push_str(encoded_metric.as_ref());
                 p.into()
             }
         }

--- a/elasticsearch/src/generated/namespace_clients/xpack.rs
+++ b/elasticsearch/src/generated/namespace_clients/xpack.rs
@@ -14,18 +14,19 @@
 // cargo run -p api_generator
 //
 // -----------------------------------------------
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use crate::{
     client::Elasticsearch,
     error::Error,
     http::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
-        request::{Body, JsonBody, NdBody},
+        request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
         Method,
     },
     params::*,
 };
+use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]

--- a/elasticsearch/src/http/request.rs
+++ b/elasticsearch/src/http/request.rs
@@ -3,7 +3,16 @@
 use crate::error::Error;
 use bytes::buf::BufMutExt;
 use bytes::{BufMut, Bytes, BytesMut};
+use percent_encoding::AsciiSet;
 use serde::Serialize;
+
+// similar to percent-encoding's NON_ALPHANUMERIC AsciiSet, but with some characters removed
+pub(crate) const PARTS_ENCODED: &AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+    .remove(b'_')
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b',')
+    .remove(b'*');
 
 /// Body of an API call.
 ///
@@ -11,11 +20,11 @@ use serde::Serialize;
 /// expect JSON, however, there are some APIs that expect newline-delimited JSON (NDJSON).
 /// The [Body] trait allows modelling different API body implementations.
 pub trait Body {
-    /// An existing immutable buffer that can be used to avoid writing
+    /// An existing immutable buffer that can be used to avoid
     /// having to write to another buffer that will then be written to the request stream.
     ///
     /// If this method returns `Some`, the bytes must be the same as
-    /// those that would be written by `write`.
+    /// those that would be written by [Body::write].
     fn bytes(&self) -> Option<Bytes> {
         None
     }

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -388,6 +388,13 @@ pub mod tests {
     }
 
     #[test]
+    fn percent_encode_characters() {
+        let parts = SearchParts::Index(&[" !\"#$%&'\\()*+,-./:;<=>?@[\\]^_`{|}~"]);
+        let url = parts.url();
+        assert_eq!(url, "/%20%21%22%23%24%25%26%27%5C%28%29*%2B,-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D%7E/_search");
+    }
+
+    #[test]
     fn build_search_on_selected_indices_and_types() {
         let parts = SearchParts::IndexType(&["index-1", "index-2"], &["type-1", "type-2"]);
         let url = parts.url();


### PR DESCRIPTION
This commit updates the api_generator to emit code
to percent encode values passed to Parts enums
when calling the url() function. A value passed to a
Part may be one that, if left unencoded, would
be interpreted differently by the HTTP client e.g.
a # (start of Fragment identifier) or ? (start of Query identifier).