### PR TITLE
Pass Transport to builder structs

### DIFF
--- a/api_generator/rest_specs/cluster.delete_component_template.json
+++ b/api_generator/rest_specs/cluster.delete_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Deletes a component template"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/api_generator/rest_specs/cluster.exists_component_template.json
+++ b/api_generator/rest_specs/cluster.exists_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Returns information about whether a particular component template exist"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/api_generator/rest_specs/cluster.get_component_template.json
+++ b/api_generator/rest_specs/cluster.get_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Returns one or more component templates"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/api_generator/rest_specs/cluster.put_component_template.json
+++ b/api_generator/rest_specs/cluster.put_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Creates or updates a component template"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/api_generator/rest_specs/dangling_indices.delete_dangling_index.json
+++ b/api_generator/rest_specs/dangling_indices.delete_dangling_index.json
@@ -1,0 +1,39 @@
+{
+  "dangling_indices.delete_dangling_index": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html",
+      "description": "Deletes the specified dangling index"
+    },
+    "stability": "stable",
+    "url": {
+      "paths": [
+        {
+          "path": "/_dangling/{index_uuid}",
+          "methods": [
+            "DELETE"
+          ],
+          "parts": {
+            "index_uuid": {
+              "type": "string",
+              "description": "The UUID of the dangling index"
+            }
+          }
+        }
+      ]
+    },
+    "params": {
+      "accept_data_loss": {
+        "type": "boolean",
+        "description": "Must be set to true in order to delete the dangling index"
+      },
+      "timeout": {
+        "type": "time",
+        "description": "Explicit operation timeout"
+      },
+      "master_timeout": {
+        "type": "time",
+        "description": "Specify timeout for connection to master"
+      }
+    }
+  }
+}

--- a/api_generator/rest_specs/dangling_indices.import_dangling_index.json
+++ b/api_generator/rest_specs/dangling_indices.import_dangling_index.json
@@ -1,0 +1,39 @@
+{
+  "dangling_indices.import_dangling_index": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html",
+      "description": "Imports the specified dangling index"
+    },
+    "stability": "stable",
+    "url": {
+      "paths": [
+        {
+          "path": "/_dangling/{index_uuid}",
+          "methods": [
+            "POST"
+          ],
+          "parts": {
+            "index_uuid": {
+              "type": "string",
+              "description": "The UUID of the dangling index"
+            }
+          }
+        }
+      ]
+    },
+    "params": {
+      "accept_data_loss": {
+        "type": "boolean",
+        "description": "Must be set to true in order to import the dangling index"
+      },
+      "timeout": {
+        "type": "time",
+        "description": "Explicit operation timeout"
+      },
+      "master_timeout": {
+        "type": "time",
+        "description": "Specify timeout for connection to master"
+      }
+    }
+  }
+}

--- a/api_generator/rest_specs/dangling_indices.list_dangling_indices.json
+++ b/api_generator/rest_specs/dangling_indices.list_dangling_indices.json
@@ -1,0 +1,20 @@
+{
+  "dangling_indices.list_dangling_indices": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-gateway-dangling-indices.html",
+      "description": "Returns all dangling indices."
+    },
+    "stability": "stable",
+    "url": {
+      "paths": [
+        {
+          "path": "/_dangling",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    },
+    "params": {}
+  }
+}

--- a/api_generator/rest_specs/eql.delete.json
+++ b/api_generator/rest_specs/eql.delete.json
@@ -1,0 +1,25 @@
+{
+  "eql.delete":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html",
+      "description": "Deletes an async EQL search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted."
+    },
+    "stability":"beta",
+    "url":{
+      "paths":[
+        {
+          "path":"/_eql/search/{id}",
+          "methods":[
+            "DELETE"
+          ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"The async search ID"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/api_generator/rest_specs/eql.get.json
+++ b/api_generator/rest_specs/eql.get.json
@@ -1,22 +1,21 @@
 {
-  "eql.search":{
+  "eql.get":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html",
-      "description": "Returns results matching a query expressed in Event Query Language (EQL)"
+      "description": "Returns async results from previously executed Event Query Language (EQL) search"
     },
     "stability": "beta",
     "url":{
       "paths":[
         {
-          "path":"/{index}/_eql/search",
+          "path":"/_eql/search/{id}",
           "methods":[
-            "GET",
-            "POST"
+            "GET"
           ],
           "parts":{
-            "index":{
+            "id":{
               "type":"string",
-              "description":"The name of the index to scope the operation"
+              "description":"The async search ID"
             }
           }
         }
@@ -27,20 +26,11 @@
         "type":"time",
         "description":"Specify the time that the request should block waiting for the final response"
       },
-      "keep_on_completion":{
-        "type":"boolean",
-        "description":"Control whether the response should be stored in the cluster if it completed within the provided [wait_for_completion] time (default: false)",
-        "default":false
-      },
       "keep_alive": {
         "type": "time",
         "description": "Update the time interval in which the results (partial or final) for this search will be available",
         "default": "5d"
       }
-    },
-    "body":{
-      "description":"Eql request body. Use the `query` to limit the query scope.",
-      "required":true
     }
   }
 }

--- a/api_generator/rest_specs/field_caps.json
+++ b/api_generator/rest_specs/field_caps.json
@@ -59,6 +59,9 @@
         "default":false,
         "description":"Indicates whether unmapped fields should be included in the response."
       }
+    },
+    "body":{
+      "description":"An index filter specified with the Query DSL"
     }
   }
 }

--- a/api_generator/rest_specs/indices.delete_index_template.json
+++ b/api_generator/rest_specs/indices.delete_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Deletes an index template."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/api_generator/rest_specs/indices.exists_index_template.json
+++ b/api_generator/rest_specs/indices.exists_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Returns information about whether a particular index template exists."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/api_generator/rest_specs/indices.get_index_template.json
+++ b/api_generator/rest_specs/indices.get_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Returns an index template."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/api_generator/rest_specs/indices.put_index_template.json
+++ b/api_generator/rest_specs/indices.put_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Creates or updates an index template."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/api_generator/rest_specs/indices.resolve_index.json
+++ b/api_generator/rest_specs/indices.resolve_index.json
@@ -1,0 +1,39 @@
+{
+  "indices.resolve_index":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index.html",
+      "description":"Returns information about any matching indices, aliases, and data streams"
+    },
+    "stability":"experimental",
+    "url":{
+      "paths":[
+        {
+          "path":"/_resolve/index/{name}",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "name":{
+              "type":"list",
+              "description":"A comma-separated list of names or wildcard expressions"
+            }
+          }
+        }
+      ]
+    },
+    "params":{
+      "expand_wildcards":{
+        "type":"enum",
+        "options":[
+          "open",
+          "closed",
+          "hidden",
+          "none",
+          "all"
+        ],
+        "default":"open",
+        "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+      }
+    }
+  }
+}

--- a/api_generator/rest_specs/indices.simulate_index_template.json
+++ b/api_generator/rest_specs/indices.simulate_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description": "Simulate matching the given index name against the index templates in the system"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/api_generator/rest_specs/indices.simulate_template.json
+++ b/api_generator/rest_specs/indices.simulate_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description": "Simulate resolving the given template name or body"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/api_generator/src/generator/code_gen/mod.rs
+++ b/api_generator/src/generator/code_gen/mod.rs
@@ -40,6 +40,7 @@ pub fn use_declarations() -> Tokens {
                 Method,
                 request::{Body, NdBody, JsonBody, PARTS_ENCODED},
                 response::Response,
+                transport::Transport,
             },
         };
         use std::borrow::Cow;

--- a/api_generator/src/generator/code_gen/namespace_clients.rs
+++ b/api_generator/src/generator/code_gen/namespace_clients.rs
@@ -77,23 +77,28 @@ pub fn generate(api: &Api, docs_dir: &PathBuf) -> Result<Vec<(String, String)>, 
 
             #namespace_doc
             pub struct #namespace_client_name<'a> {
-                client: &'a Elasticsearch
+                transport: &'a Transport
             }
 
             impl<'a> #namespace_client_name<'a> {
                 #new_namespace_client_doc
-                pub fn new(client: &'a Elasticsearch) -> Self {
+                pub fn new(transport: &'a Transport) -> Self {
                     Self {
-                        client
+                        transport
                     }
                 }
+
+                pub fn transport(&self) -> &Transport {
+                    self.transport
+                }
+
                 #(#methods)*
             }
 
             impl Elasticsearch {
                 #namespace_fn_doc
                 pub fn #namespace_name(&self) -> #namespace_client_name {
-                    #namespace_client_name::new(&self)
+                    #namespace_client_name::new(self.transport())
                 }
             }
         ));

--- a/elasticsearch/src/client.rs
+++ b/elasticsearch/src/client.rs
@@ -64,6 +64,11 @@ impl Elasticsearch {
         Elasticsearch { transport }
     }
 
+    /// Gets the transport of the client
+    pub fn transport(&self) -> &Transport {
+        &self.transport
+    }
+
     /// Creates an asynchronous request that can be awaited
     ///
     /// Accepts the HTTP method and relative path to an API,

--- a/elasticsearch/src/generated/namespace_clients/async_search.rs
+++ b/elasticsearch/src/generated/namespace_clients/async_search.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -60,7 +61,7 @@ impl<'b> AsyncSearchDeleteParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Async Search Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/async-search.html)\n\nDeletes an async search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted."]
 pub struct AsyncSearchDelete<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: AsyncSearchDeleteParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -71,10 +72,10 @@ pub struct AsyncSearchDelete<'a, 'b> {
 }
 impl<'a, 'b> AsyncSearchDelete<'a, 'b> {
     #[doc = "Creates a new instance of [AsyncSearchDelete] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: AsyncSearchDeleteParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: AsyncSearchDeleteParts<'b>) -> Self {
         let headers = HeaderMap::new();
         AsyncSearchDelete {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -148,7 +149,7 @@ impl<'a, 'b> AsyncSearchDelete<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -177,7 +178,7 @@ impl<'b> AsyncSearchGetParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Async Search Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/async-search.html)\n\nRetrieves the results of a previously submitted async search request given its ID."]
 pub struct AsyncSearchGet<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: AsyncSearchGetParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -191,10 +192,10 @@ pub struct AsyncSearchGet<'a, 'b> {
 }
 impl<'a, 'b> AsyncSearchGet<'a, 'b> {
     #[doc = "Creates a new instance of [AsyncSearchGet] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: AsyncSearchGetParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: AsyncSearchGetParts<'b>) -> Self {
         let headers = HeaderMap::new();
         AsyncSearchGet {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -295,7 +296,7 @@ impl<'a, 'b> AsyncSearchGet<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -330,7 +331,7 @@ impl<'b> AsyncSearchSubmitParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Async Search Submit API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/async-search.html)\n\nExecutes a search request asynchronously."]
 pub struct AsyncSearchSubmit<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: AsyncSearchSubmitParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -386,10 +387,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [AsyncSearchSubmit] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: AsyncSearchSubmitParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: AsyncSearchSubmitParts<'b>) -> Self {
         let headers = HeaderMap::new();
         AsyncSearchSubmit {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -487,7 +488,7 @@ where
         T: Serialize,
     {
         AsyncSearchSubmit {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             _source: self._source,
@@ -912,7 +913,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -920,32 +921,35 @@ where
 }
 #[doc = "Namespace client for AsyncSearch APIs"]
 pub struct AsyncSearch<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> AsyncSearch<'a> {
     #[doc = "Creates a new instance of [AsyncSearch]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Async Search Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/async-search.html)\n\nDeletes an async search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted."]
     pub fn delete<'b>(&'a self, parts: AsyncSearchDeleteParts<'b>) -> AsyncSearchDelete<'a, 'b> {
-        AsyncSearchDelete::new(&self.client, parts)
+        AsyncSearchDelete::new(self.transport(), parts)
     }
     #[doc = "[Async Search Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/async-search.html)\n\nRetrieves the results of a previously submitted async search request given its ID."]
     pub fn get<'b>(&'a self, parts: AsyncSearchGetParts<'b>) -> AsyncSearchGet<'a, 'b> {
-        AsyncSearchGet::new(&self.client, parts)
+        AsyncSearchGet::new(self.transport(), parts)
     }
     #[doc = "[Async Search Submit API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/async-search.html)\n\nExecutes a search request asynchronously."]
     pub fn submit<'b>(
         &'a self,
         parts: AsyncSearchSubmitParts<'b>,
     ) -> AsyncSearchSubmit<'a, 'b, ()> {
-        AsyncSearchSubmit::new(&self.client, parts)
+        AsyncSearchSubmit::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for AsyncSearch APIs"]
     pub fn async_search(&self) -> AsyncSearch {
-        AsyncSearch::new(&self)
+        AsyncSearch::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/cat.rs
+++ b/elasticsearch/src/generated/namespace_clients/cat.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -65,7 +66,7 @@ impl<'b> CatAliasesParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Aliases API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-alias.html)\n\nShows information about currently configured aliases to indices including filter and routing infos."]
 pub struct CatAliases<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatAliasesParts<'b>,
     error_trace: Option<bool>,
     expand_wildcards: Option<&'b [ExpandWildcards]>,
@@ -83,12 +84,12 @@ pub struct CatAliases<'a, 'b> {
 }
 impl<'a, 'b> CatAliases<'a, 'b> {
     #[doc = "Creates a new instance of [CatAliases] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatAliasesParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatAliasesParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatAliases {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -228,7 +229,7 @@ impl<'a, 'b> CatAliases<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -262,7 +263,7 @@ impl<'b> CatAllocationParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Allocation API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-allocation.html)\n\nProvides a snapshot of how many shards are allocated to each data node and how much disk space they are using."]
 pub struct CatAllocation<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatAllocationParts<'b>,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
@@ -281,12 +282,12 @@ pub struct CatAllocation<'a, 'b> {
 }
 impl<'a, 'b> CatAllocation<'a, 'b> {
     #[doc = "Creates a new instance of [CatAllocation] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatAllocationParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatAllocationParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatAllocation {
-            client,
+            transport,
             parts,
             headers,
             bytes: None,
@@ -432,7 +433,7 @@ impl<'a, 'b> CatAllocation<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -466,7 +467,7 @@ impl<'b> CatCountParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Count API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-count.html)\n\nProvides quick access to the document count of the entire cluster, or individual indices."]
 pub struct CatCount<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatCountParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -482,12 +483,12 @@ pub struct CatCount<'a, 'b> {
 }
 impl<'a, 'b> CatCount<'a, 'b> {
     #[doc = "Creates a new instance of [CatCount] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatCountParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatCountParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatCount {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -606,7 +607,7 @@ impl<'a, 'b> CatCount<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -640,7 +641,7 @@ impl<'b> CatFielddataParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Fielddata API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-fielddata.html)\n\nShows how much heap memory is currently being used by fielddata on every data node in the cluster."]
 pub struct CatFielddata<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatFielddataParts<'b>,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
@@ -658,12 +659,12 @@ pub struct CatFielddata<'a, 'b> {
 }
 impl<'a, 'b> CatFielddata<'a, 'b> {
     #[doc = "Creates a new instance of [CatFielddata] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatFielddataParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatFielddataParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatFielddata {
-            client,
+            transport,
             parts,
             headers,
             bytes: None,
@@ -800,7 +801,7 @@ impl<'a, 'b> CatFielddata<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -823,7 +824,7 @@ impl CatHealthParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Health API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-health.html)\n\nReturns a concise representation of the cluster health."]
 pub struct CatHealth<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatHealthParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -841,12 +842,12 @@ pub struct CatHealth<'a, 'b> {
 }
 impl<'a, 'b> CatHealth<'a, 'b> {
     #[doc = "Creates a new instance of [CatHealth]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatHealth {
-            client,
+            transport,
             parts: CatHealthParts::None,
             headers,
             error_trace: None,
@@ -983,7 +984,7 @@ impl<'a, 'b> CatHealth<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1006,7 +1007,7 @@ impl CatHelpParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Help API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat.html)\n\nReturns help for the Cat APIs."]
 pub struct CatHelp<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatHelpParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1019,12 +1020,12 @@ pub struct CatHelp<'a, 'b> {
 }
 impl<'a, 'b> CatHelp<'a, 'b> {
     #[doc = "Creates a new instance of [CatHelp]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatHelp {
-            client,
+            transport,
             parts: CatHelpParts::None,
             headers,
             error_trace: None,
@@ -1116,7 +1117,7 @@ impl<'a, 'b> CatHelp<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1150,7 +1151,7 @@ impl<'b> CatIndicesParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Indices API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-indices.html)\n\nReturns information about indices: number of primaries and replicas, document counts, disk size, ..."]
 pub struct CatIndices<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatIndicesParts<'b>,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
@@ -1174,12 +1175,12 @@ pub struct CatIndices<'a, 'b> {
 }
 impl<'a, 'b> CatIndices<'a, 'b> {
     #[doc = "Creates a new instance of [CatIndices] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatIndicesParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatIndicesParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatIndices {
-            client,
+            transport,
             parts,
             headers,
             bytes: None,
@@ -1373,7 +1374,7 @@ impl<'a, 'b> CatIndices<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1396,7 +1397,7 @@ impl CatMasterParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Master API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-master.html)\n\nReturns information about the master node."]
 pub struct CatMaster<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatMasterParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1414,12 +1415,12 @@ pub struct CatMaster<'a, 'b> {
 }
 impl<'a, 'b> CatMaster<'a, 'b> {
     #[doc = "Creates a new instance of [CatMaster]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatMaster {
-            client,
+            transport,
             parts: CatMasterParts::None,
             headers,
             error_trace: None,
@@ -1556,7 +1557,7 @@ impl<'a, 'b> CatMaster<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1588,7 +1589,7 @@ impl<'b> CatMlDataFrameAnalyticsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Ml Data Frame Analytics API](http://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-dfanalytics.html)\n\nGets configuration and usage information about data frame analytics jobs."]
 pub struct CatMlDataFrameAnalytics<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatMlDataFrameAnalyticsParts<'b>,
     allow_no_match: Option<bool>,
     bytes: Option<Bytes>,
@@ -1607,12 +1608,12 @@ pub struct CatMlDataFrameAnalytics<'a, 'b> {
 }
 impl<'a, 'b> CatMlDataFrameAnalytics<'a, 'b> {
     #[doc = "Creates a new instance of [CatMlDataFrameAnalytics] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatMlDataFrameAnalyticsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatMlDataFrameAnalyticsParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatMlDataFrameAnalytics {
-            client,
+            transport,
             parts,
             headers,
             allow_no_match: None,
@@ -1758,7 +1759,7 @@ impl<'a, 'b> CatMlDataFrameAnalytics<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1791,7 +1792,7 @@ impl<'b> CatMlDatafeedsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Ml Datafeeds API](http://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-datafeeds.html)\n\nGets configuration and usage information about datafeeds."]
 pub struct CatMlDatafeeds<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatMlDatafeedsParts<'b>,
     allow_no_datafeeds: Option<bool>,
     error_trace: Option<bool>,
@@ -1809,12 +1810,12 @@ pub struct CatMlDatafeeds<'a, 'b> {
 }
 impl<'a, 'b> CatMlDatafeeds<'a, 'b> {
     #[doc = "Creates a new instance of [CatMlDatafeeds] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatMlDatafeedsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatMlDatafeedsParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatMlDatafeeds {
-            client,
+            transport,
             parts,
             headers,
             allow_no_datafeeds: None,
@@ -1951,7 +1952,7 @@ impl<'a, 'b> CatMlDatafeeds<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1984,7 +1985,7 @@ impl<'b> CatMlJobsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Ml Jobs API](http://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-anomaly-detectors.html)\n\nGets configuration and usage information about anomaly detection jobs."]
 pub struct CatMlJobs<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatMlJobsParts<'b>,
     allow_no_jobs: Option<bool>,
     bytes: Option<Bytes>,
@@ -2003,12 +2004,12 @@ pub struct CatMlJobs<'a, 'b> {
 }
 impl<'a, 'b> CatMlJobs<'a, 'b> {
     #[doc = "Creates a new instance of [CatMlJobs] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatMlJobsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatMlJobsParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatMlJobs {
-            client,
+            transport,
             parts,
             headers,
             allow_no_jobs: None,
@@ -2154,7 +2155,7 @@ impl<'a, 'b> CatMlJobs<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2187,7 +2188,7 @@ impl<'b> CatMlTrainedModelsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Ml Trained Models API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-trained-model.html)\n\nGets configuration and usage information about inference trained models."]
 pub struct CatMlTrainedModels<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatMlTrainedModelsParts<'b>,
     allow_no_match: Option<bool>,
     bytes: Option<Bytes>,
@@ -2208,12 +2209,12 @@ pub struct CatMlTrainedModels<'a, 'b> {
 }
 impl<'a, 'b> CatMlTrainedModels<'a, 'b> {
     #[doc = "Creates a new instance of [CatMlTrainedModels] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatMlTrainedModelsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatMlTrainedModelsParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatMlTrainedModels {
-            client,
+            transport,
             parts,
             headers,
             allow_no_match: None,
@@ -2377,7 +2378,7 @@ impl<'a, 'b> CatMlTrainedModels<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2400,7 +2401,7 @@ impl CatNodeattrsParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Nodeattrs API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-nodeattrs.html)\n\nReturns information about custom node attributes."]
 pub struct CatNodeattrs<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatNodeattrsParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -2418,12 +2419,12 @@ pub struct CatNodeattrs<'a, 'b> {
 }
 impl<'a, 'b> CatNodeattrs<'a, 'b> {
     #[doc = "Creates a new instance of [CatNodeattrs]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatNodeattrs {
-            client,
+            transport,
             parts: CatNodeattrsParts::None,
             headers,
             error_trace: None,
@@ -2560,7 +2561,7 @@ impl<'a, 'b> CatNodeattrs<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2583,7 +2584,7 @@ impl CatNodesParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Nodes API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-nodes.html)\n\nReturns basic statistics about performance of cluster nodes."]
 pub struct CatNodes<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatNodesParts,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
@@ -2603,12 +2604,12 @@ pub struct CatNodes<'a, 'b> {
 }
 impl<'a, 'b> CatNodes<'a, 'b> {
     #[doc = "Creates a new instance of [CatNodes]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatNodes {
-            client,
+            transport,
             parts: CatNodesParts::None,
             headers,
             bytes: None,
@@ -2763,7 +2764,7 @@ impl<'a, 'b> CatNodes<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2786,7 +2787,7 @@ impl CatPendingTasksParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Pending Tasks API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-pending-tasks.html)\n\nReturns a concise representation of the cluster pending tasks."]
 pub struct CatPendingTasks<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatPendingTasksParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -2805,12 +2806,12 @@ pub struct CatPendingTasks<'a, 'b> {
 }
 impl<'a, 'b> CatPendingTasks<'a, 'b> {
     #[doc = "Creates a new instance of [CatPendingTasks]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatPendingTasks {
-            client,
+            transport,
             parts: CatPendingTasksParts::None,
             headers,
             error_trace: None,
@@ -2956,7 +2957,7 @@ impl<'a, 'b> CatPendingTasks<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2979,7 +2980,7 @@ impl CatPluginsParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Plugins API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-plugins.html)\n\nReturns information about installed plugins across nodes node."]
 pub struct CatPlugins<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatPluginsParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -2997,12 +2998,12 @@ pub struct CatPlugins<'a, 'b> {
 }
 impl<'a, 'b> CatPlugins<'a, 'b> {
     #[doc = "Creates a new instance of [CatPlugins]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatPlugins {
-            client,
+            transport,
             parts: CatPluginsParts::None,
             headers,
             error_trace: None,
@@ -3139,7 +3140,7 @@ impl<'a, 'b> CatPlugins<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3173,7 +3174,7 @@ impl<'b> CatRecoveryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Recovery API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-recovery.html)\n\nReturns information about index shard recoveries, both on-going completed."]
 pub struct CatRecovery<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatRecoveryParts<'b>,
     active_only: Option<bool>,
     bytes: Option<Bytes>,
@@ -3194,12 +3195,12 @@ pub struct CatRecovery<'a, 'b> {
 }
 impl<'a, 'b> CatRecovery<'a, 'b> {
     #[doc = "Creates a new instance of [CatRecovery] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatRecoveryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatRecoveryParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatRecovery {
-            client,
+            transport,
             parts,
             headers,
             active_only: None,
@@ -3363,7 +3364,7 @@ impl<'a, 'b> CatRecovery<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3386,7 +3387,7 @@ impl CatRepositoriesParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Repositories API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-repositories.html)\n\nReturns information about snapshot repositories registered in the cluster."]
 pub struct CatRepositories<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatRepositoriesParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -3404,12 +3405,12 @@ pub struct CatRepositories<'a, 'b> {
 }
 impl<'a, 'b> CatRepositories<'a, 'b> {
     #[doc = "Creates a new instance of [CatRepositories]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatRepositories {
-            client,
+            transport,
             parts: CatRepositoriesParts::None,
             headers,
             error_trace: None,
@@ -3546,7 +3547,7 @@ impl<'a, 'b> CatRepositories<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3580,7 +3581,7 @@ impl<'b> CatSegmentsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Segments API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-segments.html)\n\nProvides low-level information about the segments in the shards of an index."]
 pub struct CatSegments<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatSegmentsParts<'b>,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
@@ -3597,12 +3598,12 @@ pub struct CatSegments<'a, 'b> {
 }
 impl<'a, 'b> CatSegments<'a, 'b> {
     #[doc = "Creates a new instance of [CatSegments] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatSegmentsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatSegmentsParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatSegments {
-            client,
+            transport,
             parts,
             headers,
             bytes: None,
@@ -3730,7 +3731,7 @@ impl<'a, 'b> CatSegments<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3764,7 +3765,7 @@ impl<'b> CatShardsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Shards API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-shards.html)\n\nProvides a detailed view of shard allocation on nodes."]
 pub struct CatShards<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatShardsParts<'b>,
     bytes: Option<Bytes>,
     error_trace: Option<bool>,
@@ -3784,12 +3785,12 @@ pub struct CatShards<'a, 'b> {
 }
 impl<'a, 'b> CatShards<'a, 'b> {
     #[doc = "Creates a new instance of [CatShards] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatShardsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatShardsParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatShards {
-            client,
+            transport,
             parts,
             headers,
             bytes: None,
@@ -3944,7 +3945,7 @@ impl<'a, 'b> CatShards<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3978,7 +3979,7 @@ impl<'b> CatSnapshotsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Snapshots API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-snapshots.html)\n\nReturns all snapshots in a specific repository."]
 pub struct CatSnapshots<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatSnapshotsParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -3997,12 +3998,12 @@ pub struct CatSnapshots<'a, 'b> {
 }
 impl<'a, 'b> CatSnapshots<'a, 'b> {
     #[doc = "Creates a new instance of [CatSnapshots] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatSnapshotsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatSnapshotsParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatSnapshots {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -4148,7 +4149,7 @@ impl<'a, 'b> CatSnapshots<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4171,7 +4172,7 @@ impl CatTasksParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Tasks API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html)\n\nReturns information about the tasks currently executing on one or more nodes in the cluster."]
 pub struct CatTasks<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatTasksParts,
     actions: Option<&'b [&'b str]>,
     detailed: Option<bool>,
@@ -4192,12 +4193,12 @@ pub struct CatTasks<'a, 'b> {
 }
 impl<'a, 'b> CatTasks<'a, 'b> {
     #[doc = "Creates a new instance of [CatTasks]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatTasks {
-            client,
+            transport,
             parts: CatTasksParts::None,
             headers,
             actions: None,
@@ -4367,7 +4368,7 @@ impl<'a, 'b> CatTasks<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4399,7 +4400,7 @@ impl<'b> CatTemplatesParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Templates API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-templates.html)\n\nReturns information about existing templates."]
 pub struct CatTemplates<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatTemplatesParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -4417,12 +4418,12 @@ pub struct CatTemplates<'a, 'b> {
 }
 impl<'a, 'b> CatTemplates<'a, 'b> {
     #[doc = "Creates a new instance of [CatTemplates] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatTemplatesParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatTemplatesParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatTemplates {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -4559,7 +4560,7 @@ impl<'a, 'b> CatTemplates<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4593,7 +4594,7 @@ impl<'b> CatThreadPoolParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Thread Pool API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-thread-pool.html)\n\nReturns cluster-wide thread pool statistics per node.\nBy default the active, queue and rejected statistics are returned for all thread pools."]
 pub struct CatThreadPool<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatThreadPoolParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -4612,12 +4613,12 @@ pub struct CatThreadPool<'a, 'b> {
 }
 impl<'a, 'b> CatThreadPool<'a, 'b> {
     #[doc = "Creates a new instance of [CatThreadPool] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatThreadPoolParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatThreadPoolParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatThreadPool {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -4763,7 +4764,7 @@ impl<'a, 'b> CatThreadPool<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4796,7 +4797,7 @@ impl<'b> CatTransformsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cat Transforms API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-transforms.html)\n\nGets configuration and usage information about transforms."]
 pub struct CatTransforms<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CatTransformsParts<'b>,
     allow_no_match: Option<bool>,
     error_trace: Option<bool>,
@@ -4816,12 +4817,12 @@ pub struct CatTransforms<'a, 'b> {
 }
 impl<'a, 'b> CatTransforms<'a, 'b> {
     #[doc = "Creates a new instance of [CatTransforms] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CatTransformsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CatTransformsParts<'b>) -> Self {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         CatTransforms {
-            client,
+            transport,
             parts,
             headers,
             allow_no_match: None,
@@ -4976,7 +4977,7 @@ impl<'a, 'b> CatTransforms<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4984,123 +4985,126 @@ impl<'a, 'b> CatTransforms<'a, 'b> {
 }
 #[doc = "Namespace client for Cat APIs"]
 pub struct Cat<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Cat<'a> {
     #[doc = "Creates a new instance of [Cat]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Cat Aliases API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-alias.html)\n\nShows information about currently configured aliases to indices including filter and routing infos."]
     pub fn aliases<'b>(&'a self, parts: CatAliasesParts<'b>) -> CatAliases<'a, 'b> {
-        CatAliases::new(&self.client, parts)
+        CatAliases::new(self.transport(), parts)
     }
     #[doc = "[Cat Allocation API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-allocation.html)\n\nProvides a snapshot of how many shards are allocated to each data node and how much disk space they are using."]
     pub fn allocation<'b>(&'a self, parts: CatAllocationParts<'b>) -> CatAllocation<'a, 'b> {
-        CatAllocation::new(&self.client, parts)
+        CatAllocation::new(self.transport(), parts)
     }
     #[doc = "[Cat Count API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-count.html)\n\nProvides quick access to the document count of the entire cluster, or individual indices."]
     pub fn count<'b>(&'a self, parts: CatCountParts<'b>) -> CatCount<'a, 'b> {
-        CatCount::new(&self.client, parts)
+        CatCount::new(self.transport(), parts)
     }
     #[doc = "[Cat Fielddata API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-fielddata.html)\n\nShows how much heap memory is currently being used by fielddata on every data node in the cluster."]
     pub fn fielddata<'b>(&'a self, parts: CatFielddataParts<'b>) -> CatFielddata<'a, 'b> {
-        CatFielddata::new(&self.client, parts)
+        CatFielddata::new(self.transport(), parts)
     }
     #[doc = "[Cat Health API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-health.html)\n\nReturns a concise representation of the cluster health."]
     pub fn health<'b>(&'a self) -> CatHealth<'a, 'b> {
-        CatHealth::new(&self.client)
+        CatHealth::new(self.transport())
     }
     #[doc = "[Cat Help API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat.html)\n\nReturns help for the Cat APIs."]
     pub fn help<'b>(&'a self) -> CatHelp<'a, 'b> {
-        CatHelp::new(&self.client)
+        CatHelp::new(self.transport())
     }
     #[doc = "[Cat Indices API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-indices.html)\n\nReturns information about indices: number of primaries and replicas, document counts, disk size, ..."]
     pub fn indices<'b>(&'a self, parts: CatIndicesParts<'b>) -> CatIndices<'a, 'b> {
-        CatIndices::new(&self.client, parts)
+        CatIndices::new(self.transport(), parts)
     }
     #[doc = "[Cat Master API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-master.html)\n\nReturns information about the master node."]
     pub fn master<'b>(&'a self) -> CatMaster<'a, 'b> {
-        CatMaster::new(&self.client)
+        CatMaster::new(self.transport())
     }
     #[doc = "[Cat Ml Data Frame Analytics API](http://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-dfanalytics.html)\n\nGets configuration and usage information about data frame analytics jobs."]
     pub fn ml_data_frame_analytics<'b>(
         &'a self,
         parts: CatMlDataFrameAnalyticsParts<'b>,
     ) -> CatMlDataFrameAnalytics<'a, 'b> {
-        CatMlDataFrameAnalytics::new(&self.client, parts)
+        CatMlDataFrameAnalytics::new(self.transport(), parts)
     }
     #[doc = "[Cat Ml Datafeeds API](http://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-datafeeds.html)\n\nGets configuration and usage information about datafeeds."]
     pub fn ml_datafeeds<'b>(&'a self, parts: CatMlDatafeedsParts<'b>) -> CatMlDatafeeds<'a, 'b> {
-        CatMlDatafeeds::new(&self.client, parts)
+        CatMlDatafeeds::new(self.transport(), parts)
     }
     #[doc = "[Cat Ml Jobs API](http://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-anomaly-detectors.html)\n\nGets configuration and usage information about anomaly detection jobs."]
     pub fn ml_jobs<'b>(&'a self, parts: CatMlJobsParts<'b>) -> CatMlJobs<'a, 'b> {
-        CatMlJobs::new(&self.client, parts)
+        CatMlJobs::new(self.transport(), parts)
     }
     #[doc = "[Cat Ml Trained Models API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-trained-model.html)\n\nGets configuration and usage information about inference trained models."]
     pub fn ml_trained_models<'b>(
         &'a self,
         parts: CatMlTrainedModelsParts<'b>,
     ) -> CatMlTrainedModels<'a, 'b> {
-        CatMlTrainedModels::new(&self.client, parts)
+        CatMlTrainedModels::new(self.transport(), parts)
     }
     #[doc = "[Cat Nodeattrs API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-nodeattrs.html)\n\nReturns information about custom node attributes."]
     pub fn nodeattrs<'b>(&'a self) -> CatNodeattrs<'a, 'b> {
-        CatNodeattrs::new(&self.client)
+        CatNodeattrs::new(self.transport())
     }
     #[doc = "[Cat Nodes API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-nodes.html)\n\nReturns basic statistics about performance of cluster nodes."]
     pub fn nodes<'b>(&'a self) -> CatNodes<'a, 'b> {
-        CatNodes::new(&self.client)
+        CatNodes::new(self.transport())
     }
     #[doc = "[Cat Pending Tasks API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-pending-tasks.html)\n\nReturns a concise representation of the cluster pending tasks."]
     pub fn pending_tasks<'b>(&'a self) -> CatPendingTasks<'a, 'b> {
-        CatPendingTasks::new(&self.client)
+        CatPendingTasks::new(self.transport())
     }
     #[doc = "[Cat Plugins API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-plugins.html)\n\nReturns information about installed plugins across nodes node."]
     pub fn plugins<'b>(&'a self) -> CatPlugins<'a, 'b> {
-        CatPlugins::new(&self.client)
+        CatPlugins::new(self.transport())
     }
     #[doc = "[Cat Recovery API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-recovery.html)\n\nReturns information about index shard recoveries, both on-going completed."]
     pub fn recovery<'b>(&'a self, parts: CatRecoveryParts<'b>) -> CatRecovery<'a, 'b> {
-        CatRecovery::new(&self.client, parts)
+        CatRecovery::new(self.transport(), parts)
     }
     #[doc = "[Cat Repositories API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-repositories.html)\n\nReturns information about snapshot repositories registered in the cluster."]
     pub fn repositories<'b>(&'a self) -> CatRepositories<'a, 'b> {
-        CatRepositories::new(&self.client)
+        CatRepositories::new(self.transport())
     }
     #[doc = "[Cat Segments API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-segments.html)\n\nProvides low-level information about the segments in the shards of an index."]
     pub fn segments<'b>(&'a self, parts: CatSegmentsParts<'b>) -> CatSegments<'a, 'b> {
-        CatSegments::new(&self.client, parts)
+        CatSegments::new(self.transport(), parts)
     }
     #[doc = "[Cat Shards API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-shards.html)\n\nProvides a detailed view of shard allocation on nodes."]
     pub fn shards<'b>(&'a self, parts: CatShardsParts<'b>) -> CatShards<'a, 'b> {
-        CatShards::new(&self.client, parts)
+        CatShards::new(self.transport(), parts)
     }
     #[doc = "[Cat Snapshots API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-snapshots.html)\n\nReturns all snapshots in a specific repository."]
     pub fn snapshots<'b>(&'a self, parts: CatSnapshotsParts<'b>) -> CatSnapshots<'a, 'b> {
-        CatSnapshots::new(&self.client, parts)
+        CatSnapshots::new(self.transport(), parts)
     }
     #[doc = "[Cat Tasks API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html)\n\nReturns information about the tasks currently executing on one or more nodes in the cluster."]
     pub fn tasks<'b>(&'a self) -> CatTasks<'a, 'b> {
-        CatTasks::new(&self.client)
+        CatTasks::new(self.transport())
     }
     #[doc = "[Cat Templates API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-templates.html)\n\nReturns information about existing templates."]
     pub fn templates<'b>(&'a self, parts: CatTemplatesParts<'b>) -> CatTemplates<'a, 'b> {
-        CatTemplates::new(&self.client, parts)
+        CatTemplates::new(self.transport(), parts)
     }
     #[doc = "[Cat Thread Pool API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-thread-pool.html)\n\nReturns cluster-wide thread pool statistics per node.\nBy default the active, queue and rejected statistics are returned for all thread pools."]
     pub fn thread_pool<'b>(&'a self, parts: CatThreadPoolParts<'b>) -> CatThreadPool<'a, 'b> {
-        CatThreadPool::new(&self.client, parts)
+        CatThreadPool::new(self.transport(), parts)
     }
     #[doc = "[Cat Transforms API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cat-transforms.html)\n\nGets configuration and usage information about transforms."]
     pub fn transforms<'b>(&'a self, parts: CatTransformsParts<'b>) -> CatTransforms<'a, 'b> {
-        CatTransforms::new(&self.client, parts)
+        CatTransforms::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Cat APIs"]
     pub fn cat(&self) -> Cat {
-        Cat::new(&self)
+        Cat::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/ccr.rs
+++ b/elasticsearch/src/generated/namespace_clients/ccr.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -60,7 +61,7 @@ impl<'b> CcrDeleteAutoFollowPatternParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Delete Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-delete-auto-follow-pattern.html)\n\nDeletes auto-follow patterns."]
 pub struct CcrDeleteAutoFollowPattern<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrDeleteAutoFollowPatternParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -71,10 +72,10 @@ pub struct CcrDeleteAutoFollowPattern<'a, 'b> {
 }
 impl<'a, 'b> CcrDeleteAutoFollowPattern<'a, 'b> {
     #[doc = "Creates a new instance of [CcrDeleteAutoFollowPattern] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrDeleteAutoFollowPatternParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrDeleteAutoFollowPatternParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrDeleteAutoFollowPattern {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -148,7 +149,7 @@ impl<'a, 'b> CcrDeleteAutoFollowPattern<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -179,7 +180,7 @@ impl<'b> CcrFollowParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Follow API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-put-follow.html)\n\nCreates a new follower index configured to follow the referenced leader index."]
 pub struct CcrFollow<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrFollowParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -195,10 +196,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrFollow] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrFollowParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrFollowParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrFollow {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -216,7 +217,7 @@ where
         T: Serialize,
     {
         CcrFollow {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -300,7 +301,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -332,7 +333,7 @@ impl<'b> CcrFollowInfoParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Follow Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-follow-info.html)\n\nRetrieves information about all follower indices, including parameters and status for each follower index"]
 pub struct CcrFollowInfo<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrFollowInfoParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -343,10 +344,10 @@ pub struct CcrFollowInfo<'a, 'b> {
 }
 impl<'a, 'b> CcrFollowInfo<'a, 'b> {
     #[doc = "Creates a new instance of [CcrFollowInfo] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrFollowInfoParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrFollowInfoParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrFollowInfo {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -420,7 +421,7 @@ impl<'a, 'b> CcrFollowInfo<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -452,7 +453,7 @@ impl<'b> CcrFollowStatsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Follow Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-follow-stats.html)\n\nRetrieves follower stats. return shard-level stats about the following tasks associated with each shard for the specified indices."]
 pub struct CcrFollowStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrFollowStatsParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -463,10 +464,10 @@ pub struct CcrFollowStats<'a, 'b> {
 }
 impl<'a, 'b> CcrFollowStats<'a, 'b> {
     #[doc = "Creates a new instance of [CcrFollowStats] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrFollowStatsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrFollowStatsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrFollowStats {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -540,7 +541,7 @@ impl<'a, 'b> CcrFollowStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -571,7 +572,7 @@ impl<'b> CcrForgetFollowerParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Forget Follower API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-forget-follower.html)\n\nRemoves the follower retention leases from the leader."]
 pub struct CcrForgetFollower<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrForgetFollowerParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -586,10 +587,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrForgetFollower] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrForgetFollowerParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrForgetFollowerParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrForgetFollower {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -606,7 +607,7 @@ where
         T: Serialize,
     {
         CcrForgetFollower {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -681,7 +682,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -713,7 +714,7 @@ impl<'b> CcrGetAutoFollowPatternParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Get Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-auto-follow-pattern.html)\n\nGets configured auto-follow patterns. Returns the specified auto-follow pattern collection."]
 pub struct CcrGetAutoFollowPattern<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrGetAutoFollowPatternParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -724,10 +725,10 @@ pub struct CcrGetAutoFollowPattern<'a, 'b> {
 }
 impl<'a, 'b> CcrGetAutoFollowPattern<'a, 'b> {
     #[doc = "Creates a new instance of [CcrGetAutoFollowPattern] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrGetAutoFollowPatternParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrGetAutoFollowPatternParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrGetAutoFollowPattern {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -801,7 +802,7 @@ impl<'a, 'b> CcrGetAutoFollowPattern<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -831,7 +832,7 @@ impl<'b> CcrPauseAutoFollowPatternParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Pause Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-pause-auto-follow-pattern.html)\n\nPauses an auto-follow pattern"]
 pub struct CcrPauseAutoFollowPattern<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrPauseAutoFollowPatternParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -846,10 +847,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrPauseAutoFollowPattern] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrPauseAutoFollowPatternParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrPauseAutoFollowPatternParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrPauseAutoFollowPattern {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -866,7 +867,7 @@ where
         T: Serialize,
     {
         CcrPauseAutoFollowPattern {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -941,7 +942,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -972,7 +973,7 @@ impl<'b> CcrPauseFollowParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Pause Follow API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-pause-follow.html)\n\nPauses a follower index. The follower index will not fetch any additional operations from the leader index."]
 pub struct CcrPauseFollow<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrPauseFollowParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -987,10 +988,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrPauseFollow] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrPauseFollowParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrPauseFollowParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrPauseFollow {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1007,7 +1008,7 @@ where
         T: Serialize,
     {
         CcrPauseFollow {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1082,7 +1083,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1111,7 +1112,7 @@ impl<'b> CcrPutAutoFollowPatternParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Put Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-put-auto-follow-pattern.html)\n\nCreates a new named collection of auto-follow patterns against a specified remote cluster. Newly created indices on the remote cluster matching any of the specified patterns will be automatically configured as follower indices."]
 pub struct CcrPutAutoFollowPattern<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrPutAutoFollowPatternParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1126,10 +1127,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrPutAutoFollowPattern] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrPutAutoFollowPatternParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrPutAutoFollowPatternParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrPutAutoFollowPattern {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1146,7 +1147,7 @@ where
         T: Serialize,
     {
         CcrPutAutoFollowPattern {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1221,7 +1222,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1251,7 +1252,7 @@ impl<'b> CcrResumeAutoFollowPatternParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Resume Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-resume-auto-follow-pattern.html)\n\nResumes an auto-follow pattern that has been paused"]
 pub struct CcrResumeAutoFollowPattern<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrResumeAutoFollowPatternParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1266,10 +1267,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrResumeAutoFollowPattern] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrResumeAutoFollowPatternParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrResumeAutoFollowPatternParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrResumeAutoFollowPattern {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1286,7 +1287,7 @@ where
         T: Serialize,
     {
         CcrResumeAutoFollowPattern {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1361,7 +1362,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1392,7 +1393,7 @@ impl<'b> CcrResumeFollowParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Resume Follow API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-resume-follow.html)\n\nResumes a follower index that has been paused"]
 pub struct CcrResumeFollow<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrResumeFollowParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1407,10 +1408,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrResumeFollow] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrResumeFollowParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrResumeFollowParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrResumeFollow {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1427,7 +1428,7 @@ where
         T: Serialize,
     {
         CcrResumeFollow {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1502,7 +1503,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1525,7 +1526,7 @@ impl CcrStatsParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-stats.html)\n\nGets all stats related to cross-cluster replication."]
 pub struct CcrStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrStatsParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1536,10 +1537,10 @@ pub struct CcrStats<'a, 'b> {
 }
 impl<'a, 'b> CcrStats<'a, 'b> {
     #[doc = "Creates a new instance of [CcrStats]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         CcrStats {
-            client,
+            transport,
             parts: CcrStatsParts::None,
             headers,
             error_trace: None,
@@ -1613,7 +1614,7 @@ impl<'a, 'b> CcrStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1644,7 +1645,7 @@ impl<'b> CcrUnfollowParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ccr Unfollow API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-unfollow.html)\n\nStops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication."]
 pub struct CcrUnfollow<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CcrUnfollowParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1659,10 +1660,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [CcrUnfollow] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CcrUnfollowParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CcrUnfollowParts<'b>) -> Self {
         let headers = HeaderMap::new();
         CcrUnfollow {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1679,7 +1680,7 @@ where
         T: Serialize,
     {
         CcrUnfollow {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1754,7 +1755,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1762,93 +1763,96 @@ where
 }
 #[doc = "Namespace client for Cross Cluster Replication APIs"]
 pub struct Ccr<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Ccr<'a> {
     #[doc = "Creates a new instance of [Ccr]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Ccr Delete Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-delete-auto-follow-pattern.html)\n\nDeletes auto-follow patterns."]
     pub fn delete_auto_follow_pattern<'b>(
         &'a self,
         parts: CcrDeleteAutoFollowPatternParts<'b>,
     ) -> CcrDeleteAutoFollowPattern<'a, 'b> {
-        CcrDeleteAutoFollowPattern::new(&self.client, parts)
+        CcrDeleteAutoFollowPattern::new(self.transport(), parts)
     }
     #[doc = "[Ccr Follow API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-put-follow.html)\n\nCreates a new follower index configured to follow the referenced leader index."]
     pub fn follow<'b>(&'a self, parts: CcrFollowParts<'b>) -> CcrFollow<'a, 'b, ()> {
-        CcrFollow::new(&self.client, parts)
+        CcrFollow::new(self.transport(), parts)
     }
     #[doc = "[Ccr Follow Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-follow-info.html)\n\nRetrieves information about all follower indices, including parameters and status for each follower index"]
     pub fn follow_info<'b>(&'a self, parts: CcrFollowInfoParts<'b>) -> CcrFollowInfo<'a, 'b> {
-        CcrFollowInfo::new(&self.client, parts)
+        CcrFollowInfo::new(self.transport(), parts)
     }
     #[doc = "[Ccr Follow Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-follow-stats.html)\n\nRetrieves follower stats. return shard-level stats about the following tasks associated with each shard for the specified indices."]
     pub fn follow_stats<'b>(&'a self, parts: CcrFollowStatsParts<'b>) -> CcrFollowStats<'a, 'b> {
-        CcrFollowStats::new(&self.client, parts)
+        CcrFollowStats::new(self.transport(), parts)
     }
     #[doc = "[Ccr Forget Follower API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-forget-follower.html)\n\nRemoves the follower retention leases from the leader."]
     pub fn forget_follower<'b>(
         &'a self,
         parts: CcrForgetFollowerParts<'b>,
     ) -> CcrForgetFollower<'a, 'b, ()> {
-        CcrForgetFollower::new(&self.client, parts)
+        CcrForgetFollower::new(self.transport(), parts)
     }
     #[doc = "[Ccr Get Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-auto-follow-pattern.html)\n\nGets configured auto-follow patterns. Returns the specified auto-follow pattern collection."]
     pub fn get_auto_follow_pattern<'b>(
         &'a self,
         parts: CcrGetAutoFollowPatternParts<'b>,
     ) -> CcrGetAutoFollowPattern<'a, 'b> {
-        CcrGetAutoFollowPattern::new(&self.client, parts)
+        CcrGetAutoFollowPattern::new(self.transport(), parts)
     }
     #[doc = "[Ccr Pause Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-pause-auto-follow-pattern.html)\n\nPauses an auto-follow pattern"]
     pub fn pause_auto_follow_pattern<'b>(
         &'a self,
         parts: CcrPauseAutoFollowPatternParts<'b>,
     ) -> CcrPauseAutoFollowPattern<'a, 'b, ()> {
-        CcrPauseAutoFollowPattern::new(&self.client, parts)
+        CcrPauseAutoFollowPattern::new(self.transport(), parts)
     }
     #[doc = "[Ccr Pause Follow API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-pause-follow.html)\n\nPauses a follower index. The follower index will not fetch any additional operations from the leader index."]
     pub fn pause_follow<'b>(
         &'a self,
         parts: CcrPauseFollowParts<'b>,
     ) -> CcrPauseFollow<'a, 'b, ()> {
-        CcrPauseFollow::new(&self.client, parts)
+        CcrPauseFollow::new(self.transport(), parts)
     }
     #[doc = "[Ccr Put Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-put-auto-follow-pattern.html)\n\nCreates a new named collection of auto-follow patterns against a specified remote cluster. Newly created indices on the remote cluster matching any of the specified patterns will be automatically configured as follower indices."]
     pub fn put_auto_follow_pattern<'b>(
         &'a self,
         parts: CcrPutAutoFollowPatternParts<'b>,
     ) -> CcrPutAutoFollowPattern<'a, 'b, ()> {
-        CcrPutAutoFollowPattern::new(&self.client, parts)
+        CcrPutAutoFollowPattern::new(self.transport(), parts)
     }
     #[doc = "[Ccr Resume Auto Follow Pattern API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-resume-auto-follow-pattern.html)\n\nResumes an auto-follow pattern that has been paused"]
     pub fn resume_auto_follow_pattern<'b>(
         &'a self,
         parts: CcrResumeAutoFollowPatternParts<'b>,
     ) -> CcrResumeAutoFollowPattern<'a, 'b, ()> {
-        CcrResumeAutoFollowPattern::new(&self.client, parts)
+        CcrResumeAutoFollowPattern::new(self.transport(), parts)
     }
     #[doc = "[Ccr Resume Follow API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-resume-follow.html)\n\nResumes a follower index that has been paused"]
     pub fn resume_follow<'b>(
         &'a self,
         parts: CcrResumeFollowParts<'b>,
     ) -> CcrResumeFollow<'a, 'b, ()> {
-        CcrResumeFollow::new(&self.client, parts)
+        CcrResumeFollow::new(self.transport(), parts)
     }
     #[doc = "[Ccr Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-get-stats.html)\n\nGets all stats related to cross-cluster replication."]
     pub fn stats<'b>(&'a self) -> CcrStats<'a, 'b> {
-        CcrStats::new(&self.client)
+        CcrStats::new(self.transport())
     }
     #[doc = "[Ccr Unfollow API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ccr-post-unfollow.html)\n\nStops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication."]
     pub fn unfollow<'b>(&'a self, parts: CcrUnfollowParts<'b>) -> CcrUnfollow<'a, 'b, ()> {
-        CcrUnfollow::new(&self.client, parts)
+        CcrUnfollow::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Cross Cluster Replication APIs"]
     pub fn ccr(&self) -> Ccr {
-        Ccr::new(&self)
+        Ccr::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/cluster.rs
+++ b/elasticsearch/src/generated/namespace_clients/cluster.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -54,7 +55,7 @@ impl ClusterAllocationExplainParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Allocation Explain API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-allocation-explain.html)\n\nProvides explanations for shard allocations in the cluster."]
 pub struct ClusterAllocationExplain<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterAllocationExplainParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -71,10 +72,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [ClusterAllocationExplain]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         ClusterAllocationExplain {
-            client,
+            transport,
             parts: ClusterAllocationExplainParts::None,
             headers,
             body: None,
@@ -93,7 +94,7 @@ where
         T: Serialize,
     {
         ClusterAllocationExplain {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -189,144 +190,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Cluster Delete Component Template API"]
-pub enum ClusterDeleteComponentTemplateParts<'b> {
-    #[doc = "Name"]
-    Name(&'b str),
-}
-impl<'b> ClusterDeleteComponentTemplateParts<'b> {
-    #[doc = "Builds a relative URL path to the Cluster Delete Component Template API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            ClusterDeleteComponentTemplateParts::Name(ref name) => {
-                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
-                let mut p = String::with_capacity(21usize + encoded_name.len());
-                p.push_str("/_component_template/");
-                p.push_str(encoded_name.as_ref());
-                p.into()
-            }
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Cluster Delete Component Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html)\n\nDeletes a component template"]
-pub struct ClusterDeleteComponentTemplate<'a, 'b> {
-    client: &'a Elasticsearch,
-    parts: ClusterDeleteComponentTemplateParts<'b>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    master_timeout: Option<&'b str>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-    timeout: Option<&'b str>,
-}
-impl<'a, 'b> ClusterDeleteComponentTemplate<'a, 'b> {
-    #[doc = "Creates a new instance of [ClusterDeleteComponentTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ClusterDeleteComponentTemplateParts<'b>) -> Self {
-        let headers = HeaderMap::new();
-        ClusterDeleteComponentTemplate {
-            client,
-            parts,
-            headers,
-            error_trace: None,
-            filter_path: None,
-            human: None,
-            master_timeout: None,
-            pretty: None,
-            source: None,
-            timeout: None,
-        }
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
-        self.master_timeout = Some(master_timeout);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'b str) -> Self {
-        self.timeout = Some(timeout);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Cluster Delete Component Template API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = Method::Delete;
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'b str>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-                #[serde(rename = "timeout")]
-                timeout: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                human: self.human,
-                master_timeout: self.master_timeout,
-                pretty: self.pretty,
-                source: self.source,
-                timeout: self.timeout,
-            };
-            Some(query_params)
-        };
-        let body = Option::<()>::None;
-        let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -351,7 +215,7 @@ impl ClusterDeleteVotingConfigExclusionsParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Delete Voting Config Exclusions API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/voting-config-exclusions.html)\n\nClears cluster voting config exclusions."]
 pub struct ClusterDeleteVotingConfigExclusions<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterDeleteVotingConfigExclusionsParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -363,10 +227,10 @@ pub struct ClusterDeleteVotingConfigExclusions<'a, 'b> {
 }
 impl<'a, 'b> ClusterDeleteVotingConfigExclusions<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterDeleteVotingConfigExclusions]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         ClusterDeleteVotingConfigExclusions {
-            client,
+            transport,
             parts: ClusterDeleteVotingConfigExclusionsParts::None,
             headers,
             error_trace: None,
@@ -449,286 +313,7 @@ impl<'a, 'b> ClusterDeleteVotingConfigExclusions<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Cluster Exists Component Template API"]
-pub enum ClusterExistsComponentTemplateParts<'b> {
-    #[doc = "Name"]
-    Name(&'b str),
-}
-impl<'b> ClusterExistsComponentTemplateParts<'b> {
-    #[doc = "Builds a relative URL path to the Cluster Exists Component Template API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            ClusterExistsComponentTemplateParts::Name(ref name) => {
-                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
-                let mut p = String::with_capacity(21usize + encoded_name.len());
-                p.push_str("/_component_template/");
-                p.push_str(encoded_name.as_ref());
-                p.into()
-            }
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Cluster Exists Component Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html)\n\nReturns information about whether a particular component template exist"]
-pub struct ClusterExistsComponentTemplate<'a, 'b> {
-    client: &'a Elasticsearch,
-    parts: ClusterExistsComponentTemplateParts<'b>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    local: Option<bool>,
-    master_timeout: Option<&'b str>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-}
-impl<'a, 'b> ClusterExistsComponentTemplate<'a, 'b> {
-    #[doc = "Creates a new instance of [ClusterExistsComponentTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ClusterExistsComponentTemplateParts<'b>) -> Self {
-        let headers = HeaderMap::new();
-        ClusterExistsComponentTemplate {
-            client,
-            parts,
-            headers,
-            error_trace: None,
-            filter_path: None,
-            human: None,
-            local: None,
-            master_timeout: None,
-            pretty: None,
-            source: None,
-        }
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Return local information, do not retrieve the state from master node (default: false)"]
-    pub fn local(mut self, local: bool) -> Self {
-        self.local = Some(local);
-        self
-    }
-    #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
-        self.master_timeout = Some(master_timeout);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Cluster Exists Component Template API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = Method::Head;
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "local")]
-                local: Option<bool>,
-                #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'b str>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                human: self.human,
-                local: self.local,
-                master_timeout: self.master_timeout,
-                pretty: self.pretty,
-                source: self.source,
-            };
-            Some(query_params)
-        };
-        let body = Option::<()>::None;
-        let response = self
-            .client
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Cluster Get Component Template API"]
-pub enum ClusterGetComponentTemplateParts<'b> {
-    #[doc = "No parts"]
-    None,
-    #[doc = "Name"]
-    Name(&'b [&'b str]),
-}
-impl<'b> ClusterGetComponentTemplateParts<'b> {
-    #[doc = "Builds a relative URL path to the Cluster Get Component Template API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            ClusterGetComponentTemplateParts::None => "/_component_template".into(),
-            ClusterGetComponentTemplateParts::Name(ref name) => {
-                let name_str = name.join(",");
-                let encoded_name: Cow<str> =
-                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
-                let mut p = String::with_capacity(21usize + encoded_name.len());
-                p.push_str("/_component_template/");
-                p.push_str(encoded_name.as_ref());
-                p.into()
-            }
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Cluster Get Component Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html)\n\nReturns one or more component templates"]
-pub struct ClusterGetComponentTemplate<'a, 'b> {
-    client: &'a Elasticsearch,
-    parts: ClusterGetComponentTemplateParts<'b>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    local: Option<bool>,
-    master_timeout: Option<&'b str>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-}
-impl<'a, 'b> ClusterGetComponentTemplate<'a, 'b> {
-    #[doc = "Creates a new instance of [ClusterGetComponentTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ClusterGetComponentTemplateParts<'b>) -> Self {
-        let headers = HeaderMap::new();
-        ClusterGetComponentTemplate {
-            client,
-            parts,
-            headers,
-            error_trace: None,
-            filter_path: None,
-            human: None,
-            local: None,
-            master_timeout: None,
-            pretty: None,
-            source: None,
-        }
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Return local information, do not retrieve the state from master node (default: false)"]
-    pub fn local(mut self, local: bool) -> Self {
-        self.local = Some(local);
-        self
-    }
-    #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
-        self.master_timeout = Some(master_timeout);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Cluster Get Component Template API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = Method::Get;
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "local")]
-                local: Option<bool>,
-                #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'b str>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                human: self.human,
-                local: self.local,
-                master_timeout: self.master_timeout,
-                pretty: self.pretty,
-                source: self.source,
-            };
-            Some(query_params)
-        };
-        let body = Option::<()>::None;
-        let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -751,7 +336,7 @@ impl ClusterGetSettingsParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Get Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-update-settings.html)\n\nReturns cluster settings."]
 pub struct ClusterGetSettings<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterGetSettingsParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -766,10 +351,10 @@ pub struct ClusterGetSettings<'a, 'b> {
 }
 impl<'a, 'b> ClusterGetSettings<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterGetSettings]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         ClusterGetSettings {
-            client,
+            transport,
             parts: ClusterGetSettingsParts::None,
             headers,
             error_trace: None,
@@ -879,7 +464,7 @@ impl<'a, 'b> ClusterGetSettings<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -913,7 +498,7 @@ impl<'b> ClusterHealthParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Health API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-health.html)\n\nReturns basic information about the health of the cluster."]
 pub struct ClusterHealth<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterHealthParts<'b>,
     error_trace: Option<bool>,
     expand_wildcards: Option<&'b [ExpandWildcards]>,
@@ -935,10 +520,10 @@ pub struct ClusterHealth<'a, 'b> {
 }
 impl<'a, 'b> ClusterHealth<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterHealth] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ClusterHealthParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: ClusterHealthParts<'b>) -> Self {
         let headers = HeaderMap::new();
         ClusterHealth {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1117,7 +702,7 @@ impl<'a, 'b> ClusterHealth<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1140,7 +725,7 @@ impl ClusterPendingTasksParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Pending Tasks API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-pending.html)\n\nReturns a list of any cluster-level changes (e.g. create index, update mapping,\nallocate or fail shard) which have not yet been executed."]
 pub struct ClusterPendingTasks<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterPendingTasksParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1153,10 +738,10 @@ pub struct ClusterPendingTasks<'a, 'b> {
 }
 impl<'a, 'b> ClusterPendingTasks<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterPendingTasks]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         ClusterPendingTasks {
-            client,
+            transport,
             parts: ClusterPendingTasksParts::None,
             headers,
             error_trace: None,
@@ -1248,7 +833,7 @@ impl<'a, 'b> ClusterPendingTasks<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1273,7 +858,7 @@ impl ClusterPostVotingConfigExclusionsParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Post Voting Config Exclusions API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/voting-config-exclusions.html)\n\nUpdates the cluster voting config exclusions by node ids or node names."]
 pub struct ClusterPostVotingConfigExclusions<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterPostVotingConfigExclusionsParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1291,10 +876,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [ClusterPostVotingConfigExclusions]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         ClusterPostVotingConfigExclusions {
-            client,
+            transport,
             parts: ClusterPostVotingConfigExclusionsParts::None,
             headers,
             body: None,
@@ -1314,7 +899,7 @@ where
         T: Serialize,
     {
         ClusterPostVotingConfigExclusions {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1416,179 +1001,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Cluster Put Component Template API"]
-pub enum ClusterPutComponentTemplateParts<'b> {
-    #[doc = "Name"]
-    Name(&'b str),
-}
-impl<'b> ClusterPutComponentTemplateParts<'b> {
-    #[doc = "Builds a relative URL path to the Cluster Put Component Template API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            ClusterPutComponentTemplateParts::Name(ref name) => {
-                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
-                let mut p = String::with_capacity(21usize + encoded_name.len());
-                p.push_str("/_component_template/");
-                p.push_str(encoded_name.as_ref());
-                p.into()
-            }
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Cluster Put Component Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html)\n\nCreates or updates a component template"]
-pub struct ClusterPutComponentTemplate<'a, 'b, B> {
-    client: &'a Elasticsearch,
-    parts: ClusterPutComponentTemplateParts<'b>,
-    body: Option<B>,
-    create: Option<bool>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    master_timeout: Option<&'b str>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-    timeout: Option<&'b str>,
-}
-impl<'a, 'b, B> ClusterPutComponentTemplate<'a, 'b, B>
-where
-    B: Body,
-{
-    #[doc = "Creates a new instance of [ClusterPutComponentTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ClusterPutComponentTemplateParts<'b>) -> Self {
-        let headers = HeaderMap::new();
-        ClusterPutComponentTemplate {
-            client,
-            parts,
-            headers,
-            body: None,
-            create: None,
-            error_trace: None,
-            filter_path: None,
-            human: None,
-            master_timeout: None,
-            pretty: None,
-            source: None,
-            timeout: None,
-        }
-    }
-    #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> ClusterPutComponentTemplate<'a, 'b, JsonBody<T>>
-    where
-        T: Serialize,
-    {
-        ClusterPutComponentTemplate {
-            client: self.client,
-            parts: self.parts,
-            body: Some(body.into()),
-            create: self.create,
-            error_trace: self.error_trace,
-            filter_path: self.filter_path,
-            headers: self.headers,
-            human: self.human,
-            master_timeout: self.master_timeout,
-            pretty: self.pretty,
-            source: self.source,
-            timeout: self.timeout,
-        }
-    }
-    #[doc = "Whether the index template should only be added if new or can also replace an existing one"]
-    pub fn create(mut self, create: bool) -> Self {
-        self.create = Some(create);
-        self
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
-        self.master_timeout = Some(master_timeout);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'b str) -> Self {
-        self.timeout = Some(timeout);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Cluster Put Component Template API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = Method::Put;
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "create")]
-                create: Option<bool>,
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'b str>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-                #[serde(rename = "timeout")]
-                timeout: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                create: self.create,
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                human: self.human,
-                master_timeout: self.master_timeout,
-                pretty: self.pretty,
-                source: self.source,
-                timeout: self.timeout,
-            };
-            Some(query_params)
-        };
-        let body = self.body;
-        let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1611,7 +1024,7 @@ impl ClusterPutSettingsParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Put Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-update-settings.html)\n\nUpdates the cluster settings."]
 pub struct ClusterPutSettings<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterPutSettingsParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1629,10 +1042,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [ClusterPutSettings]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         ClusterPutSettings {
-            client,
+            transport,
             parts: ClusterPutSettingsParts::None,
             headers,
             body: None,
@@ -1652,7 +1065,7 @@ where
         T: Serialize,
     {
         ClusterPutSettings {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1754,7 +1167,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1777,7 +1190,7 @@ impl ClusterRemoteInfoParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Remote Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-remote-info.html)\n\nReturns the information about configured remote clusters."]
 pub struct ClusterRemoteInfo<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterRemoteInfoParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1788,10 +1201,10 @@ pub struct ClusterRemoteInfo<'a, 'b> {
 }
 impl<'a, 'b> ClusterRemoteInfo<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterRemoteInfo]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         ClusterRemoteInfo {
-            client,
+            transport,
             parts: ClusterRemoteInfoParts::None,
             headers,
             error_trace: None,
@@ -1865,7 +1278,7 @@ impl<'a, 'b> ClusterRemoteInfo<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1888,7 +1301,7 @@ impl ClusterRerouteParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Reroute API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-reroute.html)\n\nAllows to manually change the allocation of individual shards in the cluster."]
 pub struct ClusterReroute<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterRerouteParts,
     body: Option<B>,
     dry_run: Option<bool>,
@@ -1909,10 +1322,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [ClusterReroute]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         ClusterReroute {
-            client,
+            transport,
             parts: ClusterRerouteParts::None,
             headers,
             body: None,
@@ -1935,7 +1348,7 @@ where
         T: Serialize,
     {
         ClusterReroute {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             dry_run: self.dry_run,
@@ -2064,7 +1477,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2115,7 +1528,7 @@ impl<'b> ClusterStateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster State API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-state.html)\n\nReturns a comprehensive information about the state of the cluster."]
 pub struct ClusterState<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterStateParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -2134,10 +1547,10 @@ pub struct ClusterState<'a, 'b> {
 }
 impl<'a, 'b> ClusterState<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterState] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ClusterStateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: ClusterStateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         ClusterState {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -2286,7 +1699,7 @@ impl<'a, 'b> ClusterState<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2320,7 +1733,7 @@ impl<'b> ClusterStatsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Cluster Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-stats.html)\n\nReturns high-level overview of cluster statistics."]
 pub struct ClusterStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClusterStatsParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -2333,10 +1746,10 @@ pub struct ClusterStats<'a, 'b> {
 }
 impl<'a, 'b> ClusterStats<'a, 'b> {
     #[doc = "Creates a new instance of [ClusterStats] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ClusterStatsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: ClusterStatsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         ClusterStats {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -2428,7 +1841,7 @@ impl<'a, 'b> ClusterStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2436,93 +1849,68 @@ impl<'a, 'b> ClusterStats<'a, 'b> {
 }
 #[doc = "Namespace client for Cluster APIs"]
 pub struct Cluster<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Cluster<'a> {
     #[doc = "Creates a new instance of [Cluster]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Cluster Allocation Explain API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-allocation-explain.html)\n\nProvides explanations for shard allocations in the cluster."]
     pub fn allocation_explain<'b>(&'a self) -> ClusterAllocationExplain<'a, 'b, ()> {
-        ClusterAllocationExplain::new(&self.client)
-    }
-    #[doc = "[Cluster Delete Component Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html)\n\nDeletes a component template"]
-    pub fn delete_component_template<'b>(
-        &'a self,
-        parts: ClusterDeleteComponentTemplateParts<'b>,
-    ) -> ClusterDeleteComponentTemplate<'a, 'b> {
-        ClusterDeleteComponentTemplate::new(&self.client, parts)
+        ClusterAllocationExplain::new(self.transport())
     }
     #[doc = "[Cluster Delete Voting Config Exclusions API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/voting-config-exclusions.html)\n\nClears cluster voting config exclusions."]
     pub fn delete_voting_config_exclusions<'b>(
         &'a self,
     ) -> ClusterDeleteVotingConfigExclusions<'a, 'b> {
-        ClusterDeleteVotingConfigExclusions::new(&self.client)
-    }
-    #[doc = "[Cluster Exists Component Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html)\n\nReturns information about whether a particular component template exist"]
-    pub fn exists_component_template<'b>(
-        &'a self,
-        parts: ClusterExistsComponentTemplateParts<'b>,
-    ) -> ClusterExistsComponentTemplate<'a, 'b> {
-        ClusterExistsComponentTemplate::new(&self.client, parts)
-    }
-    #[doc = "[Cluster Get Component Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html)\n\nReturns one or more component templates"]
-    pub fn get_component_template<'b>(
-        &'a self,
-        parts: ClusterGetComponentTemplateParts<'b>,
-    ) -> ClusterGetComponentTemplate<'a, 'b> {
-        ClusterGetComponentTemplate::new(&self.client, parts)
+        ClusterDeleteVotingConfigExclusions::new(self.transport())
     }
     #[doc = "[Cluster Get Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-update-settings.html)\n\nReturns cluster settings."]
     pub fn get_settings<'b>(&'a self) -> ClusterGetSettings<'a, 'b> {
-        ClusterGetSettings::new(&self.client)
+        ClusterGetSettings::new(self.transport())
     }
     #[doc = "[Cluster Health API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-health.html)\n\nReturns basic information about the health of the cluster."]
     pub fn health<'b>(&'a self, parts: ClusterHealthParts<'b>) -> ClusterHealth<'a, 'b> {
-        ClusterHealth::new(&self.client, parts)
+        ClusterHealth::new(self.transport(), parts)
     }
     #[doc = "[Cluster Pending Tasks API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-pending.html)\n\nReturns a list of any cluster-level changes (e.g. create index, update mapping,\nallocate or fail shard) which have not yet been executed."]
     pub fn pending_tasks<'b>(&'a self) -> ClusterPendingTasks<'a, 'b> {
-        ClusterPendingTasks::new(&self.client)
+        ClusterPendingTasks::new(self.transport())
     }
     #[doc = "[Cluster Post Voting Config Exclusions API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/voting-config-exclusions.html)\n\nUpdates the cluster voting config exclusions by node ids or node names."]
     pub fn post_voting_config_exclusions<'b>(
         &'a self,
     ) -> ClusterPostVotingConfigExclusions<'a, 'b, ()> {
-        ClusterPostVotingConfigExclusions::new(&self.client)
-    }
-    #[doc = "[Cluster Put Component Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-component-template.html)\n\nCreates or updates a component template"]
-    pub fn put_component_template<'b>(
-        &'a self,
-        parts: ClusterPutComponentTemplateParts<'b>,
-    ) -> ClusterPutComponentTemplate<'a, 'b, ()> {
-        ClusterPutComponentTemplate::new(&self.client, parts)
+        ClusterPostVotingConfigExclusions::new(self.transport())
     }
     #[doc = "[Cluster Put Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-update-settings.html)\n\nUpdates the cluster settings."]
     pub fn put_settings<'b>(&'a self) -> ClusterPutSettings<'a, 'b, ()> {
-        ClusterPutSettings::new(&self.client)
+        ClusterPutSettings::new(self.transport())
     }
     #[doc = "[Cluster Remote Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-remote-info.html)\n\nReturns the information about configured remote clusters."]
     pub fn remote_info<'b>(&'a self) -> ClusterRemoteInfo<'a, 'b> {
-        ClusterRemoteInfo::new(&self.client)
+        ClusterRemoteInfo::new(self.transport())
     }
     #[doc = "[Cluster Reroute API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-reroute.html)\n\nAllows to manually change the allocation of individual shards in the cluster."]
     pub fn reroute<'b>(&'a self) -> ClusterReroute<'a, 'b, ()> {
-        ClusterReroute::new(&self.client)
+        ClusterReroute::new(self.transport())
     }
     #[doc = "[Cluster State API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-state.html)\n\nReturns a comprehensive information about the state of the cluster."]
     pub fn state<'b>(&'a self, parts: ClusterStateParts<'b>) -> ClusterState<'a, 'b> {
-        ClusterState::new(&self.client, parts)
+        ClusterState::new(self.transport(), parts)
     }
     #[doc = "[Cluster Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-stats.html)\n\nReturns high-level overview of cluster statistics."]
     pub fn stats<'b>(&'a self, parts: ClusterStatsParts<'b>) -> ClusterStats<'a, 'b> {
-        ClusterStats::new(&self.client, parts)
+        ClusterStats::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Cluster APIs"]
     pub fn cluster(&self) -> Cluster {
-        Cluster::new(&self)
+        Cluster::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/dangling_indices.rs
+++ b/elasticsearch/src/generated/namespace_clients/dangling_indices.rs
@@ -39,66 +39,241 @@ use percent_encoding::percent_encode;
 use serde::Serialize;
 use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Sql Clear Cursor API"]
-pub enum SqlClearCursorParts {
-    #[doc = "No parts"]
-    None,
+#[doc = "API parts for the Dangling Indices Delete Dangling Index API"]
+pub enum DanglingIndicesDeleteDanglingIndexParts<'b> {
+    #[doc = "IndexUuid"]
+    IndexUuid(&'b str),
 }
-impl SqlClearCursorParts {
-    #[doc = "Builds a relative URL path to the Sql Clear Cursor API"]
+impl<'b> DanglingIndicesDeleteDanglingIndexParts<'b> {
+    #[doc = "Builds a relative URL path to the Dangling Indices Delete Dangling Index API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            SqlClearCursorParts::None => "/_sql/close".into(),
+            DanglingIndicesDeleteDanglingIndexParts::IndexUuid(ref index_uuid) => {
+                let encoded_index_uuid: Cow<str> =
+                    percent_encode(index_uuid.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index_uuid.len());
+                p.push_str("/_dangling/");
+                p.push_str(encoded_index_uuid.as_ref());
+                p.into()
+            }
         }
     }
 }
 #[derive(Clone, Debug)]
-#[doc = "Builder for the [Sql Clear Cursor API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/sql-pagination.html)\n\nClears the SQL cursor"]
-pub struct SqlClearCursor<'a, 'b, B> {
+#[doc = "Builder for the [Dangling Indices Delete Dangling Index API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-gateway-dangling-indices.html)\n\nDeletes the specified dangling index"]
+pub struct DanglingIndicesDeleteDanglingIndex<'a, 'b> {
     transport: &'a Transport,
-    parts: SqlClearCursorParts,
+    parts: DanglingIndicesDeleteDanglingIndexParts<'b>,
+    accept_data_loss: Option<bool>,
+    error_trace: Option<bool>,
+    filter_path: Option<&'b [&'b str]>,
+    headers: HeaderMap,
+    human: Option<bool>,
+    master_timeout: Option<&'b str>,
+    pretty: Option<bool>,
+    source: Option<&'b str>,
+    timeout: Option<&'b str>,
+}
+impl<'a, 'b> DanglingIndicesDeleteDanglingIndex<'a, 'b> {
+    #[doc = "Creates a new instance of [DanglingIndicesDeleteDanglingIndex] with the specified API parts"]
+    pub fn new(
+        transport: &'a Transport,
+        parts: DanglingIndicesDeleteDanglingIndexParts<'b>,
+    ) -> Self {
+        let headers = HeaderMap::new();
+        DanglingIndicesDeleteDanglingIndex {
+            transport,
+            parts,
+            headers,
+            accept_data_loss: None,
+            error_trace: None,
+            filter_path: None,
+            human: None,
+            master_timeout: None,
+            pretty: None,
+            source: None,
+            timeout: None,
+        }
+    }
+    #[doc = "Must be set to true in order to delete the dangling index"]
+    pub fn accept_data_loss(mut self, accept_data_loss: bool) -> Self {
+        self.accept_data_loss = Some(accept_data_loss);
+        self
+    }
+    #[doc = "Include the stack trace of returned errors."]
+    pub fn error_trace(mut self, error_trace: bool) -> Self {
+        self.error_trace = Some(error_trace);
+        self
+    }
+    #[doc = "A comma-separated list of filters used to reduce the response."]
+    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
+        self.filter_path = Some(filter_path);
+        self
+    }
+    #[doc = "Adds a HTTP header"]
+    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
+        self.headers.insert(key, value);
+        self
+    }
+    #[doc = "Return human readable values for statistics."]
+    pub fn human(mut self, human: bool) -> Self {
+        self.human = Some(human);
+        self
+    }
+    #[doc = "Specify timeout for connection to master"]
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
+        self.master_timeout = Some(master_timeout);
+        self
+    }
+    #[doc = "Pretty format the returned JSON response."]
+    pub fn pretty(mut self, pretty: bool) -> Self {
+        self.pretty = Some(pretty);
+        self
+    }
+    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
+    pub fn source(mut self, source: &'b str) -> Self {
+        self.source = Some(source);
+        self
+    }
+    #[doc = "Explicit operation timeout"]
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+    #[doc = "Creates an asynchronous call to the Dangling Indices Delete Dangling Index API that can be awaited"]
+    pub async fn send(self) -> Result<Response, Error> {
+        let path = self.parts.url();
+        let method = Method::Delete;
+        let headers = self.headers;
+        let query_string = {
+            #[serde_with::skip_serializing_none]
+            #[derive(Serialize)]
+            struct QueryParams<'b> {
+                #[serde(rename = "accept_data_loss")]
+                accept_data_loss: Option<bool>,
+                #[serde(rename = "error_trace")]
+                error_trace: Option<bool>,
+                #[serde(
+                    rename = "filter_path",
+                    serialize_with = "crate::client::serialize_coll_qs"
+                )]
+                filter_path: Option<&'b [&'b str]>,
+                #[serde(rename = "human")]
+                human: Option<bool>,
+                #[serde(rename = "master_timeout")]
+                master_timeout: Option<&'b str>,
+                #[serde(rename = "pretty")]
+                pretty: Option<bool>,
+                #[serde(rename = "source")]
+                source: Option<&'b str>,
+                #[serde(rename = "timeout")]
+                timeout: Option<&'b str>,
+            }
+            let query_params = QueryParams {
+                accept_data_loss: self.accept_data_loss,
+                error_trace: self.error_trace,
+                filter_path: self.filter_path,
+                human: self.human,
+                master_timeout: self.master_timeout,
+                pretty: self.pretty,
+                source: self.source,
+                timeout: self.timeout,
+            };
+            Some(query_params)
+        };
+        let body = Option::<()>::None;
+        let response = self
+            .transport
+            .send(method, &path, headers, query_string.as_ref(), body)
+            .await?;
+        Ok(response)
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[doc = "API parts for the Dangling Indices Import Dangling Index API"]
+pub enum DanglingIndicesImportDanglingIndexParts<'b> {
+    #[doc = "IndexUuid"]
+    IndexUuid(&'b str),
+}
+impl<'b> DanglingIndicesImportDanglingIndexParts<'b> {
+    #[doc = "Builds a relative URL path to the Dangling Indices Import Dangling Index API"]
+    pub fn url(self) -> Cow<'static, str> {
+        match self {
+            DanglingIndicesImportDanglingIndexParts::IndexUuid(ref index_uuid) => {
+                let encoded_index_uuid: Cow<str> =
+                    percent_encode(index_uuid.as_bytes(), PARTS_ENCODED).into();
+                let mut p = String::with_capacity(11usize + encoded_index_uuid.len());
+                p.push_str("/_dangling/");
+                p.push_str(encoded_index_uuid.as_ref());
+                p.into()
+            }
+        }
+    }
+}
+#[derive(Clone, Debug)]
+#[doc = "Builder for the [Dangling Indices Import Dangling Index API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-gateway-dangling-indices.html)\n\nImports the specified dangling index"]
+pub struct DanglingIndicesImportDanglingIndex<'a, 'b, B> {
+    transport: &'a Transport,
+    parts: DanglingIndicesImportDanglingIndexParts<'b>,
+    accept_data_loss: Option<bool>,
     body: Option<B>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
     human: Option<bool>,
+    master_timeout: Option<&'b str>,
     pretty: Option<bool>,
     source: Option<&'b str>,
+    timeout: Option<&'b str>,
 }
-impl<'a, 'b, B> SqlClearCursor<'a, 'b, B>
+impl<'a, 'b, B> DanglingIndicesImportDanglingIndex<'a, 'b, B>
 where
     B: Body,
 {
-    #[doc = "Creates a new instance of [SqlClearCursor]"]
-    pub fn new(transport: &'a Transport) -> Self {
+    #[doc = "Creates a new instance of [DanglingIndicesImportDanglingIndex] with the specified API parts"]
+    pub fn new(
+        transport: &'a Transport,
+        parts: DanglingIndicesImportDanglingIndexParts<'b>,
+    ) -> Self {
         let headers = HeaderMap::new();
-        SqlClearCursor {
+        DanglingIndicesImportDanglingIndex {
             transport,
-            parts: SqlClearCursorParts::None,
+            parts,
             headers,
+            accept_data_loss: None,
             body: None,
             error_trace: None,
             filter_path: None,
             human: None,
+            master_timeout: None,
             pretty: None,
             source: None,
+            timeout: None,
         }
     }
+    #[doc = "Must be set to true in order to import the dangling index"]
+    pub fn accept_data_loss(mut self, accept_data_loss: bool) -> Self {
+        self.accept_data_loss = Some(accept_data_loss);
+        self
+    }
     #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SqlClearCursor<'a, 'b, JsonBody<T>>
+    pub fn body<T>(self, body: T) -> DanglingIndicesImportDanglingIndex<'a, 'b, JsonBody<T>>
     where
         T: Serialize,
     {
-        SqlClearCursor {
+        DanglingIndicesImportDanglingIndex {
             transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
+            accept_data_loss: self.accept_data_loss,
             error_trace: self.error_trace,
             filter_path: self.filter_path,
             headers: self.headers,
             human: self.human,
+            master_timeout: self.master_timeout,
             pretty: self.pretty,
             source: self.source,
+            timeout: self.timeout,
         }
     }
     #[doc = "Include the stack trace of returned errors."]
@@ -121,6 +296,11 @@ where
         self.human = Some(human);
         self
     }
+    #[doc = "Specify timeout for connection to master"]
+    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
+        self.master_timeout = Some(master_timeout);
+        self
+    }
     #[doc = "Pretty format the returned JSON response."]
     pub fn pretty(mut self, pretty: bool) -> Self {
         self.pretty = Some(pretty);
@@ -131,7 +311,12 @@ where
         self.source = Some(source);
         self
     }
-    #[doc = "Creates an asynchronous call to the Sql Clear Cursor API that can be awaited"]
+    #[doc = "Explicit operation timeout"]
+    pub fn timeout(mut self, timeout: &'b str) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+    #[doc = "Creates an asynchronous call to the Dangling Indices Import Dangling Index API that can be awaited"]
     pub async fn send(self) -> Result<Response, Error> {
         let path = self.parts.url();
         let method = Method::Post;
@@ -140,6 +325,8 @@ where
             #[serde_with::skip_serializing_none]
             #[derive(Serialize)]
             struct QueryParams<'b> {
+                #[serde(rename = "accept_data_loss")]
+                accept_data_loss: Option<bool>,
                 #[serde(rename = "error_trace")]
                 error_trace: Option<bool>,
                 #[serde(
@@ -149,17 +336,24 @@ where
                 filter_path: Option<&'b [&'b str]>,
                 #[serde(rename = "human")]
                 human: Option<bool>,
+                #[serde(rename = "master_timeout")]
+                master_timeout: Option<&'b str>,
                 #[serde(rename = "pretty")]
                 pretty: Option<bool>,
                 #[serde(rename = "source")]
                 source: Option<&'b str>,
+                #[serde(rename = "timeout")]
+                timeout: Option<&'b str>,
             }
             let query_params = QueryParams {
+                accept_data_loss: self.accept_data_loss,
                 error_trace: self.error_trace,
                 filter_path: self.filter_path,
                 human: self.human,
+                master_timeout: self.master_timeout,
                 pretty: self.pretty,
                 source: self.source,
+                timeout: self.timeout,
             };
             Some(query_params)
         };
@@ -172,172 +366,24 @@ where
     }
 }
 #[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Sql Query API"]
-pub enum SqlQueryParts {
+#[doc = "API parts for the Dangling Indices List Dangling Indices API"]
+pub enum DanglingIndicesListDanglingIndicesParts {
     #[doc = "No parts"]
     None,
 }
-impl SqlQueryParts {
-    #[doc = "Builds a relative URL path to the Sql Query API"]
+impl DanglingIndicesListDanglingIndicesParts {
+    #[doc = "Builds a relative URL path to the Dangling Indices List Dangling Indices API"]
     pub fn url(self) -> Cow<'static, str> {
         match self {
-            SqlQueryParts::None => "/_sql".into(),
+            DanglingIndicesListDanglingIndicesParts::None => "/_dangling".into(),
         }
     }
 }
 #[derive(Clone, Debug)]
-#[doc = "Builder for the [Sql Query API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/sql-rest-overview.html)\n\nExecutes a SQL request"]
-pub struct SqlQuery<'a, 'b, B> {
+#[doc = "Builder for the [Dangling Indices List Dangling Indices API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-gateway-dangling-indices.html)\n\nReturns all dangling indices."]
+pub struct DanglingIndicesListDanglingIndices<'a, 'b> {
     transport: &'a Transport,
-    parts: SqlQueryParts,
-    body: Option<B>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    format: Option<&'b str>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-}
-impl<'a, 'b, B> SqlQuery<'a, 'b, B>
-where
-    B: Body,
-{
-    #[doc = "Creates a new instance of [SqlQuery]"]
-    pub fn new(transport: &'a Transport) -> Self {
-        let headers = HeaderMap::new();
-        SqlQuery {
-            transport,
-            parts: SqlQueryParts::None,
-            headers,
-            body: None,
-            error_trace: None,
-            filter_path: None,
-            format: None,
-            human: None,
-            pretty: None,
-            source: None,
-        }
-    }
-    #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SqlQuery<'a, 'b, JsonBody<T>>
-    where
-        T: Serialize,
-    {
-        SqlQuery {
-            transport: self.transport,
-            parts: self.parts,
-            body: Some(body.into()),
-            error_trace: self.error_trace,
-            filter_path: self.filter_path,
-            format: self.format,
-            headers: self.headers,
-            human: self.human,
-            pretty: self.pretty,
-            source: self.source,
-        }
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "a short version of the Accept header, e.g. json, yaml"]
-    pub fn format(mut self, format: &'b str) -> Self {
-        self.format = Some(format);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Sql Query API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = match self.body {
-            Some(_) => Method::Post,
-            None => Method::Get,
-        };
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "format")]
-                format: Option<&'b str>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                format: self.format,
-                human: self.human,
-                pretty: self.pretty,
-                source: self.source,
-            };
-            Some(query_params)
-        };
-        let body = self.body;
-        let response = self
-            .transport
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Sql Translate API"]
-pub enum SqlTranslateParts {
-    #[doc = "No parts"]
-    None,
-}
-impl SqlTranslateParts {
-    #[doc = "Builds a relative URL path to the Sql Translate API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            SqlTranslateParts::None => "/_sql/translate".into(),
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Sql Translate API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/sql-translate.html)\n\nTranslates SQL into Elasticsearch queries"]
-pub struct SqlTranslate<'a, 'b, B> {
-    transport: &'a Transport,
-    parts: SqlTranslateParts,
-    body: Option<B>,
+    parts: DanglingIndicesListDanglingIndicesParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
     headers: HeaderMap,
@@ -345,40 +391,19 @@ pub struct SqlTranslate<'a, 'b, B> {
     pretty: Option<bool>,
     source: Option<&'b str>,
 }
-impl<'a, 'b, B> SqlTranslate<'a, 'b, B>
-where
-    B: Body,
-{
-    #[doc = "Creates a new instance of [SqlTranslate]"]
+impl<'a, 'b> DanglingIndicesListDanglingIndices<'a, 'b> {
+    #[doc = "Creates a new instance of [DanglingIndicesListDanglingIndices]"]
     pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
-        SqlTranslate {
+        DanglingIndicesListDanglingIndices {
             transport,
-            parts: SqlTranslateParts::None,
+            parts: DanglingIndicesListDanglingIndicesParts::None,
             headers,
-            body: None,
             error_trace: None,
             filter_path: None,
             human: None,
             pretty: None,
             source: None,
-        }
-    }
-    #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> SqlTranslate<'a, 'b, JsonBody<T>>
-    where
-        T: Serialize,
-    {
-        SqlTranslate {
-            transport: self.transport,
-            parts: self.parts,
-            body: Some(body.into()),
-            error_trace: self.error_trace,
-            filter_path: self.filter_path,
-            headers: self.headers,
-            human: self.human,
-            pretty: self.pretty,
-            source: self.source,
         }
     }
     #[doc = "Include the stack trace of returned errors."]
@@ -411,13 +436,10 @@ where
         self.source = Some(source);
         self
     }
-    #[doc = "Creates an asynchronous call to the Sql Translate API that can be awaited"]
+    #[doc = "Creates an asynchronous call to the Dangling Indices List Dangling Indices API that can be awaited"]
     pub async fn send(self) -> Result<Response, Error> {
         let path = self.parts.url();
-        let method = match self.body {
-            Some(_) => Method::Post,
-            None => Method::Get,
-        };
+        let method = Method::Get;
         let headers = self.headers;
         let query_string = {
             #[serde_with::skip_serializing_none]
@@ -446,7 +468,7 @@ where
             };
             Some(query_params)
         };
-        let body = self.body;
+        let body = Option::<()>::None;
         let response = self
             .transport
             .send(method, &path, headers, query_string.as_ref(), body)
@@ -454,34 +476,40 @@ where
         Ok(response)
     }
 }
-#[doc = "Namespace client for Sql APIs"]
-pub struct Sql<'a> {
+#[doc = "Namespace client for DanglingIndices APIs"]
+pub struct DanglingIndices<'a> {
     transport: &'a Transport,
 }
-impl<'a> Sql<'a> {
-    #[doc = "Creates a new instance of [Sql]"]
+impl<'a> DanglingIndices<'a> {
+    #[doc = "Creates a new instance of [DanglingIndices]"]
     pub fn new(transport: &'a Transport) -> Self {
         Self { transport }
     }
     pub fn transport(&self) -> &Transport {
         self.transport
     }
-    #[doc = "[Sql Clear Cursor API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/sql-pagination.html)\n\nClears the SQL cursor"]
-    pub fn clear_cursor<'b>(&'a self) -> SqlClearCursor<'a, 'b, ()> {
-        SqlClearCursor::new(self.transport())
+    #[doc = "[Dangling Indices Delete Dangling Index API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-gateway-dangling-indices.html)\n\nDeletes the specified dangling index"]
+    pub fn delete_dangling_index<'b>(
+        &'a self,
+        parts: DanglingIndicesDeleteDanglingIndexParts<'b>,
+    ) -> DanglingIndicesDeleteDanglingIndex<'a, 'b> {
+        DanglingIndicesDeleteDanglingIndex::new(self.transport(), parts)
     }
-    #[doc = "[Sql Query API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/sql-rest-overview.html)\n\nExecutes a SQL request"]
-    pub fn query<'b>(&'a self) -> SqlQuery<'a, 'b, ()> {
-        SqlQuery::new(self.transport())
+    #[doc = "[Dangling Indices Import Dangling Index API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-gateway-dangling-indices.html)\n\nImports the specified dangling index"]
+    pub fn import_dangling_index<'b>(
+        &'a self,
+        parts: DanglingIndicesImportDanglingIndexParts<'b>,
+    ) -> DanglingIndicesImportDanglingIndex<'a, 'b, ()> {
+        DanglingIndicesImportDanglingIndex::new(self.transport(), parts)
     }
-    #[doc = "[Sql Translate API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/sql-translate.html)\n\nTranslates SQL into Elasticsearch queries"]
-    pub fn translate<'b>(&'a self) -> SqlTranslate<'a, 'b, ()> {
-        SqlTranslate::new(self.transport())
+    #[doc = "[Dangling Indices List Dangling Indices API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-gateway-dangling-indices.html)\n\nReturns all dangling indices."]
+    pub fn list_dangling_indices<'b>(&'a self) -> DanglingIndicesListDanglingIndices<'a, 'b> {
+        DanglingIndicesListDanglingIndices::new(self.transport())
     }
 }
 impl Elasticsearch {
-    #[doc = "Creates a namespace client for Sql APIs"]
-    pub fn sql(&self) -> Sql {
-        Sql::new(self.transport())
+    #[doc = "Creates a namespace client for DanglingIndices APIs"]
+    pub fn dangling_indices(&self) -> DanglingIndices {
+        DanglingIndices::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/enrich.rs
+++ b/elasticsearch/src/generated/namespace_clients/enrich.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -60,7 +61,7 @@ impl<'b> EnrichDeletePolicyParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Enrich Delete Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-enrich-policy-api.html)\n\nDeletes an existing enrich policy and its enrich index."]
 pub struct EnrichDeletePolicy<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: EnrichDeletePolicyParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -71,10 +72,10 @@ pub struct EnrichDeletePolicy<'a, 'b> {
 }
 impl<'a, 'b> EnrichDeletePolicy<'a, 'b> {
     #[doc = "Creates a new instance of [EnrichDeletePolicy] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: EnrichDeletePolicyParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: EnrichDeletePolicyParts<'b>) -> Self {
         let headers = HeaderMap::new();
         EnrichDeletePolicy {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -148,7 +149,7 @@ impl<'a, 'b> EnrichDeletePolicy<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -178,7 +179,7 @@ impl<'b> EnrichExecutePolicyParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Enrich Execute Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/execute-enrich-policy-api.html)\n\nCreates the enrich index for an existing enrich policy."]
 pub struct EnrichExecutePolicy<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: EnrichExecutePolicyParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -194,10 +195,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [EnrichExecutePolicy] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: EnrichExecutePolicyParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: EnrichExecutePolicyParts<'b>) -> Self {
         let headers = HeaderMap::new();
         EnrichExecutePolicy {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -215,7 +216,7 @@ where
         T: Serialize,
     {
         EnrichExecutePolicy {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -299,7 +300,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -333,7 +334,7 @@ impl<'b> EnrichGetPolicyParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Enrich Get Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-enrich-policy-api.html)\n\nGets information about an enrich policy."]
 pub struct EnrichGetPolicy<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: EnrichGetPolicyParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -344,10 +345,10 @@ pub struct EnrichGetPolicy<'a, 'b> {
 }
 impl<'a, 'b> EnrichGetPolicy<'a, 'b> {
     #[doc = "Creates a new instance of [EnrichGetPolicy] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: EnrichGetPolicyParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: EnrichGetPolicyParts<'b>) -> Self {
         let headers = HeaderMap::new();
         EnrichGetPolicy {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -421,7 +422,7 @@ impl<'a, 'b> EnrichGetPolicy<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -450,7 +451,7 @@ impl<'b> EnrichPutPolicyParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Enrich Put Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/put-enrich-policy-api.html)\n\nCreates a new enrich policy."]
 pub struct EnrichPutPolicy<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: EnrichPutPolicyParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -465,10 +466,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [EnrichPutPolicy] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: EnrichPutPolicyParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: EnrichPutPolicyParts<'b>) -> Self {
         let headers = HeaderMap::new();
         EnrichPutPolicy {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -485,7 +486,7 @@ where
         T: Serialize,
     {
         EnrichPutPolicy {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -560,7 +561,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -583,7 +584,7 @@ impl EnrichStatsParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Enrich Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/enrich-stats-api.html)\n\nGets enrich coordinator statistics and information about enrich policies that are currently executing."]
 pub struct EnrichStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: EnrichStatsParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -594,10 +595,10 @@ pub struct EnrichStats<'a, 'b> {
 }
 impl<'a, 'b> EnrichStats<'a, 'b> {
     #[doc = "Creates a new instance of [EnrichStats]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         EnrichStats {
-            client,
+            transport,
             parts: EnrichStatsParts::None,
             headers,
             error_trace: None,
@@ -671,7 +672,7 @@ impl<'a, 'b> EnrichStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -679,46 +680,49 @@ impl<'a, 'b> EnrichStats<'a, 'b> {
 }
 #[doc = "Namespace client for Enrich APIs"]
 pub struct Enrich<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Enrich<'a> {
     #[doc = "Creates a new instance of [Enrich]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Enrich Delete Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-enrich-policy-api.html)\n\nDeletes an existing enrich policy and its enrich index."]
     pub fn delete_policy<'b>(
         &'a self,
         parts: EnrichDeletePolicyParts<'b>,
     ) -> EnrichDeletePolicy<'a, 'b> {
-        EnrichDeletePolicy::new(&self.client, parts)
+        EnrichDeletePolicy::new(self.transport(), parts)
     }
     #[doc = "[Enrich Execute Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/execute-enrich-policy-api.html)\n\nCreates the enrich index for an existing enrich policy."]
     pub fn execute_policy<'b>(
         &'a self,
         parts: EnrichExecutePolicyParts<'b>,
     ) -> EnrichExecutePolicy<'a, 'b, ()> {
-        EnrichExecutePolicy::new(&self.client, parts)
+        EnrichExecutePolicy::new(self.transport(), parts)
     }
     #[doc = "[Enrich Get Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-enrich-policy-api.html)\n\nGets information about an enrich policy."]
     pub fn get_policy<'b>(&'a self, parts: EnrichGetPolicyParts<'b>) -> EnrichGetPolicy<'a, 'b> {
-        EnrichGetPolicy::new(&self.client, parts)
+        EnrichGetPolicy::new(self.transport(), parts)
     }
     #[doc = "[Enrich Put Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/put-enrich-policy-api.html)\n\nCreates a new enrich policy."]
     pub fn put_policy<'b>(
         &'a self,
         parts: EnrichPutPolicyParts<'b>,
     ) -> EnrichPutPolicy<'a, 'b, ()> {
-        EnrichPutPolicy::new(&self.client, parts)
+        EnrichPutPolicy::new(self.transport(), parts)
     }
     #[doc = "[Enrich Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/enrich-stats-api.html)\n\nGets enrich coordinator statistics and information about enrich policies that are currently executing."]
     pub fn stats<'b>(&'a self) -> EnrichStats<'a, 'b> {
-        EnrichStats::new(&self.client)
+        EnrichStats::new(self.transport())
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Enrich APIs"]
     pub fn enrich(&self) -> Enrich {
-        Enrich::new(&self)
+        Enrich::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/graph.rs
+++ b/elasticsearch/src/generated/namespace_clients/graph.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -63,7 +64,7 @@ impl<'b> GraphExploreParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Graph Explore API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/graph-explore-api.html)\n\nExplore extracted and summarized information about the documents and terms in an index."]
 pub struct GraphExplore<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: GraphExploreParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -80,10 +81,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [GraphExplore] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: GraphExploreParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: GraphExploreParts<'b>) -> Self {
         let headers = HeaderMap::new();
         GraphExplore {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -102,7 +103,7 @@ where
         T: Serialize,
     {
         GraphExplore {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -198,7 +199,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -206,21 +207,24 @@ where
 }
 #[doc = "Namespace client for Graph APIs"]
 pub struct Graph<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Graph<'a> {
     #[doc = "Creates a new instance of [Graph]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Graph Explore API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/graph-explore-api.html)\n\nExplore extracted and summarized information about the documents and terms in an index."]
     pub fn explore<'b>(&'a self, parts: GraphExploreParts<'b>) -> GraphExplore<'a, 'b, ()> {
-        GraphExplore::new(&self.client, parts)
+        GraphExplore::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Graph APIs"]
     pub fn graph(&self) -> Graph {
-        Graph::new(&self)
+        Graph::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/ilm.rs
+++ b/elasticsearch/src/generated/namespace_clients/ilm.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -61,7 +62,7 @@ impl<'b> IlmDeleteLifecycleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Delete Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-delete-lifecycle.html)\n\nDeletes the specified lifecycle policy definition. A currently used policy cannot be deleted."]
 pub struct IlmDeleteLifecycle<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IlmDeleteLifecycleParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -72,10 +73,10 @@ pub struct IlmDeleteLifecycle<'a, 'b> {
 }
 impl<'a, 'b> IlmDeleteLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [IlmDeleteLifecycle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IlmDeleteLifecycleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IlmDeleteLifecycleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IlmDeleteLifecycle {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -149,7 +150,7 @@ impl<'a, 'b> IlmDeleteLifecycle<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -180,7 +181,7 @@ impl<'b> IlmExplainLifecycleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Explain Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-explain-lifecycle.html)\n\nRetrieves information about the index's current lifecycle state, such as the currently executing phase, action, and step."]
 pub struct IlmExplainLifecycle<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IlmExplainLifecycleParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -193,10 +194,10 @@ pub struct IlmExplainLifecycle<'a, 'b> {
 }
 impl<'a, 'b> IlmExplainLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [IlmExplainLifecycle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IlmExplainLifecycleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IlmExplainLifecycleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IlmExplainLifecycle {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -288,7 +289,7 @@ impl<'a, 'b> IlmExplainLifecycle<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -321,7 +322,7 @@ impl<'b> IlmGetLifecycleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Get Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-get-lifecycle.html)\n\nReturns the specified policy definition. Includes the policy version and last modified date."]
 pub struct IlmGetLifecycle<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IlmGetLifecycleParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -332,10 +333,10 @@ pub struct IlmGetLifecycle<'a, 'b> {
 }
 impl<'a, 'b> IlmGetLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [IlmGetLifecycle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IlmGetLifecycleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IlmGetLifecycleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IlmGetLifecycle {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -409,7 +410,7 @@ impl<'a, 'b> IlmGetLifecycle<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -432,7 +433,7 @@ impl IlmGetStatusParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Get Status API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-get-status.html)\n\nRetrieves the current index lifecycle management (ILM) status."]
 pub struct IlmGetStatus<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IlmGetStatusParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -443,10 +444,10 @@ pub struct IlmGetStatus<'a, 'b> {
 }
 impl<'a, 'b> IlmGetStatus<'a, 'b> {
     #[doc = "Creates a new instance of [IlmGetStatus]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         IlmGetStatus {
-            client,
+            transport,
             parts: IlmGetStatusParts::None,
             headers,
             error_trace: None,
@@ -520,7 +521,7 @@ impl<'a, 'b> IlmGetStatus<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -550,7 +551,7 @@ impl<'b> IlmMoveToStepParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Move To Step API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-move-to-step.html)\n\nManually moves an index into the specified step and executes that step."]
 pub struct IlmMoveToStep<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IlmMoveToStepParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -565,10 +566,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmMoveToStep] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IlmMoveToStepParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IlmMoveToStepParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IlmMoveToStep {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -585,7 +586,7 @@ where
         T: Serialize,
     {
         IlmMoveToStep {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -660,7 +661,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -690,7 +691,7 @@ impl<'b> IlmPutLifecycleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Put Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-put-lifecycle.html)\n\nCreates a lifecycle policy"]
 pub struct IlmPutLifecycle<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IlmPutLifecycleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -705,10 +706,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmPutLifecycle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IlmPutLifecycleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IlmPutLifecycleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IlmPutLifecycle {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -725,7 +726,7 @@ where
         T: Serialize,
     {
         IlmPutLifecycle {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -800,7 +801,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -831,7 +832,7 @@ impl<'b> IlmRemovePolicyParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Remove Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-remove-policy.html)\n\nRemoves the assigned lifecycle policy and stops managing the specified index"]
 pub struct IlmRemovePolicy<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IlmRemovePolicyParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -846,10 +847,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmRemovePolicy] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IlmRemovePolicyParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IlmRemovePolicyParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IlmRemovePolicy {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -866,7 +867,7 @@ where
         T: Serialize,
     {
         IlmRemovePolicy {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -941,7 +942,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -972,7 +973,7 @@ impl<'b> IlmRetryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Retry API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-retry-policy.html)\n\nRetries executing the policy for an index that is in the ERROR step."]
 pub struct IlmRetry<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IlmRetryParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -987,10 +988,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmRetry] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IlmRetryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IlmRetryParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IlmRetry {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1007,7 +1008,7 @@ where
         T: Serialize,
     {
         IlmRetry {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1082,7 +1083,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1105,7 +1106,7 @@ impl IlmStartParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Start API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-start.html)\n\nStart the index lifecycle management (ILM) plugin."]
 pub struct IlmStart<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IlmStartParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1120,10 +1121,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmStart]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         IlmStart {
-            client,
+            transport,
             parts: IlmStartParts::None,
             headers,
             body: None,
@@ -1140,7 +1141,7 @@ where
         T: Serialize,
     {
         IlmStart {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1215,7 +1216,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1238,7 +1239,7 @@ impl IlmStopParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ilm Stop API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-stop.html)\n\nHalts all lifecycle management operations and stops the index lifecycle management (ILM) plugin"]
 pub struct IlmStop<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IlmStopParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1253,10 +1254,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IlmStop]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         IlmStop {
-            client,
+            transport,
             parts: IlmStopParts::None,
             headers,
             body: None,
@@ -1273,7 +1274,7 @@ where
         T: Serialize,
     {
         IlmStop {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1348,7 +1349,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1356,69 +1357,72 @@ where
 }
 #[doc = "Namespace client for Index Lifecycle Management APIs"]
 pub struct Ilm<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Ilm<'a> {
     #[doc = "Creates a new instance of [Ilm]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Ilm Delete Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-delete-lifecycle.html)\n\nDeletes the specified lifecycle policy definition. A currently used policy cannot be deleted."]
     pub fn delete_lifecycle<'b>(
         &'a self,
         parts: IlmDeleteLifecycleParts<'b>,
     ) -> IlmDeleteLifecycle<'a, 'b> {
-        IlmDeleteLifecycle::new(&self.client, parts)
+        IlmDeleteLifecycle::new(self.transport(), parts)
     }
     #[doc = "[Ilm Explain Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-explain-lifecycle.html)\n\nRetrieves information about the index's current lifecycle state, such as the currently executing phase, action, and step."]
     pub fn explain_lifecycle<'b>(
         &'a self,
         parts: IlmExplainLifecycleParts<'b>,
     ) -> IlmExplainLifecycle<'a, 'b> {
-        IlmExplainLifecycle::new(&self.client, parts)
+        IlmExplainLifecycle::new(self.transport(), parts)
     }
     #[doc = "[Ilm Get Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-get-lifecycle.html)\n\nReturns the specified policy definition. Includes the policy version and last modified date."]
     pub fn get_lifecycle<'b>(&'a self, parts: IlmGetLifecycleParts<'b>) -> IlmGetLifecycle<'a, 'b> {
-        IlmGetLifecycle::new(&self.client, parts)
+        IlmGetLifecycle::new(self.transport(), parts)
     }
     #[doc = "[Ilm Get Status API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-get-status.html)\n\nRetrieves the current index lifecycle management (ILM) status."]
     pub fn get_status<'b>(&'a self) -> IlmGetStatus<'a, 'b> {
-        IlmGetStatus::new(&self.client)
+        IlmGetStatus::new(self.transport())
     }
     #[doc = "[Ilm Move To Step API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-move-to-step.html)\n\nManually moves an index into the specified step and executes that step."]
     pub fn move_to_step<'b>(&'a self, parts: IlmMoveToStepParts<'b>) -> IlmMoveToStep<'a, 'b, ()> {
-        IlmMoveToStep::new(&self.client, parts)
+        IlmMoveToStep::new(self.transport(), parts)
     }
     #[doc = "[Ilm Put Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-put-lifecycle.html)\n\nCreates a lifecycle policy"]
     pub fn put_lifecycle<'b>(
         &'a self,
         parts: IlmPutLifecycleParts<'b>,
     ) -> IlmPutLifecycle<'a, 'b, ()> {
-        IlmPutLifecycle::new(&self.client, parts)
+        IlmPutLifecycle::new(self.transport(), parts)
     }
     #[doc = "[Ilm Remove Policy API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-remove-policy.html)\n\nRemoves the assigned lifecycle policy and stops managing the specified index"]
     pub fn remove_policy<'b>(
         &'a self,
         parts: IlmRemovePolicyParts<'b>,
     ) -> IlmRemovePolicy<'a, 'b, ()> {
-        IlmRemovePolicy::new(&self.client, parts)
+        IlmRemovePolicy::new(self.transport(), parts)
     }
     #[doc = "[Ilm Retry API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-retry-policy.html)\n\nRetries executing the policy for an index that is in the ERROR step."]
     pub fn retry<'b>(&'a self, parts: IlmRetryParts<'b>) -> IlmRetry<'a, 'b, ()> {
-        IlmRetry::new(&self.client, parts)
+        IlmRetry::new(self.transport(), parts)
     }
     #[doc = "[Ilm Start API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-start.html)\n\nStart the index lifecycle management (ILM) plugin."]
     pub fn start<'b>(&'a self) -> IlmStart<'a, 'b, ()> {
-        IlmStart::new(&self.client)
+        IlmStart::new(self.transport())
     }
     #[doc = "[Ilm Stop API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ilm-stop.html)\n\nHalts all lifecycle management operations and stops the index lifecycle management (ILM) plugin"]
     pub fn stop<'b>(&'a self) -> IlmStop<'a, 'b, ()> {
-        IlmStop::new(&self.client)
+        IlmStop::new(self.transport())
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Index Lifecycle Management APIs"]
     pub fn ilm(&self) -> Ilm {
-        Ilm::new(&self)
+        Ilm::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/indices.rs
+++ b/elasticsearch/src/generated/namespace_clients/indices.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -65,7 +66,7 @@ impl<'b> IndicesAnalyzeParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Analyze API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-analyze.html)\n\nPerforms the analysis process on a text and return the tokens breakdown of the text."]
 pub struct IndicesAnalyze<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesAnalyzeParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -81,10 +82,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesAnalyze] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesAnalyzeParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesAnalyzeParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesAnalyze {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -102,7 +103,7 @@ where
         T: Serialize,
     {
         IndicesAnalyze {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -189,7 +190,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -224,7 +225,7 @@ impl<'b> IndicesClearCacheParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Clear Cache API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-clearcache.html)\n\nClears all or specific caches for one or more indices."]
 pub struct IndicesClearCache<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesClearCacheParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -247,10 +248,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesClearCache] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesClearCacheParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesClearCacheParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesClearCache {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -280,7 +281,7 @@ where
         T: Serialize,
     {
         IndicesClearCache {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -425,7 +426,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -460,7 +461,7 @@ impl<'b> IndicesCloneParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Clone API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-clone-index.html)\n\nClones an index"]
 pub struct IndicesClone<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesCloneParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -478,10 +479,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesClone] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesCloneParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesCloneParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesClone {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -501,7 +502,7 @@ where
         T: Serialize,
     {
         IndicesClone {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -603,7 +604,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -635,7 +636,7 @@ impl<'b> IndicesCloseParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Close API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-open-close.html)\n\nCloses an index."]
 pub struct IndicesClose<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesCloseParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -656,10 +657,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesClose] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesCloseParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesCloseParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesClose {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -687,7 +688,7 @@ where
         T: Serialize,
     {
         IndicesClose {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -814,7 +815,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -844,7 +845,7 @@ impl<'b> IndicesCreateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Create API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-create-index.html)\n\nCreates an index with optional settings and mappings."]
 pub struct IndicesCreate<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesCreateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -862,10 +863,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesCreate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesCreateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesCreateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesCreate {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -885,7 +886,7 @@ where
         T: Serialize,
     {
         IndicesCreate {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -987,7 +988,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1018,7 +1019,7 @@ impl<'b> IndicesDeleteParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-delete-index.html)\n\nDeletes an index."]
 pub struct IndicesDelete<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesDeleteParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -1034,10 +1035,10 @@ pub struct IndicesDelete<'a, 'b> {
 }
 impl<'a, 'b> IndicesDelete<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesDelete] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesDeleteParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesDeleteParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesDelete {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -1159,7 +1160,7 @@ impl<'a, 'b> IndicesDelete<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1196,7 +1197,7 @@ impl<'b> IndicesDeleteAliasParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Delete Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html)\n\nDeletes an alias."]
 pub struct IndicesDeleteAlias<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesDeleteAliasParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1209,10 +1210,10 @@ pub struct IndicesDeleteAlias<'a, 'b> {
 }
 impl<'a, 'b> IndicesDeleteAlias<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesDeleteAlias] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesDeleteAliasParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesDeleteAliasParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesDeleteAlias {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1304,144 +1305,7 @@ impl<'a, 'b> IndicesDeleteAlias<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Indices Delete Index Template API"]
-pub enum IndicesDeleteIndexTemplateParts<'b> {
-    #[doc = "Name"]
-    Name(&'b str),
-}
-impl<'b> IndicesDeleteIndexTemplateParts<'b> {
-    #[doc = "Builds a relative URL path to the Indices Delete Index Template API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            IndicesDeleteIndexTemplateParts::Name(ref name) => {
-                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
-                let mut p = String::with_capacity(17usize + encoded_name.len());
-                p.push_str("/_index_template/");
-                p.push_str(encoded_name.as_ref());
-                p.into()
-            }
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Indices Delete Index Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nDeletes an index template."]
-pub struct IndicesDeleteIndexTemplate<'a, 'b> {
-    client: &'a Elasticsearch,
-    parts: IndicesDeleteIndexTemplateParts<'b>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    master_timeout: Option<&'b str>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-    timeout: Option<&'b str>,
-}
-impl<'a, 'b> IndicesDeleteIndexTemplate<'a, 'b> {
-    #[doc = "Creates a new instance of [IndicesDeleteIndexTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesDeleteIndexTemplateParts<'b>) -> Self {
-        let headers = HeaderMap::new();
-        IndicesDeleteIndexTemplate {
-            client,
-            parts,
-            headers,
-            error_trace: None,
-            filter_path: None,
-            human: None,
-            master_timeout: None,
-            pretty: None,
-            source: None,
-            timeout: None,
-        }
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
-        self.master_timeout = Some(master_timeout);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Explicit operation timeout"]
-    pub fn timeout(mut self, timeout: &'b str) -> Self {
-        self.timeout = Some(timeout);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Indices Delete Index Template API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = Method::Delete;
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'b str>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-                #[serde(rename = "timeout")]
-                timeout: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                human: self.human,
-                master_timeout: self.master_timeout,
-                pretty: self.pretty,
-                source: self.source,
-                timeout: self.timeout,
-            };
-            Some(query_params)
-        };
-        let body = Option::<()>::None;
-        let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1470,7 +1334,7 @@ impl<'b> IndicesDeleteTemplateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Delete Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nDeletes an index template."]
 pub struct IndicesDeleteTemplate<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesDeleteTemplateParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1483,10 +1347,10 @@ pub struct IndicesDeleteTemplate<'a, 'b> {
 }
 impl<'a, 'b> IndicesDeleteTemplate<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesDeleteTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesDeleteTemplateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesDeleteTemplateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesDeleteTemplate {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1578,7 +1442,7 @@ impl<'a, 'b> IndicesDeleteTemplate<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1609,7 +1473,7 @@ impl<'b> IndicesExistsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Exists API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-exists.html)\n\nReturns information about whether a particular index exists."]
 pub struct IndicesExists<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesExistsParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -1626,10 +1490,10 @@ pub struct IndicesExists<'a, 'b> {
 }
 impl<'a, 'b> IndicesExists<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExists] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesExistsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesExistsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesExists {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -1760,7 +1624,7 @@ impl<'a, 'b> IndicesExists<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1808,7 +1672,7 @@ impl<'b> IndicesExistsAliasParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Exists Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html)\n\nReturns information about whether a particular alias exists."]
 pub struct IndicesExistsAlias<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesExistsAliasParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -1823,10 +1687,10 @@ pub struct IndicesExistsAlias<'a, 'b> {
 }
 impl<'a, 'b> IndicesExistsAlias<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExistsAlias] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesExistsAliasParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesExistsAliasParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesExistsAlias {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -1939,154 +1803,7 @@ impl<'a, 'b> IndicesExistsAlias<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Indices Exists Index Template API"]
-pub enum IndicesExistsIndexTemplateParts<'b> {
-    #[doc = "Name"]
-    Name(&'b str),
-}
-impl<'b> IndicesExistsIndexTemplateParts<'b> {
-    #[doc = "Builds a relative URL path to the Indices Exists Index Template API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            IndicesExistsIndexTemplateParts::Name(ref name) => {
-                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
-                let mut p = String::with_capacity(17usize + encoded_name.len());
-                p.push_str("/_index_template/");
-                p.push_str(encoded_name.as_ref());
-                p.into()
-            }
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Indices Exists Index Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nReturns information about whether a particular index template exists."]
-pub struct IndicesExistsIndexTemplate<'a, 'b> {
-    client: &'a Elasticsearch,
-    parts: IndicesExistsIndexTemplateParts<'b>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    flat_settings: Option<bool>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    local: Option<bool>,
-    master_timeout: Option<&'b str>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-}
-impl<'a, 'b> IndicesExistsIndexTemplate<'a, 'b> {
-    #[doc = "Creates a new instance of [IndicesExistsIndexTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesExistsIndexTemplateParts<'b>) -> Self {
-        let headers = HeaderMap::new();
-        IndicesExistsIndexTemplate {
-            client,
-            parts,
-            headers,
-            error_trace: None,
-            filter_path: None,
-            flat_settings: None,
-            human: None,
-            local: None,
-            master_timeout: None,
-            pretty: None,
-            source: None,
-        }
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "Return settings in flat format (default: false)"]
-    pub fn flat_settings(mut self, flat_settings: bool) -> Self {
-        self.flat_settings = Some(flat_settings);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Return local information, do not retrieve the state from master node (default: false)"]
-    pub fn local(mut self, local: bool) -> Self {
-        self.local = Some(local);
-        self
-    }
-    #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
-        self.master_timeout = Some(master_timeout);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Indices Exists Index Template API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = Method::Head;
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "flat_settings")]
-                flat_settings: Option<bool>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "local")]
-                local: Option<bool>,
-                #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'b str>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                flat_settings: self.flat_settings,
-                human: self.human,
-                local: self.local,
-                master_timeout: self.master_timeout,
-                pretty: self.pretty,
-                source: self.source,
-            };
-            Some(query_params)
-        };
-        let body = Option::<()>::None;
-        let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2117,7 +1834,7 @@ impl<'b> IndicesExistsTemplateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Exists Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nReturns information about whether a particular index template exists."]
 pub struct IndicesExistsTemplate<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesExistsTemplateParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -2131,10 +1848,10 @@ pub struct IndicesExistsTemplate<'a, 'b> {
 }
 impl<'a, 'b> IndicesExistsTemplate<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExistsTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesExistsTemplateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesExistsTemplateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesExistsTemplate {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -2235,7 +1952,7 @@ impl<'a, 'b> IndicesExistsTemplate<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2270,7 +1987,7 @@ impl<'b> IndicesExistsTypeParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Exists Type API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-types-exists.html)\n\nReturns information about whether a particular document type exists. (DEPRECATED)"]
 pub struct IndicesExistsType<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesExistsTypeParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -2285,10 +2002,10 @@ pub struct IndicesExistsType<'a, 'b> {
 }
 impl<'a, 'b> IndicesExistsType<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesExistsType] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesExistsTypeParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesExistsTypeParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesExistsType {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -2401,7 +2118,7 @@ impl<'a, 'b> IndicesExistsType<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2436,7 +2153,7 @@ impl<'b> IndicesFlushParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Flush API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-flush.html)\n\nPerforms the flush operation on one or more indices."]
 pub struct IndicesFlush<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesFlushParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -2456,10 +2173,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesFlush] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesFlushParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesFlushParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesFlush {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -2486,7 +2203,7 @@ where
         T: Serialize,
     {
         IndicesFlush {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -2607,7 +2324,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2642,7 +2359,7 @@ impl<'b> IndicesForcemergeParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Forcemerge API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-forcemerge.html)\n\nPerforms the force merge operation on one or more indices."]
 pub struct IndicesForcemerge<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesForcemergeParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -2663,10 +2380,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesForcemerge] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesForcemergeParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesForcemergeParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesForcemerge {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -2694,7 +2411,7 @@ where
         T: Serialize,
     {
         IndicesForcemerge {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -2821,7 +2538,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2852,7 +2569,7 @@ impl<'b> IndicesFreezeParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Freeze API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/freeze-index-api.html)\n\nFreezes an index. A frozen index has almost no overhead on the cluster (except for maintaining its metadata in memory) and is read-only."]
 pub struct IndicesFreeze<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesFreezeParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -2873,10 +2590,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesFreeze] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesFreezeParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesFreezeParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesFreeze {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -2904,7 +2621,7 @@ where
         T: Serialize,
     {
         IndicesFreeze {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -3031,7 +2748,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3062,7 +2779,7 @@ impl<'b> IndicesGetParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-index.html)\n\nReturns information about one or more indices."]
 pub struct IndicesGet<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesGetParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -3080,10 +2797,10 @@ pub struct IndicesGet<'a, 'b> {
 }
 impl<'a, 'b> IndicesGet<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGet] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesGetParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesGetParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesGet {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -3223,7 +2940,7 @@ impl<'a, 'b> IndicesGet<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3286,7 +3003,7 @@ impl<'b> IndicesGetAliasParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html)\n\nReturns an alias."]
 pub struct IndicesGetAlias<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesGetAliasParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -3301,10 +3018,10 @@ pub struct IndicesGetAlias<'a, 'b> {
 }
 impl<'a, 'b> IndicesGetAlias<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetAlias] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesGetAliasParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesGetAliasParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesGetAlias {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -3417,7 +3134,7 @@ impl<'a, 'b> IndicesGetAlias<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3465,7 +3182,7 @@ impl<'b> IndicesGetFieldMappingParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Field Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-field-mapping.html)\n\nReturns mapping for one or more fields."]
 pub struct IndicesGetFieldMapping<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesGetFieldMappingParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -3481,10 +3198,10 @@ pub struct IndicesGetFieldMapping<'a, 'b> {
 }
 impl<'a, 'b> IndicesGetFieldMapping<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetFieldMapping] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesGetFieldMappingParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesGetFieldMappingParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesGetFieldMapping {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -3606,159 +3323,7 @@ impl<'a, 'b> IndicesGetFieldMapping<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Indices Get Index Template API"]
-pub enum IndicesGetIndexTemplateParts<'b> {
-    #[doc = "No parts"]
-    None,
-    #[doc = "Name"]
-    Name(&'b [&'b str]),
-}
-impl<'b> IndicesGetIndexTemplateParts<'b> {
-    #[doc = "Builds a relative URL path to the Indices Get Index Template API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            IndicesGetIndexTemplateParts::None => "/_index_template".into(),
-            IndicesGetIndexTemplateParts::Name(ref name) => {
-                let name_str = name.join(",");
-                let encoded_name: Cow<str> =
-                    percent_encode(name_str.as_bytes(), PARTS_ENCODED).into();
-                let mut p = String::with_capacity(17usize + encoded_name.len());
-                p.push_str("/_index_template/");
-                p.push_str(encoded_name.as_ref());
-                p.into()
-            }
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Indices Get Index Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nReturns an index template."]
-pub struct IndicesGetIndexTemplate<'a, 'b> {
-    client: &'a Elasticsearch,
-    parts: IndicesGetIndexTemplateParts<'b>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    flat_settings: Option<bool>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    local: Option<bool>,
-    master_timeout: Option<&'b str>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-}
-impl<'a, 'b> IndicesGetIndexTemplate<'a, 'b> {
-    #[doc = "Creates a new instance of [IndicesGetIndexTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesGetIndexTemplateParts<'b>) -> Self {
-        let headers = HeaderMap::new();
-        IndicesGetIndexTemplate {
-            client,
-            parts,
-            headers,
-            error_trace: None,
-            filter_path: None,
-            flat_settings: None,
-            human: None,
-            local: None,
-            master_timeout: None,
-            pretty: None,
-            source: None,
-        }
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "Return settings in flat format (default: false)"]
-    pub fn flat_settings(mut self, flat_settings: bool) -> Self {
-        self.flat_settings = Some(flat_settings);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Return local information, do not retrieve the state from master node (default: false)"]
-    pub fn local(mut self, local: bool) -> Self {
-        self.local = Some(local);
-        self
-    }
-    #[doc = "Explicit operation timeout for connection to master node"]
-    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
-        self.master_timeout = Some(master_timeout);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Indices Get Index Template API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = Method::Get;
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "flat_settings")]
-                flat_settings: Option<bool>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "local")]
-                local: Option<bool>,
-                #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'b str>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                flat_settings: self.flat_settings,
-                human: self.human,
-                local: self.local,
-                master_timeout: self.master_timeout,
-                pretty: self.pretty,
-                source: self.source,
-            };
-            Some(query_params)
-        };
-        let body = Option::<()>::None;
-        let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3793,7 +3358,7 @@ impl<'b> IndicesGetMappingParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-mapping.html)\n\nReturns mappings for one or more indices."]
 pub struct IndicesGetMapping<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesGetMappingParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -3809,10 +3374,10 @@ pub struct IndicesGetMapping<'a, 'b> {
 }
 impl<'a, 'b> IndicesGetMapping<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetMapping] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesGetMappingParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesGetMappingParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesGetMapping {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -3934,7 +3499,7 @@ impl<'a, 'b> IndicesGetMapping<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3997,7 +3562,7 @@ impl<'b> IndicesGetSettingsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-settings.html)\n\nReturns settings for one or more indices."]
 pub struct IndicesGetSettings<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesGetSettingsParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -4015,10 +3580,10 @@ pub struct IndicesGetSettings<'a, 'b> {
 }
 impl<'a, 'b> IndicesGetSettings<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetSettings] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesGetSettingsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesGetSettingsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesGetSettings {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -4158,7 +3723,7 @@ impl<'a, 'b> IndicesGetSettings<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4192,7 +3757,7 @@ impl<'b> IndicesGetTemplateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nReturns an index template."]
 pub struct IndicesGetTemplate<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesGetTemplateParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -4206,10 +3771,10 @@ pub struct IndicesGetTemplate<'a, 'b> {
 }
 impl<'a, 'b> IndicesGetTemplate<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesGetTemplateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesGetTemplateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesGetTemplate {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -4310,7 +3875,7 @@ impl<'a, 'b> IndicesGetTemplate<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4345,7 +3910,7 @@ impl<'b> IndicesGetUpgradeParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Get Upgrade API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-upgrade.html)\n\nDEPRECATED Returns a progress status of current upgrade."]
 pub struct IndicesGetUpgrade<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesGetUpgradeParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -4359,10 +3924,10 @@ pub struct IndicesGetUpgrade<'a, 'b> {
 }
 impl<'a, 'b> IndicesGetUpgrade<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesGetUpgrade] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesGetUpgradeParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesGetUpgradeParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesGetUpgrade {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -4466,7 +4031,7 @@ impl<'a, 'b> IndicesGetUpgrade<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4498,7 +4063,7 @@ impl<'b> IndicesOpenParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Open API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-open-close.html)\n\nOpens an index."]
 pub struct IndicesOpen<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesOpenParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -4519,10 +4084,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesOpen] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesOpenParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesOpenParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesOpen {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -4550,7 +4115,7 @@ where
         T: Serialize,
     {
         IndicesOpen {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -4677,7 +4242,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4712,7 +4277,7 @@ impl<'b> IndicesPutAliasParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Put Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html)\n\nCreates or updates an alias."]
 pub struct IndicesPutAlias<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesPutAliasParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -4729,10 +4294,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesPutAlias] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesPutAliasParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesPutAliasParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesPutAlias {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -4751,7 +4316,7 @@ where
         T: Serialize,
     {
         IndicesPutAlias {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -4844,179 +4409,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Indices Put Index Template API"]
-pub enum IndicesPutIndexTemplateParts<'b> {
-    #[doc = "Name"]
-    Name(&'b str),
-}
-impl<'b> IndicesPutIndexTemplateParts<'b> {
-    #[doc = "Builds a relative URL path to the Indices Put Index Template API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            IndicesPutIndexTemplateParts::Name(ref name) => {
-                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
-                let mut p = String::with_capacity(17usize + encoded_name.len());
-                p.push_str("/_index_template/");
-                p.push_str(encoded_name.as_ref());
-                p.into()
-            }
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Indices Put Index Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nCreates or updates an index template."]
-pub struct IndicesPutIndexTemplate<'a, 'b, B> {
-    client: &'a Elasticsearch,
-    parts: IndicesPutIndexTemplateParts<'b>,
-    body: Option<B>,
-    cause: Option<&'b str>,
-    create: Option<bool>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    master_timeout: Option<&'b str>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-}
-impl<'a, 'b, B> IndicesPutIndexTemplate<'a, 'b, B>
-where
-    B: Body,
-{
-    #[doc = "Creates a new instance of [IndicesPutIndexTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesPutIndexTemplateParts<'b>) -> Self {
-        let headers = HeaderMap::new();
-        IndicesPutIndexTemplate {
-            client,
-            parts,
-            headers,
-            body: None,
-            cause: None,
-            create: None,
-            error_trace: None,
-            filter_path: None,
-            human: None,
-            master_timeout: None,
-            pretty: None,
-            source: None,
-        }
-    }
-    #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesPutIndexTemplate<'a, 'b, JsonBody<T>>
-    where
-        T: Serialize,
-    {
-        IndicesPutIndexTemplate {
-            client: self.client,
-            parts: self.parts,
-            body: Some(body.into()),
-            cause: self.cause,
-            create: self.create,
-            error_trace: self.error_trace,
-            filter_path: self.filter_path,
-            headers: self.headers,
-            human: self.human,
-            master_timeout: self.master_timeout,
-            pretty: self.pretty,
-            source: self.source,
-        }
-    }
-    #[doc = "User defined reason for creating/updating the index template"]
-    pub fn cause(mut self, cause: &'b str) -> Self {
-        self.cause = Some(cause);
-        self
-    }
-    #[doc = "Whether the index template should only be added if new or can also replace an existing one"]
-    pub fn create(mut self, create: bool) -> Self {
-        self.create = Some(create);
-        self
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
-        self.master_timeout = Some(master_timeout);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Indices Put Index Template API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = Method::Put;
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "cause")]
-                cause: Option<&'b str>,
-                #[serde(rename = "create")]
-                create: Option<bool>,
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'b str>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                cause: self.cause,
-                create: self.create,
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                human: self.human,
-                master_timeout: self.master_timeout,
-                pretty: self.pretty,
-                source: self.source,
-            };
-            Some(query_params)
-        };
-        let body = self.body;
-        let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5048,7 +4441,7 @@ impl<'b> IndicesPutMappingParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Put Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-put-mapping.html)\n\nUpdates the index mappings."]
 pub struct IndicesPutMapping<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesPutMappingParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -5068,10 +4461,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesPutMapping] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesPutMappingParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesPutMappingParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesPutMapping {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -5098,7 +4491,7 @@ where
         T: Serialize,
     {
         IndicesPutMapping {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -5216,7 +4609,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5251,7 +4644,7 @@ impl<'b> IndicesPutSettingsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Put Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-update-settings.html)\n\nUpdates the index settings."]
 pub struct IndicesPutSettings<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesPutSettingsParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -5273,10 +4666,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesPutSettings] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesPutSettingsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesPutSettingsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesPutSettings {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -5305,7 +4698,7 @@ where
         T: Serialize,
     {
         IndicesPutSettings {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -5441,7 +4834,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5470,7 +4863,7 @@ impl<'b> IndicesPutTemplateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Put Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nCreates or updates an index template."]
 pub struct IndicesPutTemplate<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesPutTemplateParts<'b>,
     body: Option<B>,
     create: Option<bool>,
@@ -5488,10 +4881,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesPutTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesPutTemplateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesPutTemplateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesPutTemplate {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -5511,7 +4904,7 @@ where
         T: Serialize,
     {
         IndicesPutTemplate {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             create: self.create,
@@ -5613,7 +5006,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5648,7 +5041,7 @@ impl<'b> IndicesRecoveryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Recovery API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-recovery.html)\n\nReturns information about ongoing index shard recoveries."]
 pub struct IndicesRecovery<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesRecoveryParts<'b>,
     active_only: Option<bool>,
     detailed: Option<bool>,
@@ -5661,10 +5054,10 @@ pub struct IndicesRecovery<'a, 'b> {
 }
 impl<'a, 'b> IndicesRecovery<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesRecovery] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesRecoveryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesRecoveryParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesRecovery {
-            client,
+            transport,
             parts,
             headers,
             active_only: None,
@@ -5756,7 +5149,7 @@ impl<'a, 'b> IndicesRecovery<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5791,7 +5184,7 @@ impl<'b> IndicesRefreshParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Refresh API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-refresh.html)\n\nPerforms the refresh operation in one or more indices."]
 pub struct IndicesRefresh<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesRefreshParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -5809,10 +5202,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesRefresh] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesRefreshParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesRefreshParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesRefresh {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -5837,7 +5230,7 @@ where
         T: Serialize,
     {
         IndicesRefresh {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -5940,7 +5333,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5972,7 +5365,7 @@ impl<'b> IndicesReloadSearchAnalyzersParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Reload Search Analyzers API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-reload-analyzers.html)\n\nReloads an index's search analyzers and their resources."]
 pub struct IndicesReloadSearchAnalyzers<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesReloadSearchAnalyzersParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -5990,10 +5383,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesReloadSearchAnalyzers] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesReloadSearchAnalyzersParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesReloadSearchAnalyzersParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesReloadSearchAnalyzers {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -6018,7 +5411,7 @@ where
         T: Serialize,
     {
         IndicesReloadSearchAnalyzers {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -6121,7 +5514,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6167,7 +5560,7 @@ impl<'b> IndicesRolloverParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Rollover API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-rollover-index.html)\n\nUpdates an alias to point to a new index when the existing index\nis considered to be too large or too old."]
 pub struct IndicesRollover<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesRolloverParts<'b>,
     body: Option<B>,
     dry_run: Option<bool>,
@@ -6186,10 +5579,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesRollover] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesRolloverParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesRolloverParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesRollover {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -6210,7 +5603,7 @@ where
         T: Serialize,
     {
         IndicesRollover {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             dry_run: self.dry_run,
@@ -6321,7 +5714,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6356,7 +5749,7 @@ impl<'b> IndicesSegmentsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Segments API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-segments.html)\n\nProvides low-level information about segments in a Lucene index."]
 pub struct IndicesSegments<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesSegmentsParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -6371,10 +5764,10 @@ pub struct IndicesSegments<'a, 'b> {
 }
 impl<'a, 'b> IndicesSegments<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesSegments] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesSegmentsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesSegmentsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesSegments {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -6487,7 +5880,7 @@ impl<'a, 'b> IndicesSegments<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6522,7 +5915,7 @@ impl<'b> IndicesShardStoresParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Shard Stores API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-shards-stores.html)\n\nProvides store information for shard copies of indices."]
 pub struct IndicesShardStores<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesShardStoresParts<'b>,
     allow_no_indices: Option<bool>,
     error_trace: Option<bool>,
@@ -6537,10 +5930,10 @@ pub struct IndicesShardStores<'a, 'b> {
 }
 impl<'a, 'b> IndicesShardStores<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesShardStores] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesShardStoresParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesShardStoresParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesShardStores {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -6653,7 +6046,7 @@ impl<'a, 'b> IndicesShardStores<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6688,7 +6081,7 @@ impl<'b> IndicesShrinkParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Shrink API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-shrink-index.html)\n\nAllow to shrink an existing index into a new index with fewer primary shards."]
 pub struct IndicesShrink<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesShrinkParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -6706,10 +6099,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesShrink] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesShrinkParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesShrinkParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesShrink {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -6729,7 +6122,7 @@ where
         T: Serialize,
     {
         IndicesShrink {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -6831,354 +6224,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Indices Simulate Index Template API"]
-pub enum IndicesSimulateIndexTemplateParts<'b> {
-    #[doc = "Name"]
-    Name(&'b str),
-}
-impl<'b> IndicesSimulateIndexTemplateParts<'b> {
-    #[doc = "Builds a relative URL path to the Indices Simulate Index Template API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            IndicesSimulateIndexTemplateParts::Name(ref name) => {
-                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
-                let mut p = String::with_capacity(33usize + encoded_name.len());
-                p.push_str("/_index_template/_simulate_index/");
-                p.push_str(encoded_name.as_ref());
-                p.into()
-            }
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Indices Simulate Index Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nSimulate matching the given index name against the index templates in the system"]
-pub struct IndicesSimulateIndexTemplate<'a, 'b, B> {
-    client: &'a Elasticsearch,
-    parts: IndicesSimulateIndexTemplateParts<'b>,
-    body: Option<B>,
-    cause: Option<&'b str>,
-    create: Option<bool>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    master_timeout: Option<&'b str>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-}
-impl<'a, 'b, B> IndicesSimulateIndexTemplate<'a, 'b, B>
-where
-    B: Body,
-{
-    #[doc = "Creates a new instance of [IndicesSimulateIndexTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesSimulateIndexTemplateParts<'b>) -> Self {
-        let headers = HeaderMap::new();
-        IndicesSimulateIndexTemplate {
-            client,
-            parts,
-            headers,
-            body: None,
-            cause: None,
-            create: None,
-            error_trace: None,
-            filter_path: None,
-            human: None,
-            master_timeout: None,
-            pretty: None,
-            source: None,
-        }
-    }
-    #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesSimulateIndexTemplate<'a, 'b, JsonBody<T>>
-    where
-        T: Serialize,
-    {
-        IndicesSimulateIndexTemplate {
-            client: self.client,
-            parts: self.parts,
-            body: Some(body.into()),
-            cause: self.cause,
-            create: self.create,
-            error_trace: self.error_trace,
-            filter_path: self.filter_path,
-            headers: self.headers,
-            human: self.human,
-            master_timeout: self.master_timeout,
-            pretty: self.pretty,
-            source: self.source,
-        }
-    }
-    #[doc = "User defined reason for dry-run creating the new template for simulation purposes"]
-    pub fn cause(mut self, cause: &'b str) -> Self {
-        self.cause = Some(cause);
-        self
-    }
-    #[doc = "Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one"]
-    pub fn create(mut self, create: bool) -> Self {
-        self.create = Some(create);
-        self
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
-        self.master_timeout = Some(master_timeout);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Indices Simulate Index Template API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = Method::Post;
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "cause")]
-                cause: Option<&'b str>,
-                #[serde(rename = "create")]
-                create: Option<bool>,
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'b str>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                cause: self.cause,
-                create: self.create,
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                human: self.human,
-                master_timeout: self.master_timeout,
-                pretty: self.pretty,
-                source: self.source,
-            };
-            Some(query_params)
-        };
-        let body = self.body;
-        let response = self
-            .client
-            .send(method, &path, headers, query_string.as_ref(), body)
-            .await?;
-        Ok(response)
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[doc = "API parts for the Indices Simulate Template API"]
-pub enum IndicesSimulateTemplateParts<'b> {
-    #[doc = "No parts"]
-    None,
-    #[doc = "Name"]
-    Name(&'b str),
-}
-impl<'b> IndicesSimulateTemplateParts<'b> {
-    #[doc = "Builds a relative URL path to the Indices Simulate Template API"]
-    pub fn url(self) -> Cow<'static, str> {
-        match self {
-            IndicesSimulateTemplateParts::None => "/_index_template/_simulate".into(),
-            IndicesSimulateTemplateParts::Name(ref name) => {
-                let encoded_name: Cow<str> = percent_encode(name.as_bytes(), PARTS_ENCODED).into();
-                let mut p = String::with_capacity(27usize + encoded_name.len());
-                p.push_str("/_index_template/_simulate/");
-                p.push_str(encoded_name.as_ref());
-                p.into()
-            }
-        }
-    }
-}
-#[derive(Clone, Debug)]
-#[doc = "Builder for the [Indices Simulate Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nSimulate resolving the given template name or body"]
-pub struct IndicesSimulateTemplate<'a, 'b, B> {
-    client: &'a Elasticsearch,
-    parts: IndicesSimulateTemplateParts<'b>,
-    body: Option<B>,
-    cause: Option<&'b str>,
-    create: Option<bool>,
-    error_trace: Option<bool>,
-    filter_path: Option<&'b [&'b str]>,
-    headers: HeaderMap,
-    human: Option<bool>,
-    master_timeout: Option<&'b str>,
-    pretty: Option<bool>,
-    source: Option<&'b str>,
-}
-impl<'a, 'b, B> IndicesSimulateTemplate<'a, 'b, B>
-where
-    B: Body,
-{
-    #[doc = "Creates a new instance of [IndicesSimulateTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesSimulateTemplateParts<'b>) -> Self {
-        let headers = HeaderMap::new();
-        IndicesSimulateTemplate {
-            client,
-            parts,
-            headers,
-            body: None,
-            cause: None,
-            create: None,
-            error_trace: None,
-            filter_path: None,
-            human: None,
-            master_timeout: None,
-            pretty: None,
-            source: None,
-        }
-    }
-    #[doc = "The body for the API call"]
-    pub fn body<T>(self, body: T) -> IndicesSimulateTemplate<'a, 'b, JsonBody<T>>
-    where
-        T: Serialize,
-    {
-        IndicesSimulateTemplate {
-            client: self.client,
-            parts: self.parts,
-            body: Some(body.into()),
-            cause: self.cause,
-            create: self.create,
-            error_trace: self.error_trace,
-            filter_path: self.filter_path,
-            headers: self.headers,
-            human: self.human,
-            master_timeout: self.master_timeout,
-            pretty: self.pretty,
-            source: self.source,
-        }
-    }
-    #[doc = "User defined reason for dry-run creating the new template for simulation purposes"]
-    pub fn cause(mut self, cause: &'b str) -> Self {
-        self.cause = Some(cause);
-        self
-    }
-    #[doc = "Whether the index template we optionally defined in the body should only be dry-run added if new or can also replace an existing one"]
-    pub fn create(mut self, create: bool) -> Self {
-        self.create = Some(create);
-        self
-    }
-    #[doc = "Include the stack trace of returned errors."]
-    pub fn error_trace(mut self, error_trace: bool) -> Self {
-        self.error_trace = Some(error_trace);
-        self
-    }
-    #[doc = "A comma-separated list of filters used to reduce the response."]
-    pub fn filter_path(mut self, filter_path: &'b [&'b str]) -> Self {
-        self.filter_path = Some(filter_path);
-        self
-    }
-    #[doc = "Adds a HTTP header"]
-    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
-        self.headers.insert(key, value);
-        self
-    }
-    #[doc = "Return human readable values for statistics."]
-    pub fn human(mut self, human: bool) -> Self {
-        self.human = Some(human);
-        self
-    }
-    #[doc = "Specify timeout for connection to master"]
-    pub fn master_timeout(mut self, master_timeout: &'b str) -> Self {
-        self.master_timeout = Some(master_timeout);
-        self
-    }
-    #[doc = "Pretty format the returned JSON response."]
-    pub fn pretty(mut self, pretty: bool) -> Self {
-        self.pretty = Some(pretty);
-        self
-    }
-    #[doc = "The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."]
-    pub fn source(mut self, source: &'b str) -> Self {
-        self.source = Some(source);
-        self
-    }
-    #[doc = "Creates an asynchronous call to the Indices Simulate Template API that can be awaited"]
-    pub async fn send(self) -> Result<Response, Error> {
-        let path = self.parts.url();
-        let method = Method::Post;
-        let headers = self.headers;
-        let query_string = {
-            #[serde_with::skip_serializing_none]
-            #[derive(Serialize)]
-            struct QueryParams<'b> {
-                #[serde(rename = "cause")]
-                cause: Option<&'b str>,
-                #[serde(rename = "create")]
-                create: Option<bool>,
-                #[serde(rename = "error_trace")]
-                error_trace: Option<bool>,
-                #[serde(
-                    rename = "filter_path",
-                    serialize_with = "crate::client::serialize_coll_qs"
-                )]
-                filter_path: Option<&'b [&'b str]>,
-                #[serde(rename = "human")]
-                human: Option<bool>,
-                #[serde(rename = "master_timeout")]
-                master_timeout: Option<&'b str>,
-                #[serde(rename = "pretty")]
-                pretty: Option<bool>,
-                #[serde(rename = "source")]
-                source: Option<&'b str>,
-            }
-            let query_params = QueryParams {
-                cause: self.cause,
-                create: self.create,
-                error_trace: self.error_trace,
-                filter_path: self.filter_path,
-                human: self.human,
-                master_timeout: self.master_timeout,
-                pretty: self.pretty,
-                source: self.source,
-            };
-            Some(query_params)
-        };
-        let body = self.body;
-        let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -7213,7 +6259,7 @@ impl<'b> IndicesSplitParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Split API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-split-index.html)\n\nAllows you to split an existing index into a new index with more primary shards."]
 pub struct IndicesSplit<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesSplitParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -7231,10 +6277,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesSplit] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesSplitParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesSplitParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesSplit {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -7254,7 +6300,7 @@ where
         T: Serialize,
     {
         IndicesSplit {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -7356,7 +6402,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -7419,7 +6465,7 @@ impl<'b> IndicesStatsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-stats.html)\n\nProvides statistics on operations happening in an index."]
 pub struct IndicesStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesStatsParts<'b>,
     completion_fields: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
@@ -7440,10 +6486,10 @@ pub struct IndicesStats<'a, 'b> {
 }
 impl<'a, 'b> IndicesStats<'a, 'b> {
     #[doc = "Creates a new instance of [IndicesStats] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesStatsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesStatsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesStats {
-            client,
+            transport,
             parts,
             headers,
             completion_fields: None,
@@ -7616,7 +6662,7 @@ impl<'a, 'b> IndicesStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -7647,7 +6693,7 @@ impl<'b> IndicesUnfreezeParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Unfreeze API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/unfreeze-index-api.html)\n\nUnfreezes an index. When a frozen index is unfrozen, the index goes through the normal recovery process and becomes writeable again."]
 pub struct IndicesUnfreeze<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesUnfreezeParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -7668,10 +6714,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesUnfreeze] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesUnfreezeParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesUnfreezeParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesUnfreeze {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -7699,7 +6745,7 @@ where
         T: Serialize,
     {
         IndicesUnfreeze {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -7826,7 +6872,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -7849,7 +6895,7 @@ impl IndicesUpdateAliasesParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Update Aliases API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html)\n\nUpdates index aliases."]
 pub struct IndicesUpdateAliases<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesUpdateAliasesParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -7866,10 +6912,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesUpdateAliases]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         IndicesUpdateAliases {
-            client,
+            transport,
             parts: IndicesUpdateAliasesParts::None,
             headers,
             body: None,
@@ -7888,7 +6934,7 @@ where
         T: Serialize,
     {
         IndicesUpdateAliases {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -7981,7 +7027,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -8016,7 +7062,7 @@ impl<'b> IndicesUpgradeParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Upgrade API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-upgrade.html)\n\nDEPRECATED Upgrades to the current version of Lucene."]
 pub struct IndicesUpgrade<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesUpgradeParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -8036,10 +7082,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesUpgrade] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesUpgradeParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesUpgradeParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesUpgrade {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -8066,7 +7112,7 @@ where
         T: Serialize,
     {
         IndicesUpgrade {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -8184,7 +7230,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -8235,7 +7281,7 @@ impl<'b> IndicesValidateQueryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Indices Validate Query API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-validate.html)\n\nAllows a user to validate a potentially expensive query without executing it."]
 pub struct IndicesValidateQuery<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndicesValidateQueryParts<'b>,
     all_shards: Option<bool>,
     allow_no_indices: Option<bool>,
@@ -8262,10 +7308,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IndicesValidateQuery] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndicesValidateQueryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndicesValidateQueryParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IndicesValidateQuery {
-            client,
+            transport,
             parts,
             headers,
             all_shards: None,
@@ -8314,7 +7360,7 @@ where
         T: Serialize,
     {
         IndicesValidateQuery {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             all_shards: self.all_shards,
@@ -8483,7 +7529,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -8491,273 +7537,234 @@ where
 }
 #[doc = "Namespace client for Indices APIs"]
 pub struct Indices<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Indices<'a> {
     #[doc = "Creates a new instance of [Indices]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Indices Analyze API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-analyze.html)\n\nPerforms the analysis process on a text and return the tokens breakdown of the text."]
     pub fn analyze<'b>(&'a self, parts: IndicesAnalyzeParts<'b>) -> IndicesAnalyze<'a, 'b, ()> {
-        IndicesAnalyze::new(&self.client, parts)
+        IndicesAnalyze::new(self.transport(), parts)
     }
     #[doc = "[Indices Clear Cache API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-clearcache.html)\n\nClears all or specific caches for one or more indices."]
     pub fn clear_cache<'b>(
         &'a self,
         parts: IndicesClearCacheParts<'b>,
     ) -> IndicesClearCache<'a, 'b, ()> {
-        IndicesClearCache::new(&self.client, parts)
+        IndicesClearCache::new(self.transport(), parts)
     }
     #[doc = "[Indices Clone API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-clone-index.html)\n\nClones an index"]
     pub fn clone<'b>(&'a self, parts: IndicesCloneParts<'b>) -> IndicesClone<'a, 'b, ()> {
-        IndicesClone::new(&self.client, parts)
+        IndicesClone::new(self.transport(), parts)
     }
     #[doc = "[Indices Close API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-open-close.html)\n\nCloses an index."]
     pub fn close<'b>(&'a self, parts: IndicesCloseParts<'b>) -> IndicesClose<'a, 'b, ()> {
-        IndicesClose::new(&self.client, parts)
+        IndicesClose::new(self.transport(), parts)
     }
     #[doc = "[Indices Create API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-create-index.html)\n\nCreates an index with optional settings and mappings.\n\n# Examples\n\nCreate an index with a mapping\n\n```rust,no_run\n# use elasticsearch::{Elasticsearch, Error, indices::IndicesCreateParts};\n# use serde_json::{json, Value};\n# async fn doc() -> Result<(), Box<dyn std::error::Error>> {\nlet client = Elasticsearch::default();\nlet response = client\n    .indices()\n    .create(IndicesCreateParts::Index(\"test_index\"))\n    .body(json!({\n        \"mappings\" : {\n            \"properties\" : {\n                \"field1\" : { \"type\" : \"text\" }\n            }\n        }\n    }))\n    .send()\n    .await?;\n    \n# Ok(())\n# }\n```"]
     pub fn create<'b>(&'a self, parts: IndicesCreateParts<'b>) -> IndicesCreate<'a, 'b, ()> {
-        IndicesCreate::new(&self.client, parts)
+        IndicesCreate::new(self.transport(), parts)
     }
     #[doc = "[Indices Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-delete-index.html)\n\nDeletes an index."]
     pub fn delete<'b>(&'a self, parts: IndicesDeleteParts<'b>) -> IndicesDelete<'a, 'b> {
-        IndicesDelete::new(&self.client, parts)
+        IndicesDelete::new(self.transport(), parts)
     }
     #[doc = "[Indices Delete Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html)\n\nDeletes an alias."]
     pub fn delete_alias<'b>(
         &'a self,
         parts: IndicesDeleteAliasParts<'b>,
     ) -> IndicesDeleteAlias<'a, 'b> {
-        IndicesDeleteAlias::new(&self.client, parts)
-    }
-    #[doc = "[Indices Delete Index Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nDeletes an index template."]
-    pub fn delete_index_template<'b>(
-        &'a self,
-        parts: IndicesDeleteIndexTemplateParts<'b>,
-    ) -> IndicesDeleteIndexTemplate<'a, 'b> {
-        IndicesDeleteIndexTemplate::new(&self.client, parts)
+        IndicesDeleteAlias::new(self.transport(), parts)
     }
     #[doc = "[Indices Delete Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nDeletes an index template."]
     pub fn delete_template<'b>(
         &'a self,
         parts: IndicesDeleteTemplateParts<'b>,
     ) -> IndicesDeleteTemplate<'a, 'b> {
-        IndicesDeleteTemplate::new(&self.client, parts)
+        IndicesDeleteTemplate::new(self.transport(), parts)
     }
     #[doc = "[Indices Exists API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-exists.html)\n\nReturns information about whether a particular index exists."]
     pub fn exists<'b>(&'a self, parts: IndicesExistsParts<'b>) -> IndicesExists<'a, 'b> {
-        IndicesExists::new(&self.client, parts)
+        IndicesExists::new(self.transport(), parts)
     }
     #[doc = "[Indices Exists Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html)\n\nReturns information about whether a particular alias exists."]
     pub fn exists_alias<'b>(
         &'a self,
         parts: IndicesExistsAliasParts<'b>,
     ) -> IndicesExistsAlias<'a, 'b> {
-        IndicesExistsAlias::new(&self.client, parts)
-    }
-    #[doc = "[Indices Exists Index Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nReturns information about whether a particular index template exists."]
-    pub fn exists_index_template<'b>(
-        &'a self,
-        parts: IndicesExistsIndexTemplateParts<'b>,
-    ) -> IndicesExistsIndexTemplate<'a, 'b> {
-        IndicesExistsIndexTemplate::new(&self.client, parts)
+        IndicesExistsAlias::new(self.transport(), parts)
     }
     #[doc = "[Indices Exists Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nReturns information about whether a particular index template exists."]
     pub fn exists_template<'b>(
         &'a self,
         parts: IndicesExistsTemplateParts<'b>,
     ) -> IndicesExistsTemplate<'a, 'b> {
-        IndicesExistsTemplate::new(&self.client, parts)
+        IndicesExistsTemplate::new(self.transport(), parts)
     }
     #[doc = "[Indices Exists Type API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-types-exists.html)\n\nReturns information about whether a particular document type exists. (DEPRECATED)"]
     pub fn exists_type<'b>(
         &'a self,
         parts: IndicesExistsTypeParts<'b>,
     ) -> IndicesExistsType<'a, 'b> {
-        IndicesExistsType::new(&self.client, parts)
+        IndicesExistsType::new(self.transport(), parts)
     }
     #[doc = "[Indices Flush API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-flush.html)\n\nPerforms the flush operation on one or more indices."]
     pub fn flush<'b>(&'a self, parts: IndicesFlushParts<'b>) -> IndicesFlush<'a, 'b, ()> {
-        IndicesFlush::new(&self.client, parts)
+        IndicesFlush::new(self.transport(), parts)
     }
     #[doc = "[Indices Forcemerge API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-forcemerge.html)\n\nPerforms the force merge operation on one or more indices."]
     pub fn forcemerge<'b>(
         &'a self,
         parts: IndicesForcemergeParts<'b>,
     ) -> IndicesForcemerge<'a, 'b, ()> {
-        IndicesForcemerge::new(&self.client, parts)
+        IndicesForcemerge::new(self.transport(), parts)
     }
     #[doc = "[Indices Freeze API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/freeze-index-api.html)\n\nFreezes an index. A frozen index has almost no overhead on the cluster (except for maintaining its metadata in memory) and is read-only."]
     pub fn freeze<'b>(&'a self, parts: IndicesFreezeParts<'b>) -> IndicesFreeze<'a, 'b, ()> {
-        IndicesFreeze::new(&self.client, parts)
+        IndicesFreeze::new(self.transport(), parts)
     }
     #[doc = "[Indices Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-index.html)\n\nReturns information about one or more indices."]
     pub fn get<'b>(&'a self, parts: IndicesGetParts<'b>) -> IndicesGet<'a, 'b> {
-        IndicesGet::new(&self.client, parts)
+        IndicesGet::new(self.transport(), parts)
     }
     #[doc = "[Indices Get Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html)\n\nReturns an alias."]
     pub fn get_alias<'b>(&'a self, parts: IndicesGetAliasParts<'b>) -> IndicesGetAlias<'a, 'b> {
-        IndicesGetAlias::new(&self.client, parts)
+        IndicesGetAlias::new(self.transport(), parts)
     }
     #[doc = "[Indices Get Field Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-field-mapping.html)\n\nReturns mapping for one or more fields."]
     pub fn get_field_mapping<'b>(
         &'a self,
         parts: IndicesGetFieldMappingParts<'b>,
     ) -> IndicesGetFieldMapping<'a, 'b> {
-        IndicesGetFieldMapping::new(&self.client, parts)
-    }
-    #[doc = "[Indices Get Index Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nReturns an index template."]
-    pub fn get_index_template<'b>(
-        &'a self,
-        parts: IndicesGetIndexTemplateParts<'b>,
-    ) -> IndicesGetIndexTemplate<'a, 'b> {
-        IndicesGetIndexTemplate::new(&self.client, parts)
+        IndicesGetFieldMapping::new(self.transport(), parts)
     }
     #[doc = "[Indices Get Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-mapping.html)\n\nReturns mappings for one or more indices."]
     pub fn get_mapping<'b>(
         &'a self,
         parts: IndicesGetMappingParts<'b>,
     ) -> IndicesGetMapping<'a, 'b> {
-        IndicesGetMapping::new(&self.client, parts)
+        IndicesGetMapping::new(self.transport(), parts)
     }
     #[doc = "[Indices Get Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-get-settings.html)\n\nReturns settings for one or more indices."]
     pub fn get_settings<'b>(
         &'a self,
         parts: IndicesGetSettingsParts<'b>,
     ) -> IndicesGetSettings<'a, 'b> {
-        IndicesGetSettings::new(&self.client, parts)
+        IndicesGetSettings::new(self.transport(), parts)
     }
     #[doc = "[Indices Get Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nReturns an index template."]
     pub fn get_template<'b>(
         &'a self,
         parts: IndicesGetTemplateParts<'b>,
     ) -> IndicesGetTemplate<'a, 'b> {
-        IndicesGetTemplate::new(&self.client, parts)
+        IndicesGetTemplate::new(self.transport(), parts)
     }
     #[doc = "[Indices Get Upgrade API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-upgrade.html)\n\nDEPRECATED Returns a progress status of current upgrade."]
     pub fn get_upgrade<'b>(
         &'a self,
         parts: IndicesGetUpgradeParts<'b>,
     ) -> IndicesGetUpgrade<'a, 'b> {
-        IndicesGetUpgrade::new(&self.client, parts)
+        IndicesGetUpgrade::new(self.transport(), parts)
     }
     #[doc = "[Indices Open API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-open-close.html)\n\nOpens an index."]
     pub fn open<'b>(&'a self, parts: IndicesOpenParts<'b>) -> IndicesOpen<'a, 'b, ()> {
-        IndicesOpen::new(&self.client, parts)
+        IndicesOpen::new(self.transport(), parts)
     }
     #[doc = "[Indices Put Alias API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html)\n\nCreates or updates an alias."]
     pub fn put_alias<'b>(&'a self, parts: IndicesPutAliasParts<'b>) -> IndicesPutAlias<'a, 'b, ()> {
-        IndicesPutAlias::new(&self.client, parts)
-    }
-    #[doc = "[Indices Put Index Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nCreates or updates an index template."]
-    pub fn put_index_template<'b>(
-        &'a self,
-        parts: IndicesPutIndexTemplateParts<'b>,
-    ) -> IndicesPutIndexTemplate<'a, 'b, ()> {
-        IndicesPutIndexTemplate::new(&self.client, parts)
+        IndicesPutAlias::new(self.transport(), parts)
     }
     #[doc = "[Indices Put Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-put-mapping.html)\n\nUpdates the index mappings.\n\n# Examples\n\nPut a mapping into an existing index, assuming the index does not have a mapping, \nor that any properties specified do not conflict with existing properties\n\n```rust,no_run\n# use elasticsearch::{Elasticsearch, Error, indices::IndicesPutMappingParts};\n# use serde_json::{json, Value};\n# async fn doc() -> Result<(), Box<dyn std::error::Error>> {\nlet client = Elasticsearch::default();\nlet response = client\n    .indices()\n    .put_mapping(IndicesPutMappingParts::Index(&[\"test_index\"]))\n    .body(json!({\n        \"properties\" : {\n            \"field1\" : { \"type\" : \"text\" }\n        }\n    }))\n    .send()\n    .await?;\n    \n# Ok(())\n# }\n```"]
     pub fn put_mapping<'b>(
         &'a self,
         parts: IndicesPutMappingParts<'b>,
     ) -> IndicesPutMapping<'a, 'b, ()> {
-        IndicesPutMapping::new(&self.client, parts)
+        IndicesPutMapping::new(self.transport(), parts)
     }
     #[doc = "[Indices Put Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-update-settings.html)\n\nUpdates the index settings."]
     pub fn put_settings<'b>(
         &'a self,
         parts: IndicesPutSettingsParts<'b>,
     ) -> IndicesPutSettings<'a, 'b, ()> {
-        IndicesPutSettings::new(&self.client, parts)
+        IndicesPutSettings::new(self.transport(), parts)
     }
     #[doc = "[Indices Put Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nCreates or updates an index template."]
     pub fn put_template<'b>(
         &'a self,
         parts: IndicesPutTemplateParts<'b>,
     ) -> IndicesPutTemplate<'a, 'b, ()> {
-        IndicesPutTemplate::new(&self.client, parts)
+        IndicesPutTemplate::new(self.transport(), parts)
     }
     #[doc = "[Indices Recovery API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-recovery.html)\n\nReturns information about ongoing index shard recoveries."]
     pub fn recovery<'b>(&'a self, parts: IndicesRecoveryParts<'b>) -> IndicesRecovery<'a, 'b> {
-        IndicesRecovery::new(&self.client, parts)
+        IndicesRecovery::new(self.transport(), parts)
     }
     #[doc = "[Indices Refresh API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-refresh.html)\n\nPerforms the refresh operation in one or more indices."]
     pub fn refresh<'b>(&'a self, parts: IndicesRefreshParts<'b>) -> IndicesRefresh<'a, 'b, ()> {
-        IndicesRefresh::new(&self.client, parts)
+        IndicesRefresh::new(self.transport(), parts)
     }
     #[doc = "[Indices Reload Search Analyzers API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-reload-analyzers.html)\n\nReloads an index's search analyzers and their resources."]
     pub fn reload_search_analyzers<'b>(
         &'a self,
         parts: IndicesReloadSearchAnalyzersParts<'b>,
     ) -> IndicesReloadSearchAnalyzers<'a, 'b, ()> {
-        IndicesReloadSearchAnalyzers::new(&self.client, parts)
+        IndicesReloadSearchAnalyzers::new(self.transport(), parts)
     }
     #[doc = "[Indices Rollover API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-rollover-index.html)\n\nUpdates an alias to point to a new index when the existing index\nis considered to be too large or too old."]
     pub fn rollover<'b>(&'a self, parts: IndicesRolloverParts<'b>) -> IndicesRollover<'a, 'b, ()> {
-        IndicesRollover::new(&self.client, parts)
+        IndicesRollover::new(self.transport(), parts)
     }
     #[doc = "[Indices Segments API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-segments.html)\n\nProvides low-level information about segments in a Lucene index."]
     pub fn segments<'b>(&'a self, parts: IndicesSegmentsParts<'b>) -> IndicesSegments<'a, 'b> {
-        IndicesSegments::new(&self.client, parts)
+        IndicesSegments::new(self.transport(), parts)
     }
     #[doc = "[Indices Shard Stores API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-shards-stores.html)\n\nProvides store information for shard copies of indices."]
     pub fn shard_stores<'b>(
         &'a self,
         parts: IndicesShardStoresParts<'b>,
     ) -> IndicesShardStores<'a, 'b> {
-        IndicesShardStores::new(&self.client, parts)
+        IndicesShardStores::new(self.transport(), parts)
     }
     #[doc = "[Indices Shrink API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-shrink-index.html)\n\nAllow to shrink an existing index into a new index with fewer primary shards."]
     pub fn shrink<'b>(&'a self, parts: IndicesShrinkParts<'b>) -> IndicesShrink<'a, 'b, ()> {
-        IndicesShrink::new(&self.client, parts)
-    }
-    #[doc = "[Indices Simulate Index Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nSimulate matching the given index name against the index templates in the system"]
-    pub fn simulate_index_template<'b>(
-        &'a self,
-        parts: IndicesSimulateIndexTemplateParts<'b>,
-    ) -> IndicesSimulateIndexTemplate<'a, 'b, ()> {
-        IndicesSimulateIndexTemplate::new(&self.client, parts)
-    }
-    #[doc = "[Indices Simulate Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-templates.html)\n\nSimulate resolving the given template name or body"]
-    pub fn simulate_template<'b>(
-        &'a self,
-        parts: IndicesSimulateTemplateParts<'b>,
-    ) -> IndicesSimulateTemplate<'a, 'b, ()> {
-        IndicesSimulateTemplate::new(&self.client, parts)
+        IndicesShrink::new(self.transport(), parts)
     }
     #[doc = "[Indices Split API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-split-index.html)\n\nAllows you to split an existing index into a new index with more primary shards."]
     pub fn split<'b>(&'a self, parts: IndicesSplitParts<'b>) -> IndicesSplit<'a, 'b, ()> {
-        IndicesSplit::new(&self.client, parts)
+        IndicesSplit::new(self.transport(), parts)
     }
     #[doc = "[Indices Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-stats.html)\n\nProvides statistics on operations happening in an index."]
     pub fn stats<'b>(&'a self, parts: IndicesStatsParts<'b>) -> IndicesStats<'a, 'b> {
-        IndicesStats::new(&self.client, parts)
+        IndicesStats::new(self.transport(), parts)
     }
     #[doc = "[Indices Unfreeze API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/unfreeze-index-api.html)\n\nUnfreezes an index. When a frozen index is unfrozen, the index goes through the normal recovery process and becomes writeable again."]
     pub fn unfreeze<'b>(&'a self, parts: IndicesUnfreezeParts<'b>) -> IndicesUnfreeze<'a, 'b, ()> {
-        IndicesUnfreeze::new(&self.client, parts)
+        IndicesUnfreeze::new(self.transport(), parts)
     }
     #[doc = "[Indices Update Aliases API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-aliases.html)\n\nUpdates index aliases."]
     pub fn update_aliases<'b>(&'a self) -> IndicesUpdateAliases<'a, 'b, ()> {
-        IndicesUpdateAliases::new(&self.client)
+        IndicesUpdateAliases::new(self.transport())
     }
     #[doc = "[Indices Upgrade API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-upgrade.html)\n\nDEPRECATED Upgrades to the current version of Lucene."]
     pub fn upgrade<'b>(&'a self, parts: IndicesUpgradeParts<'b>) -> IndicesUpgrade<'a, 'b, ()> {
-        IndicesUpgrade::new(&self.client, parts)
+        IndicesUpgrade::new(self.transport(), parts)
     }
     #[doc = "[Indices Validate Query API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-validate.html)\n\nAllows a user to validate a potentially expensive query without executing it."]
     pub fn validate_query<'b>(
         &'a self,
         parts: IndicesValidateQueryParts<'b>,
     ) -> IndicesValidateQuery<'a, 'b, ()> {
-        IndicesValidateQuery::new(&self.client, parts)
+        IndicesValidateQuery::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Indices APIs"]
     pub fn indices(&self) -> Indices {
-        Indices::new(&self)
+        Indices::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/ingest.rs
+++ b/elasticsearch/src/generated/namespace_clients/ingest.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -60,7 +61,7 @@ impl<'b> IngestDeletePipelineParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ingest Delete Pipeline API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-pipeline-api.html)\n\nDeletes a pipeline."]
 pub struct IngestDeletePipeline<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IngestDeletePipelineParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -73,10 +74,10 @@ pub struct IngestDeletePipeline<'a, 'b> {
 }
 impl<'a, 'b> IngestDeletePipeline<'a, 'b> {
     #[doc = "Creates a new instance of [IngestDeletePipeline] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IngestDeletePipelineParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IngestDeletePipelineParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IngestDeletePipeline {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -168,7 +169,7 @@ impl<'a, 'b> IngestDeletePipeline<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -200,7 +201,7 @@ impl<'b> IngestGetPipelineParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ingest Get Pipeline API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-pipeline-api.html)\n\nReturns a pipeline."]
 pub struct IngestGetPipeline<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IngestGetPipelineParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -212,10 +213,10 @@ pub struct IngestGetPipeline<'a, 'b> {
 }
 impl<'a, 'b> IngestGetPipeline<'a, 'b> {
     #[doc = "Creates a new instance of [IngestGetPipeline] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IngestGetPipelineParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IngestGetPipelineParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IngestGetPipeline {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -298,7 +299,7 @@ impl<'a, 'b> IngestGetPipeline<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -321,7 +322,7 @@ impl IngestProcessorGrokParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ingest Processor Grok API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/grok-processor.html#grok-processor-rest-get)\n\nReturns a list of the built-in patterns."]
 pub struct IngestProcessorGrok<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IngestProcessorGrokParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -332,10 +333,10 @@ pub struct IngestProcessorGrok<'a, 'b> {
 }
 impl<'a, 'b> IngestProcessorGrok<'a, 'b> {
     #[doc = "Creates a new instance of [IngestProcessorGrok]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         IngestProcessorGrok {
-            client,
+            transport,
             parts: IngestProcessorGrokParts::None,
             headers,
             error_trace: None,
@@ -409,7 +410,7 @@ impl<'a, 'b> IngestProcessorGrok<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -438,7 +439,7 @@ impl<'b> IngestPutPipelineParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ingest Put Pipeline API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/put-pipeline-api.html)\n\nCreates or updates a pipeline."]
 pub struct IngestPutPipeline<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IngestPutPipelineParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -455,10 +456,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IngestPutPipeline] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IngestPutPipelineParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IngestPutPipelineParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IngestPutPipeline {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -477,7 +478,7 @@ where
         T: Serialize,
     {
         IngestPutPipeline {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -570,7 +571,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -603,7 +604,7 @@ impl<'b> IngestSimulateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ingest Simulate API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/simulate-pipeline-api.html)\n\nAllows to simulate a pipeline with example documents."]
 pub struct IngestSimulate<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IngestSimulateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -619,10 +620,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [IngestSimulate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IngestSimulateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IngestSimulateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         IngestSimulate {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -640,7 +641,7 @@ where
         T: Serialize,
     {
         IngestSimulate {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -727,7 +728,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -735,46 +736,49 @@ where
 }
 #[doc = "Namespace client for Ingest APIs"]
 pub struct Ingest<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Ingest<'a> {
     #[doc = "Creates a new instance of [Ingest]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Ingest Delete Pipeline API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-pipeline-api.html)\n\nDeletes a pipeline."]
     pub fn delete_pipeline<'b>(
         &'a self,
         parts: IngestDeletePipelineParts<'b>,
     ) -> IngestDeletePipeline<'a, 'b> {
-        IngestDeletePipeline::new(&self.client, parts)
+        IngestDeletePipeline::new(self.transport(), parts)
     }
     #[doc = "[Ingest Get Pipeline API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-pipeline-api.html)\n\nReturns a pipeline."]
     pub fn get_pipeline<'b>(
         &'a self,
         parts: IngestGetPipelineParts<'b>,
     ) -> IngestGetPipeline<'a, 'b> {
-        IngestGetPipeline::new(&self.client, parts)
+        IngestGetPipeline::new(self.transport(), parts)
     }
     #[doc = "[Ingest Processor Grok API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/grok-processor.html#grok-processor-rest-get)\n\nReturns a list of the built-in patterns."]
     pub fn processor_grok<'b>(&'a self) -> IngestProcessorGrok<'a, 'b> {
-        IngestProcessorGrok::new(&self.client)
+        IngestProcessorGrok::new(self.transport())
     }
     #[doc = "[Ingest Put Pipeline API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/put-pipeline-api.html)\n\nCreates or updates a pipeline."]
     pub fn put_pipeline<'b>(
         &'a self,
         parts: IngestPutPipelineParts<'b>,
     ) -> IngestPutPipeline<'a, 'b, ()> {
-        IngestPutPipeline::new(&self.client, parts)
+        IngestPutPipeline::new(self.transport(), parts)
     }
     #[doc = "[Ingest Simulate API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/simulate-pipeline-api.html)\n\nAllows to simulate a pipeline with example documents."]
     pub fn simulate<'b>(&'a self, parts: IngestSimulateParts<'b>) -> IngestSimulate<'a, 'b, ()> {
-        IngestSimulate::new(&self.client, parts)
+        IngestSimulate::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Ingest APIs"]
     pub fn ingest(&self) -> Ingest {
-        Ingest::new(&self)
+        Ingest::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/license.rs
+++ b/elasticsearch/src/generated/namespace_clients/license.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -54,7 +55,7 @@ impl LicenseDeleteParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-license.html)\n\nDeletes licensing information for the cluster"]
 pub struct LicenseDelete<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: LicenseDeleteParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -65,10 +66,10 @@ pub struct LicenseDelete<'a, 'b> {
 }
 impl<'a, 'b> LicenseDelete<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseDelete]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         LicenseDelete {
-            client,
+            transport,
             parts: LicenseDeleteParts::None,
             headers,
             error_trace: None,
@@ -142,7 +143,7 @@ impl<'a, 'b> LicenseDelete<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -165,7 +166,7 @@ impl LicenseGetParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-license.html)\n\nRetrieves licensing information for the cluster"]
 pub struct LicenseGet<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: LicenseGetParts,
     accept_enterprise: Option<bool>,
     error_trace: Option<bool>,
@@ -178,10 +179,10 @@ pub struct LicenseGet<'a, 'b> {
 }
 impl<'a, 'b> LicenseGet<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseGet]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         LicenseGet {
-            client,
+            transport,
             parts: LicenseGetParts::None,
             headers,
             accept_enterprise: None,
@@ -273,7 +274,7 @@ impl<'a, 'b> LicenseGet<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -296,7 +297,7 @@ impl LicenseGetBasicStatusParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Get Basic Status API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-basic-status.html)\n\nRetrieves information about the status of the basic license."]
 pub struct LicenseGetBasicStatus<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: LicenseGetBasicStatusParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -307,10 +308,10 @@ pub struct LicenseGetBasicStatus<'a, 'b> {
 }
 impl<'a, 'b> LicenseGetBasicStatus<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseGetBasicStatus]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         LicenseGetBasicStatus {
-            client,
+            transport,
             parts: LicenseGetBasicStatusParts::None,
             headers,
             error_trace: None,
@@ -384,7 +385,7 @@ impl<'a, 'b> LicenseGetBasicStatus<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -407,7 +408,7 @@ impl LicenseGetTrialStatusParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Get Trial Status API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-trial-status.html)\n\nRetrieves information about the status of the trial license."]
 pub struct LicenseGetTrialStatus<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: LicenseGetTrialStatusParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -418,10 +419,10 @@ pub struct LicenseGetTrialStatus<'a, 'b> {
 }
 impl<'a, 'b> LicenseGetTrialStatus<'a, 'b> {
     #[doc = "Creates a new instance of [LicenseGetTrialStatus]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         LicenseGetTrialStatus {
-            client,
+            transport,
             parts: LicenseGetTrialStatusParts::None,
             headers,
             error_trace: None,
@@ -495,7 +496,7 @@ impl<'a, 'b> LicenseGetTrialStatus<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -518,7 +519,7 @@ impl LicensePostParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Post API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/update-license.html)\n\nUpdates the license for the cluster."]
 pub struct LicensePost<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: LicensePostParts,
     acknowledge: Option<bool>,
     body: Option<B>,
@@ -534,10 +535,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [LicensePost]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         LicensePost {
-            client,
+            transport,
             parts: LicensePostParts::None,
             headers,
             acknowledge: None,
@@ -560,7 +561,7 @@ where
         T: Serialize,
     {
         LicensePost {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             acknowledge: self.acknowledge,
@@ -639,7 +640,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -662,7 +663,7 @@ impl LicensePostStartBasicParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Post Start Basic API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/start-basic.html)\n\nStarts an indefinite basic license."]
 pub struct LicensePostStartBasic<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: LicensePostStartBasicParts,
     acknowledge: Option<bool>,
     body: Option<B>,
@@ -678,10 +679,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [LicensePostStartBasic]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         LicensePostStartBasic {
-            client,
+            transport,
             parts: LicensePostStartBasicParts::None,
             headers,
             acknowledge: None,
@@ -704,7 +705,7 @@ where
         T: Serialize,
     {
         LicensePostStartBasic {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             acknowledge: self.acknowledge,
@@ -783,7 +784,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -806,7 +807,7 @@ impl LicensePostStartTrialParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [License Post Start Trial API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/start-trial.html)\n\nstarts a limited time trial license."]
 pub struct LicensePostStartTrial<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: LicensePostStartTrialParts,
     acknowledge: Option<bool>,
     body: Option<B>,
@@ -823,10 +824,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [LicensePostStartTrial]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         LicensePostStartTrial {
-            client,
+            transport,
             parts: LicensePostStartTrialParts::None,
             headers,
             acknowledge: None,
@@ -850,7 +851,7 @@ where
         T: Serialize,
     {
         LicensePostStartTrial {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             acknowledge: self.acknowledge,
@@ -938,7 +939,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -946,45 +947,48 @@ where
 }
 #[doc = "Namespace client for License APIs"]
 pub struct License<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> License<'a> {
     #[doc = "Creates a new instance of [License]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[License Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-license.html)\n\nDeletes licensing information for the cluster"]
     pub fn delete<'b>(&'a self) -> LicenseDelete<'a, 'b> {
-        LicenseDelete::new(&self.client)
+        LicenseDelete::new(self.transport())
     }
     #[doc = "[License Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-license.html)\n\nRetrieves licensing information for the cluster"]
     pub fn get<'b>(&'a self) -> LicenseGet<'a, 'b> {
-        LicenseGet::new(&self.client)
+        LicenseGet::new(self.transport())
     }
     #[doc = "[License Get Basic Status API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-basic-status.html)\n\nRetrieves information about the status of the basic license."]
     pub fn get_basic_status<'b>(&'a self) -> LicenseGetBasicStatus<'a, 'b> {
-        LicenseGetBasicStatus::new(&self.client)
+        LicenseGetBasicStatus::new(self.transport())
     }
     #[doc = "[License Get Trial Status API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-trial-status.html)\n\nRetrieves information about the status of the trial license."]
     pub fn get_trial_status<'b>(&'a self) -> LicenseGetTrialStatus<'a, 'b> {
-        LicenseGetTrialStatus::new(&self.client)
+        LicenseGetTrialStatus::new(self.transport())
     }
     #[doc = "[License Post API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/update-license.html)\n\nUpdates the license for the cluster."]
     pub fn post<'b>(&'a self) -> LicensePost<'a, 'b, ()> {
-        LicensePost::new(&self.client)
+        LicensePost::new(self.transport())
     }
     #[doc = "[License Post Start Basic API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/start-basic.html)\n\nStarts an indefinite basic license."]
     pub fn post_start_basic<'b>(&'a self) -> LicensePostStartBasic<'a, 'b, ()> {
-        LicensePostStartBasic::new(&self.client)
+        LicensePostStartBasic::new(self.transport())
     }
     #[doc = "[License Post Start Trial API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/start-trial.html)\n\nstarts a limited time trial license."]
     pub fn post_start_trial<'b>(&'a self) -> LicensePostStartTrial<'a, 'b, ()> {
-        LicensePostStartTrial::new(&self.client)
+        LicensePostStartTrial::new(self.transport())
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for License APIs"]
     pub fn license(&self) -> License {
-        License::new(&self)
+        License::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/migration.rs
+++ b/elasticsearch/src/generated/namespace_clients/migration.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -65,7 +66,7 @@ impl<'b> MigrationDeprecationsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Migration Deprecations API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/migration-api-deprecation.html)\n\nRetrieves information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version."]
 pub struct MigrationDeprecations<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MigrationDeprecationsParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -76,10 +77,10 @@ pub struct MigrationDeprecations<'a, 'b> {
 }
 impl<'a, 'b> MigrationDeprecations<'a, 'b> {
     #[doc = "Creates a new instance of [MigrationDeprecations] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MigrationDeprecationsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MigrationDeprecationsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MigrationDeprecations {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -153,7 +154,7 @@ impl<'a, 'b> MigrationDeprecations<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -161,24 +162,27 @@ impl<'a, 'b> MigrationDeprecations<'a, 'b> {
 }
 #[doc = "Namespace client for Migration APIs"]
 pub struct Migration<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Migration<'a> {
     #[doc = "Creates a new instance of [Migration]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Migration Deprecations API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/migration-api-deprecation.html)\n\nRetrieves information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version."]
     pub fn deprecations<'b>(
         &'a self,
         parts: MigrationDeprecationsParts<'b>,
     ) -> MigrationDeprecations<'a, 'b> {
-        MigrationDeprecations::new(&self.client, parts)
+        MigrationDeprecations::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Migration APIs"]
     pub fn migration(&self) -> Migration {
-        Migration::new(&self)
+        Migration::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/ml.rs
+++ b/elasticsearch/src/generated/namespace_clients/ml.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -62,7 +63,7 @@ impl<'b> MlCloseJobParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Close Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-close-job.html)\n\nCloses one or more anomaly detection jobs. A job can be opened and closed multiple times throughout its lifecycle."]
 pub struct MlCloseJob<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlCloseJobParts<'b>,
     allow_no_jobs: Option<bool>,
     body: Option<B>,
@@ -80,10 +81,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlCloseJob] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlCloseJobParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlCloseJobParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlCloseJob {
-            client,
+            transport,
             parts,
             headers,
             allow_no_jobs: None,
@@ -108,7 +109,7 @@ where
         T: Serialize,
     {
         MlCloseJob {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_jobs: self.allow_no_jobs,
@@ -205,7 +206,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -235,7 +236,7 @@ impl<'b> MlDeleteCalendarParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Calendar API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-calendar.html)\n\nDeletes a calendar."]
 pub struct MlDeleteCalendar<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlDeleteCalendarParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -246,10 +247,10 @@ pub struct MlDeleteCalendar<'a, 'b> {
 }
 impl<'a, 'b> MlDeleteCalendar<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteCalendar] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlDeleteCalendarParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlDeleteCalendarParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlDeleteCalendar {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -323,7 +324,7 @@ impl<'a, 'b> MlDeleteCalendar<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -359,7 +360,7 @@ impl<'b> MlDeleteCalendarEventParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Calendar Event API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-calendar-event.html)\n\nDeletes scheduled events from a calendar."]
 pub struct MlDeleteCalendarEvent<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlDeleteCalendarEventParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -370,10 +371,10 @@ pub struct MlDeleteCalendarEvent<'a, 'b> {
 }
 impl<'a, 'b> MlDeleteCalendarEvent<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteCalendarEvent] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlDeleteCalendarEventParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlDeleteCalendarEventParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlDeleteCalendarEvent {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -447,7 +448,7 @@ impl<'a, 'b> MlDeleteCalendarEvent<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -483,7 +484,7 @@ impl<'b> MlDeleteCalendarJobParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Calendar Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-calendar-job.html)\n\nDeletes anomaly detection jobs from a calendar."]
 pub struct MlDeleteCalendarJob<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlDeleteCalendarJobParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -494,10 +495,10 @@ pub struct MlDeleteCalendarJob<'a, 'b> {
 }
 impl<'a, 'b> MlDeleteCalendarJob<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteCalendarJob] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlDeleteCalendarJobParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlDeleteCalendarJobParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlDeleteCalendarJob {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -571,7 +572,7 @@ impl<'a, 'b> MlDeleteCalendarJob<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -601,7 +602,7 @@ impl<'b> MlDeleteDatafeedParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-datafeed.html)\n\nDeletes an existing datafeed."]
 pub struct MlDeleteDatafeed<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlDeleteDatafeedParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -613,10 +614,10 @@ pub struct MlDeleteDatafeed<'a, 'b> {
 }
 impl<'a, 'b> MlDeleteDatafeed<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteDatafeed] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlDeleteDatafeedParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlDeleteDatafeedParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlDeleteDatafeed {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -699,7 +700,7 @@ impl<'a, 'b> MlDeleteDatafeed<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -732,7 +733,7 @@ impl<'b> MlDeleteExpiredDataParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Expired Data API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-expired-data.html)\n\nDeletes expired and unused machine learning data."]
 pub struct MlDeleteExpiredData<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlDeleteExpiredDataParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -749,10 +750,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlDeleteExpiredData] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlDeleteExpiredDataParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlDeleteExpiredDataParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlDeleteExpiredData {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -771,7 +772,7 @@ where
         T: Serialize,
     {
         MlDeleteExpiredData {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -864,7 +865,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -894,7 +895,7 @@ impl<'b> MlDeleteFilterParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Filter API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-filter.html)\n\nDeletes a filter."]
 pub struct MlDeleteFilter<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlDeleteFilterParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -905,10 +906,10 @@ pub struct MlDeleteFilter<'a, 'b> {
 }
 impl<'a, 'b> MlDeleteFilter<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteFilter] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlDeleteFilterParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlDeleteFilterParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlDeleteFilter {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -982,7 +983,7 @@ impl<'a, 'b> MlDeleteFilter<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1029,7 +1030,7 @@ impl<'b> MlDeleteForecastParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Forecast API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-forecast.html)\n\nDeletes forecasts from a machine learning job."]
 pub struct MlDeleteForecast<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlDeleteForecastParts<'b>,
     allow_no_forecasts: Option<bool>,
     error_trace: Option<bool>,
@@ -1042,10 +1043,10 @@ pub struct MlDeleteForecast<'a, 'b> {
 }
 impl<'a, 'b> MlDeleteForecast<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteForecast] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlDeleteForecastParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlDeleteForecastParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlDeleteForecast {
-            client,
+            transport,
             parts,
             headers,
             allow_no_forecasts: None,
@@ -1137,7 +1138,7 @@ impl<'a, 'b> MlDeleteForecast<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1167,7 +1168,7 @@ impl<'b> MlDeleteJobParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-job.html)\n\nDeletes an existing anomaly detection job."]
 pub struct MlDeleteJob<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlDeleteJobParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1180,10 +1181,10 @@ pub struct MlDeleteJob<'a, 'b> {
 }
 impl<'a, 'b> MlDeleteJob<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteJob] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlDeleteJobParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlDeleteJobParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlDeleteJob {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1275,7 +1276,7 @@ impl<'a, 'b> MlDeleteJob<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1311,7 +1312,7 @@ impl<'b> MlDeleteModelSnapshotParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Delete Model Snapshot API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-snapshot.html)\n\nDeletes an existing model snapshot."]
 pub struct MlDeleteModelSnapshot<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlDeleteModelSnapshotParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1322,10 +1323,10 @@ pub struct MlDeleteModelSnapshot<'a, 'b> {
 }
 impl<'a, 'b> MlDeleteModelSnapshot<'a, 'b> {
     #[doc = "Creates a new instance of [MlDeleteModelSnapshot] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlDeleteModelSnapshotParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlDeleteModelSnapshotParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlDeleteModelSnapshot {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1399,7 +1400,7 @@ impl<'a, 'b> MlDeleteModelSnapshot<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1424,7 +1425,7 @@ impl MlEstimateModelMemoryParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Estimate Model Memory API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-apis.html)\n\nEstimates the model memory"]
 pub struct MlEstimateModelMemory<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlEstimateModelMemoryParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1439,10 +1440,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlEstimateModelMemory]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         MlEstimateModelMemory {
-            client,
+            transport,
             parts: MlEstimateModelMemoryParts::None,
             headers,
             body: None,
@@ -1459,7 +1460,7 @@ where
         T: Serialize,
     {
         MlEstimateModelMemory {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1534,7 +1535,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1565,7 +1566,7 @@ impl<'b> MlFlushJobParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Flush Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-flush-job.html)\n\nForces any buffered data to be processed by the job."]
 pub struct MlFlushJob<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlFlushJobParts<'b>,
     advance_time: Option<&'b str>,
     body: Option<B>,
@@ -1585,10 +1586,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlFlushJob] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlFlushJobParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlFlushJobParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlFlushJob {
-            client,
+            transport,
             parts,
             headers,
             advance_time: None,
@@ -1615,7 +1616,7 @@ where
         T: Serialize,
     {
         MlFlushJob {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             advance_time: self.advance_time,
@@ -1730,7 +1731,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1761,7 +1762,7 @@ impl<'b> MlForecastParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Forecast API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-forecast.html)\n\nPredicts the future behavior of a time series by using its historical behavior."]
 pub struct MlForecast<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlForecastParts<'b>,
     body: Option<B>,
     duration: Option<&'b str>,
@@ -1779,10 +1780,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlForecast] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlForecastParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlForecastParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlForecast {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1802,7 +1803,7 @@ where
         T: Serialize,
     {
         MlForecast {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             duration: self.duration,
@@ -1904,7 +1905,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1950,7 +1951,7 @@ impl<'b> MlGetBucketsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Buckets API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-bucket.html)\n\nRetrieves anomaly detection job results for one or more buckets."]
 pub struct MlGetBuckets<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetBucketsParts<'b>,
     anomaly_score: Option<f64>,
     body: Option<B>,
@@ -1974,10 +1975,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetBuckets] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetBucketsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetBucketsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetBuckets {
-            client,
+            transport,
             parts,
             headers,
             anomaly_score: None,
@@ -2008,7 +2009,7 @@ where
         T: Serialize,
     {
         MlGetBuckets {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             anomaly_score: self.anomaly_score,
@@ -2162,7 +2163,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2193,7 +2194,7 @@ impl<'b> MlGetCalendarEventsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Calendar Events API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-calendar-event.html)\n\nRetrieves information about the scheduled events in calendars."]
 pub struct MlGetCalendarEvents<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetCalendarEventsParts<'b>,
     end: Option<&'b str>,
     error_trace: Option<bool>,
@@ -2209,10 +2210,10 @@ pub struct MlGetCalendarEvents<'a, 'b> {
 }
 impl<'a, 'b> MlGetCalendarEvents<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetCalendarEvents] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetCalendarEventsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetCalendarEventsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetCalendarEvents {
-            client,
+            transport,
             parts,
             headers,
             end: None,
@@ -2331,7 +2332,7 @@ impl<'a, 'b> MlGetCalendarEvents<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2364,7 +2365,7 @@ impl<'b> MlGetCalendarsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Calendars API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-calendar.html)\n\nRetrieves configuration information for calendars."]
 pub struct MlGetCalendars<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetCalendarsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -2381,10 +2382,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetCalendars] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetCalendarsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetCalendarsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetCalendars {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -2403,7 +2404,7 @@ where
         T: Serialize,
     {
         MlGetCalendars {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -2499,7 +2500,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2547,7 +2548,7 @@ impl<'b> MlGetCategoriesParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Categories API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-category.html)\n\nRetrieves anomaly detection job results for one or more categories."]
 pub struct MlGetCategories<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetCategoriesParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -2565,10 +2566,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetCategories] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetCategoriesParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetCategoriesParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetCategories {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -2588,7 +2589,7 @@ where
         T: Serialize,
     {
         MlGetCategories {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -2693,7 +2694,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2727,7 +2728,7 @@ impl<'b> MlGetDatafeedStatsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Datafeed Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-datafeed-stats.html)\n\nRetrieves usage information for datafeeds."]
 pub struct MlGetDatafeedStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetDatafeedStatsParts<'b>,
     allow_no_datafeeds: Option<bool>,
     error_trace: Option<bool>,
@@ -2739,10 +2740,10 @@ pub struct MlGetDatafeedStats<'a, 'b> {
 }
 impl<'a, 'b> MlGetDatafeedStats<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetDatafeedStats] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetDatafeedStatsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetDatafeedStatsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetDatafeedStats {
-            client,
+            transport,
             parts,
             headers,
             allow_no_datafeeds: None,
@@ -2825,7 +2826,7 @@ impl<'a, 'b> MlGetDatafeedStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2858,7 +2859,7 @@ impl<'b> MlGetDatafeedsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Datafeeds API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-datafeed.html)\n\nRetrieves configuration information for datafeeds."]
 pub struct MlGetDatafeeds<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetDatafeedsParts<'b>,
     allow_no_datafeeds: Option<bool>,
     error_trace: Option<bool>,
@@ -2870,10 +2871,10 @@ pub struct MlGetDatafeeds<'a, 'b> {
 }
 impl<'a, 'b> MlGetDatafeeds<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetDatafeeds] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetDatafeedsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetDatafeedsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetDatafeeds {
-            client,
+            transport,
             parts,
             headers,
             allow_no_datafeeds: None,
@@ -2956,7 +2957,7 @@ impl<'a, 'b> MlGetDatafeeds<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2989,7 +2990,7 @@ impl<'b> MlGetFiltersParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Filters API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-filter.html)\n\nRetrieves filters."]
 pub struct MlGetFilters<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetFiltersParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -3002,10 +3003,10 @@ pub struct MlGetFilters<'a, 'b> {
 }
 impl<'a, 'b> MlGetFilters<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetFilters] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetFiltersParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetFiltersParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetFilters {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -3097,7 +3098,7 @@ impl<'a, 'b> MlGetFilters<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3128,7 +3129,7 @@ impl<'b> MlGetInfluencersParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Influencers API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-influencer.html)\n\nRetrieves anomaly detection job results for one or more influencers."]
 pub struct MlGetInfluencers<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetInfluencersParts<'b>,
     body: Option<B>,
     desc: Option<bool>,
@@ -3151,10 +3152,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetInfluencers] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetInfluencersParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetInfluencersParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetInfluencers {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -3179,7 +3180,7 @@ where
         T: Serialize,
     {
         MlGetInfluencers {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             desc: self.desc,
@@ -3329,7 +3330,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3363,7 +3364,7 @@ impl<'b> MlGetJobStatsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Job Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-job-stats.html)\n\nRetrieves usage information for anomaly detection jobs."]
 pub struct MlGetJobStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetJobStatsParts<'b>,
     allow_no_jobs: Option<bool>,
     error_trace: Option<bool>,
@@ -3375,10 +3376,10 @@ pub struct MlGetJobStats<'a, 'b> {
 }
 impl<'a, 'b> MlGetJobStats<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetJobStats] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetJobStatsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetJobStatsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetJobStats {
-            client,
+            transport,
             parts,
             headers,
             allow_no_jobs: None,
@@ -3461,7 +3462,7 @@ impl<'a, 'b> MlGetJobStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3494,7 +3495,7 @@ impl<'b> MlGetJobsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Jobs API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-job.html)\n\nRetrieves configuration information for anomaly detection jobs."]
 pub struct MlGetJobs<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetJobsParts<'b>,
     allow_no_jobs: Option<bool>,
     error_trace: Option<bool>,
@@ -3506,10 +3507,10 @@ pub struct MlGetJobs<'a, 'b> {
 }
 impl<'a, 'b> MlGetJobs<'a, 'b> {
     #[doc = "Creates a new instance of [MlGetJobs] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetJobsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetJobsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetJobs {
-            client,
+            transport,
             parts,
             headers,
             allow_no_jobs: None,
@@ -3592,7 +3593,7 @@ impl<'a, 'b> MlGetJobs<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3639,7 +3640,7 @@ impl<'b> MlGetModelSnapshotsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Model Snapshots API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-snapshot.html)\n\nRetrieves information about model snapshots."]
 pub struct MlGetModelSnapshots<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetModelSnapshotsParts<'b>,
     body: Option<B>,
     desc: Option<bool>,
@@ -3660,10 +3661,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetModelSnapshots] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetModelSnapshotsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetModelSnapshotsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetModelSnapshots {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -3686,7 +3687,7 @@ where
         T: Serialize,
     {
         MlGetModelSnapshots {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             desc: self.desc,
@@ -3818,7 +3819,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3849,7 +3850,7 @@ impl<'b> MlGetOverallBucketsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Overall Buckets API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-overall-buckets.html)\n\nRetrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs."]
 pub struct MlGetOverallBuckets<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetOverallBucketsParts<'b>,
     allow_no_jobs: Option<bool>,
     body: Option<B>,
@@ -3871,10 +3872,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetOverallBuckets] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetOverallBucketsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetOverallBucketsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetOverallBuckets {
-            client,
+            transport,
             parts,
             headers,
             allow_no_jobs: None,
@@ -3903,7 +3904,7 @@ where
         T: Serialize,
     {
         MlGetOverallBuckets {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_jobs: self.allow_no_jobs,
@@ -4039,7 +4040,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4070,7 +4071,7 @@ impl<'b> MlGetRecordsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Get Records API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-record.html)\n\nRetrieves anomaly records for an anomaly detection job."]
 pub struct MlGetRecords<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlGetRecordsParts<'b>,
     body: Option<B>,
     desc: Option<bool>,
@@ -4093,10 +4094,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlGetRecords] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlGetRecordsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlGetRecordsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlGetRecords {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -4121,7 +4122,7 @@ where
         T: Serialize,
     {
         MlGetRecords {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             desc: self.desc,
@@ -4271,7 +4272,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4294,7 +4295,7 @@ impl MlInfoParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-ml-info.html)\n\nReturns defaults and limits used by machine learning."]
 pub struct MlInfo<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlInfoParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -4305,10 +4306,10 @@ pub struct MlInfo<'a, 'b> {
 }
 impl<'a, 'b> MlInfo<'a, 'b> {
     #[doc = "Creates a new instance of [MlInfo]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         MlInfo {
-            client,
+            transport,
             parts: MlInfoParts::None,
             headers,
             error_trace: None,
@@ -4382,7 +4383,7 @@ impl<'a, 'b> MlInfo<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4413,7 +4414,7 @@ impl<'b> MlOpenJobParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Open Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-open-job.html)\n\nOpens one or more anomaly detection jobs."]
 pub struct MlOpenJob<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlOpenJobParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -4428,10 +4429,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlOpenJob] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlOpenJobParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlOpenJobParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlOpenJob {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -4448,7 +4449,7 @@ where
         T: Serialize,
     {
         MlOpenJob {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -4523,7 +4524,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4554,7 +4555,7 @@ impl<'b> MlPostCalendarEventsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Post Calendar Events API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-post-calendar-event.html)\n\nPosts scheduled events in a calendar."]
 pub struct MlPostCalendarEvents<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlPostCalendarEventsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -4569,10 +4570,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPostCalendarEvents] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlPostCalendarEventsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlPostCalendarEventsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlPostCalendarEvents {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -4589,7 +4590,7 @@ where
         T: Serialize,
     {
         MlPostCalendarEvents {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -4664,7 +4665,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4695,7 +4696,7 @@ impl<'b> MlPostDataParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Post Data API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-post-data.html)\n\nSends data to an anomaly detection job for analysis."]
 pub struct MlPostData<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlPostDataParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -4712,10 +4713,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPostData] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlPostDataParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlPostDataParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlPostData {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -4734,7 +4735,7 @@ where
         T: Body,
     {
         MlPostData {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(NdBody(body)),
             error_trace: self.error_trace,
@@ -4827,7 +4828,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4858,7 +4859,7 @@ impl<'b> MlPreviewDatafeedParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Preview Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-preview-datafeed.html)\n\nPreviews a datafeed."]
 pub struct MlPreviewDatafeed<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlPreviewDatafeedParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -4869,10 +4870,10 @@ pub struct MlPreviewDatafeed<'a, 'b> {
 }
 impl<'a, 'b> MlPreviewDatafeed<'a, 'b> {
     #[doc = "Creates a new instance of [MlPreviewDatafeed] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlPreviewDatafeedParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlPreviewDatafeedParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlPreviewDatafeed {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -4946,7 +4947,7 @@ impl<'a, 'b> MlPreviewDatafeed<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4976,7 +4977,7 @@ impl<'b> MlPutCalendarParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Put Calendar API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-put-calendar.html)\n\nInstantiates a calendar."]
 pub struct MlPutCalendar<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlPutCalendarParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -4991,10 +4992,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPutCalendar] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlPutCalendarParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlPutCalendarParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlPutCalendar {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -5011,7 +5012,7 @@ where
         T: Serialize,
     {
         MlPutCalendar {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -5086,7 +5087,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5122,7 +5123,7 @@ impl<'b> MlPutCalendarJobParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Put Calendar Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-put-calendar-job.html)\n\nAdds an anomaly detection job to a calendar."]
 pub struct MlPutCalendarJob<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlPutCalendarJobParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -5137,10 +5138,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPutCalendarJob] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlPutCalendarJobParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlPutCalendarJobParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlPutCalendarJob {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -5157,7 +5158,7 @@ where
         T: Serialize,
     {
         MlPutCalendarJob {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -5232,7 +5233,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5262,7 +5263,7 @@ impl<'b> MlPutDatafeedParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Put Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-put-datafeed.html)\n\nInstantiates a datafeed."]
 pub struct MlPutDatafeed<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlPutDatafeedParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -5281,10 +5282,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPutDatafeed] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlPutDatafeedParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlPutDatafeedParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlPutDatafeed {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -5310,7 +5311,7 @@ where
         T: Serialize,
     {
         MlPutDatafeed {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -5419,7 +5420,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5449,7 +5450,7 @@ impl<'b> MlPutFilterParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Put Filter API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-put-filter.html)\n\nInstantiates a filter."]
 pub struct MlPutFilter<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlPutFilterParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -5464,10 +5465,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPutFilter] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlPutFilterParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlPutFilterParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlPutFilter {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -5484,7 +5485,7 @@ where
         T: Serialize,
     {
         MlPutFilter {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -5559,7 +5560,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5589,7 +5590,7 @@ impl<'b> MlPutJobParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Put Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-put-job.html)\n\nInstantiates an anomaly detection job."]
 pub struct MlPutJob<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlPutJobParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -5604,10 +5605,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlPutJob] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlPutJobParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlPutJobParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlPutJob {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -5624,7 +5625,7 @@ where
         T: Serialize,
     {
         MlPutJob {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -5699,7 +5700,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5736,7 +5737,7 @@ impl<'b> MlRevertModelSnapshotParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Revert Model Snapshot API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-revert-snapshot.html)\n\nReverts to a specific snapshot."]
 pub struct MlRevertModelSnapshot<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlRevertModelSnapshotParts<'b>,
     body: Option<B>,
     delete_intervening_results: Option<bool>,
@@ -5752,10 +5753,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlRevertModelSnapshot] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlRevertModelSnapshotParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlRevertModelSnapshotParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlRevertModelSnapshot {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -5773,7 +5774,7 @@ where
         T: Serialize,
     {
         MlRevertModelSnapshot {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             delete_intervening_results: self.delete_intervening_results,
@@ -5857,7 +5858,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5880,7 +5881,7 @@ impl MlSetUpgradeModeParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Set Upgrade Mode API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-set-upgrade-mode.html)\n\nSets a cluster wide upgrade_mode setting that prepares machine learning indices for an upgrade."]
 pub struct MlSetUpgradeMode<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlSetUpgradeModeParts,
     body: Option<B>,
     enabled: Option<bool>,
@@ -5897,10 +5898,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlSetUpgradeMode]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         MlSetUpgradeMode {
-            client,
+            transport,
             parts: MlSetUpgradeModeParts::None,
             headers,
             body: None,
@@ -5919,7 +5920,7 @@ where
         T: Serialize,
     {
         MlSetUpgradeMode {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             enabled: self.enabled,
@@ -6012,7 +6013,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6043,7 +6044,7 @@ impl<'b> MlStartDatafeedParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Start Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-start-datafeed.html)\n\nStarts one or more datafeeds."]
 pub struct MlStartDatafeed<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlStartDatafeedParts<'b>,
     body: Option<B>,
     end: Option<&'b str>,
@@ -6061,10 +6062,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlStartDatafeed] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlStartDatafeedParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlStartDatafeedParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlStartDatafeed {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -6084,7 +6085,7 @@ where
         T: Serialize,
     {
         MlStartDatafeed {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             end: self.end,
@@ -6186,7 +6187,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6217,7 +6218,7 @@ impl<'b> MlStopDatafeedParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Stop Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-stop-datafeed.html)\n\nStops one or more datafeeds."]
 pub struct MlStopDatafeed<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlStopDatafeedParts<'b>,
     allow_no_datafeeds: Option<bool>,
     body: Option<B>,
@@ -6235,10 +6236,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlStopDatafeed] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlStopDatafeedParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlStopDatafeedParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlStopDatafeed {
-            client,
+            transport,
             parts,
             headers,
             allow_no_datafeeds: None,
@@ -6263,7 +6264,7 @@ where
         T: Serialize,
     {
         MlStopDatafeed {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_datafeeds: self.allow_no_datafeeds,
@@ -6360,7 +6361,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6391,7 +6392,7 @@ impl<'b> MlUpdateDatafeedParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Update Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-update-datafeed.html)\n\nUpdates certain properties of a datafeed."]
 pub struct MlUpdateDatafeed<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlUpdateDatafeedParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -6410,10 +6411,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlUpdateDatafeed] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlUpdateDatafeedParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlUpdateDatafeedParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlUpdateDatafeed {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -6439,7 +6440,7 @@ where
         T: Serialize,
     {
         MlUpdateDatafeed {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -6548,7 +6549,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6579,7 +6580,7 @@ impl<'b> MlUpdateFilterParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Update Filter API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-update-filter.html)\n\nUpdates the description of a filter, adds items, or removes items."]
 pub struct MlUpdateFilter<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlUpdateFilterParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -6594,10 +6595,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlUpdateFilter] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlUpdateFilterParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlUpdateFilterParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlUpdateFilter {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -6614,7 +6615,7 @@ where
         T: Serialize,
     {
         MlUpdateFilter {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -6689,7 +6690,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6720,7 +6721,7 @@ impl<'b> MlUpdateJobParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Update Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-update-job.html)\n\nUpdates certain properties of an anomaly detection job."]
 pub struct MlUpdateJob<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlUpdateJobParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -6735,10 +6736,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlUpdateJob] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlUpdateJobParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlUpdateJobParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlUpdateJob {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -6755,7 +6756,7 @@ where
         T: Serialize,
     {
         MlUpdateJob {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -6830,7 +6831,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6867,7 +6868,7 @@ impl<'b> MlUpdateModelSnapshotParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Update Model Snapshot API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-update-snapshot.html)\n\nUpdates certain properties of a snapshot."]
 pub struct MlUpdateModelSnapshot<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlUpdateModelSnapshotParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -6882,10 +6883,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlUpdateModelSnapshot] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MlUpdateModelSnapshotParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MlUpdateModelSnapshotParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MlUpdateModelSnapshot {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -6902,7 +6903,7 @@ where
         T: Serialize,
     {
         MlUpdateModelSnapshot {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -6977,7 +6978,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -7000,7 +7001,7 @@ impl MlValidateParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Validate API](https://www.elastic.co/guide/en/machine-learning/8.0/ml-jobs.html)\n\nValidates an anomaly detection job."]
 pub struct MlValidate<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlValidateParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -7015,10 +7016,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlValidate]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         MlValidate {
-            client,
+            transport,
             parts: MlValidateParts::None,
             headers,
             body: None,
@@ -7035,7 +7036,7 @@ where
         T: Serialize,
     {
         MlValidate {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -7110,7 +7111,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -7133,7 +7134,7 @@ impl MlValidateDetectorParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ml Validate Detector API](https://www.elastic.co/guide/en/machine-learning/8.0/ml-jobs.html)\n\nValidates an anomaly detection detector."]
 pub struct MlValidateDetector<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MlValidateDetectorParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -7148,10 +7149,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MlValidateDetector]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         MlValidateDetector {
-            client,
+            transport,
             parts: MlValidateDetectorParts::None,
             headers,
             body: None,
@@ -7168,7 +7169,7 @@ where
         T: Serialize,
     {
         MlValidateDetector {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -7243,7 +7244,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -7251,270 +7252,273 @@ where
 }
 #[doc = "Namespace client for Machine Learning APIs"]
 pub struct Ml<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Ml<'a> {
     #[doc = "Creates a new instance of [Ml]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Ml Close Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-close-job.html)\n\nCloses one or more anomaly detection jobs. A job can be opened and closed multiple times throughout its lifecycle."]
     pub fn close_job<'b>(&'a self, parts: MlCloseJobParts<'b>) -> MlCloseJob<'a, 'b, ()> {
-        MlCloseJob::new(&self.client, parts)
+        MlCloseJob::new(self.transport(), parts)
     }
     #[doc = "[Ml Delete Calendar API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-calendar.html)\n\nDeletes a calendar."]
     pub fn delete_calendar<'b>(
         &'a self,
         parts: MlDeleteCalendarParts<'b>,
     ) -> MlDeleteCalendar<'a, 'b> {
-        MlDeleteCalendar::new(&self.client, parts)
+        MlDeleteCalendar::new(self.transport(), parts)
     }
     #[doc = "[Ml Delete Calendar Event API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-calendar-event.html)\n\nDeletes scheduled events from a calendar."]
     pub fn delete_calendar_event<'b>(
         &'a self,
         parts: MlDeleteCalendarEventParts<'b>,
     ) -> MlDeleteCalendarEvent<'a, 'b> {
-        MlDeleteCalendarEvent::new(&self.client, parts)
+        MlDeleteCalendarEvent::new(self.transport(), parts)
     }
     #[doc = "[Ml Delete Calendar Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-calendar-job.html)\n\nDeletes anomaly detection jobs from a calendar."]
     pub fn delete_calendar_job<'b>(
         &'a self,
         parts: MlDeleteCalendarJobParts<'b>,
     ) -> MlDeleteCalendarJob<'a, 'b> {
-        MlDeleteCalendarJob::new(&self.client, parts)
+        MlDeleteCalendarJob::new(self.transport(), parts)
     }
     #[doc = "[Ml Delete Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-datafeed.html)\n\nDeletes an existing datafeed."]
     pub fn delete_datafeed<'b>(
         &'a self,
         parts: MlDeleteDatafeedParts<'b>,
     ) -> MlDeleteDatafeed<'a, 'b> {
-        MlDeleteDatafeed::new(&self.client, parts)
+        MlDeleteDatafeed::new(self.transport(), parts)
     }
     #[doc = "[Ml Delete Expired Data API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-expired-data.html)\n\nDeletes expired and unused machine learning data."]
     pub fn delete_expired_data<'b>(
         &'a self,
         parts: MlDeleteExpiredDataParts<'b>,
     ) -> MlDeleteExpiredData<'a, 'b, ()> {
-        MlDeleteExpiredData::new(&self.client, parts)
+        MlDeleteExpiredData::new(self.transport(), parts)
     }
     #[doc = "[Ml Delete Filter API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-filter.html)\n\nDeletes a filter."]
     pub fn delete_filter<'b>(&'a self, parts: MlDeleteFilterParts<'b>) -> MlDeleteFilter<'a, 'b> {
-        MlDeleteFilter::new(&self.client, parts)
+        MlDeleteFilter::new(self.transport(), parts)
     }
     #[doc = "[Ml Delete Forecast API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-forecast.html)\n\nDeletes forecasts from a machine learning job."]
     pub fn delete_forecast<'b>(
         &'a self,
         parts: MlDeleteForecastParts<'b>,
     ) -> MlDeleteForecast<'a, 'b> {
-        MlDeleteForecast::new(&self.client, parts)
+        MlDeleteForecast::new(self.transport(), parts)
     }
     #[doc = "[Ml Delete Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-job.html)\n\nDeletes an existing anomaly detection job."]
     pub fn delete_job<'b>(&'a self, parts: MlDeleteJobParts<'b>) -> MlDeleteJob<'a, 'b> {
-        MlDeleteJob::new(&self.client, parts)
+        MlDeleteJob::new(self.transport(), parts)
     }
     #[doc = "[Ml Delete Model Snapshot API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-delete-snapshot.html)\n\nDeletes an existing model snapshot."]
     pub fn delete_model_snapshot<'b>(
         &'a self,
         parts: MlDeleteModelSnapshotParts<'b>,
     ) -> MlDeleteModelSnapshot<'a, 'b> {
-        MlDeleteModelSnapshot::new(&self.client, parts)
+        MlDeleteModelSnapshot::new(self.transport(), parts)
     }
     #[doc = "[Ml Estimate Model Memory API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-apis.html)\n\nEstimates the model memory"]
     pub fn estimate_model_memory<'b>(&'a self) -> MlEstimateModelMemory<'a, 'b, ()> {
-        MlEstimateModelMemory::new(&self.client)
+        MlEstimateModelMemory::new(self.transport())
     }
     #[doc = "[Ml Flush Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-flush-job.html)\n\nForces any buffered data to be processed by the job."]
     pub fn flush_job<'b>(&'a self, parts: MlFlushJobParts<'b>) -> MlFlushJob<'a, 'b, ()> {
-        MlFlushJob::new(&self.client, parts)
+        MlFlushJob::new(self.transport(), parts)
     }
     #[doc = "[Ml Forecast API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-forecast.html)\n\nPredicts the future behavior of a time series by using its historical behavior."]
     pub fn forecast<'b>(&'a self, parts: MlForecastParts<'b>) -> MlForecast<'a, 'b, ()> {
-        MlForecast::new(&self.client, parts)
+        MlForecast::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Buckets API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-bucket.html)\n\nRetrieves anomaly detection job results for one or more buckets."]
     pub fn get_buckets<'b>(&'a self, parts: MlGetBucketsParts<'b>) -> MlGetBuckets<'a, 'b, ()> {
-        MlGetBuckets::new(&self.client, parts)
+        MlGetBuckets::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Calendar Events API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-calendar-event.html)\n\nRetrieves information about the scheduled events in calendars."]
     pub fn get_calendar_events<'b>(
         &'a self,
         parts: MlGetCalendarEventsParts<'b>,
     ) -> MlGetCalendarEvents<'a, 'b> {
-        MlGetCalendarEvents::new(&self.client, parts)
+        MlGetCalendarEvents::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Calendars API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-calendar.html)\n\nRetrieves configuration information for calendars."]
     pub fn get_calendars<'b>(
         &'a self,
         parts: MlGetCalendarsParts<'b>,
     ) -> MlGetCalendars<'a, 'b, ()> {
-        MlGetCalendars::new(&self.client, parts)
+        MlGetCalendars::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Categories API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-category.html)\n\nRetrieves anomaly detection job results for one or more categories."]
     pub fn get_categories<'b>(
         &'a self,
         parts: MlGetCategoriesParts<'b>,
     ) -> MlGetCategories<'a, 'b, ()> {
-        MlGetCategories::new(&self.client, parts)
+        MlGetCategories::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Datafeed Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-datafeed-stats.html)\n\nRetrieves usage information for datafeeds."]
     pub fn get_datafeed_stats<'b>(
         &'a self,
         parts: MlGetDatafeedStatsParts<'b>,
     ) -> MlGetDatafeedStats<'a, 'b> {
-        MlGetDatafeedStats::new(&self.client, parts)
+        MlGetDatafeedStats::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Datafeeds API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-datafeed.html)\n\nRetrieves configuration information for datafeeds."]
     pub fn get_datafeeds<'b>(&'a self, parts: MlGetDatafeedsParts<'b>) -> MlGetDatafeeds<'a, 'b> {
-        MlGetDatafeeds::new(&self.client, parts)
+        MlGetDatafeeds::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Filters API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-filter.html)\n\nRetrieves filters."]
     pub fn get_filters<'b>(&'a self, parts: MlGetFiltersParts<'b>) -> MlGetFilters<'a, 'b> {
-        MlGetFilters::new(&self.client, parts)
+        MlGetFilters::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Influencers API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-influencer.html)\n\nRetrieves anomaly detection job results for one or more influencers."]
     pub fn get_influencers<'b>(
         &'a self,
         parts: MlGetInfluencersParts<'b>,
     ) -> MlGetInfluencers<'a, 'b, ()> {
-        MlGetInfluencers::new(&self.client, parts)
+        MlGetInfluencers::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Job Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-job-stats.html)\n\nRetrieves usage information for anomaly detection jobs."]
     pub fn get_job_stats<'b>(&'a self, parts: MlGetJobStatsParts<'b>) -> MlGetJobStats<'a, 'b> {
-        MlGetJobStats::new(&self.client, parts)
+        MlGetJobStats::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Jobs API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-job.html)\n\nRetrieves configuration information for anomaly detection jobs."]
     pub fn get_jobs<'b>(&'a self, parts: MlGetJobsParts<'b>) -> MlGetJobs<'a, 'b> {
-        MlGetJobs::new(&self.client, parts)
+        MlGetJobs::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Model Snapshots API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-snapshot.html)\n\nRetrieves information about model snapshots."]
     pub fn get_model_snapshots<'b>(
         &'a self,
         parts: MlGetModelSnapshotsParts<'b>,
     ) -> MlGetModelSnapshots<'a, 'b, ()> {
-        MlGetModelSnapshots::new(&self.client, parts)
+        MlGetModelSnapshots::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Overall Buckets API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-overall-buckets.html)\n\nRetrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs."]
     pub fn get_overall_buckets<'b>(
         &'a self,
         parts: MlGetOverallBucketsParts<'b>,
     ) -> MlGetOverallBuckets<'a, 'b, ()> {
-        MlGetOverallBuckets::new(&self.client, parts)
+        MlGetOverallBuckets::new(self.transport(), parts)
     }
     #[doc = "[Ml Get Records API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-get-record.html)\n\nRetrieves anomaly records for an anomaly detection job."]
     pub fn get_records<'b>(&'a self, parts: MlGetRecordsParts<'b>) -> MlGetRecords<'a, 'b, ()> {
-        MlGetRecords::new(&self.client, parts)
+        MlGetRecords::new(self.transport(), parts)
     }
     #[doc = "[Ml Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-ml-info.html)\n\nReturns defaults and limits used by machine learning."]
     pub fn info<'b>(&'a self) -> MlInfo<'a, 'b> {
-        MlInfo::new(&self.client)
+        MlInfo::new(self.transport())
     }
     #[doc = "[Ml Open Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-open-job.html)\n\nOpens one or more anomaly detection jobs."]
     pub fn open_job<'b>(&'a self, parts: MlOpenJobParts<'b>) -> MlOpenJob<'a, 'b, ()> {
-        MlOpenJob::new(&self.client, parts)
+        MlOpenJob::new(self.transport(), parts)
     }
     #[doc = "[Ml Post Calendar Events API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-post-calendar-event.html)\n\nPosts scheduled events in a calendar."]
     pub fn post_calendar_events<'b>(
         &'a self,
         parts: MlPostCalendarEventsParts<'b>,
     ) -> MlPostCalendarEvents<'a, 'b, ()> {
-        MlPostCalendarEvents::new(&self.client, parts)
+        MlPostCalendarEvents::new(self.transport(), parts)
     }
     #[doc = "[Ml Post Data API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-post-data.html)\n\nSends data to an anomaly detection job for analysis."]
     pub fn post_data<'b>(&'a self, parts: MlPostDataParts<'b>) -> MlPostData<'a, 'b, ()> {
-        MlPostData::new(&self.client, parts)
+        MlPostData::new(self.transport(), parts)
     }
     #[doc = "[Ml Preview Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-preview-datafeed.html)\n\nPreviews a datafeed."]
     pub fn preview_datafeed<'b>(
         &'a self,
         parts: MlPreviewDatafeedParts<'b>,
     ) -> MlPreviewDatafeed<'a, 'b> {
-        MlPreviewDatafeed::new(&self.client, parts)
+        MlPreviewDatafeed::new(self.transport(), parts)
     }
     #[doc = "[Ml Put Calendar API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-put-calendar.html)\n\nInstantiates a calendar."]
     pub fn put_calendar<'b>(&'a self, parts: MlPutCalendarParts<'b>) -> MlPutCalendar<'a, 'b, ()> {
-        MlPutCalendar::new(&self.client, parts)
+        MlPutCalendar::new(self.transport(), parts)
     }
     #[doc = "[Ml Put Calendar Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-put-calendar-job.html)\n\nAdds an anomaly detection job to a calendar."]
     pub fn put_calendar_job<'b>(
         &'a self,
         parts: MlPutCalendarJobParts<'b>,
     ) -> MlPutCalendarJob<'a, 'b, ()> {
-        MlPutCalendarJob::new(&self.client, parts)
+        MlPutCalendarJob::new(self.transport(), parts)
     }
     #[doc = "[Ml Put Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-put-datafeed.html)\n\nInstantiates a datafeed."]
     pub fn put_datafeed<'b>(&'a self, parts: MlPutDatafeedParts<'b>) -> MlPutDatafeed<'a, 'b, ()> {
-        MlPutDatafeed::new(&self.client, parts)
+        MlPutDatafeed::new(self.transport(), parts)
     }
     #[doc = "[Ml Put Filter API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-put-filter.html)\n\nInstantiates a filter."]
     pub fn put_filter<'b>(&'a self, parts: MlPutFilterParts<'b>) -> MlPutFilter<'a, 'b, ()> {
-        MlPutFilter::new(&self.client, parts)
+        MlPutFilter::new(self.transport(), parts)
     }
     #[doc = "[Ml Put Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-put-job.html)\n\nInstantiates an anomaly detection job."]
     pub fn put_job<'b>(&'a self, parts: MlPutJobParts<'b>) -> MlPutJob<'a, 'b, ()> {
-        MlPutJob::new(&self.client, parts)
+        MlPutJob::new(self.transport(), parts)
     }
     #[doc = "[Ml Revert Model Snapshot API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-revert-snapshot.html)\n\nReverts to a specific snapshot."]
     pub fn revert_model_snapshot<'b>(
         &'a self,
         parts: MlRevertModelSnapshotParts<'b>,
     ) -> MlRevertModelSnapshot<'a, 'b, ()> {
-        MlRevertModelSnapshot::new(&self.client, parts)
+        MlRevertModelSnapshot::new(self.transport(), parts)
     }
     #[doc = "[Ml Set Upgrade Mode API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-set-upgrade-mode.html)\n\nSets a cluster wide upgrade_mode setting that prepares machine learning indices for an upgrade."]
     pub fn set_upgrade_mode<'b>(&'a self) -> MlSetUpgradeMode<'a, 'b, ()> {
-        MlSetUpgradeMode::new(&self.client)
+        MlSetUpgradeMode::new(self.transport())
     }
     #[doc = "[Ml Start Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-start-datafeed.html)\n\nStarts one or more datafeeds."]
     pub fn start_datafeed<'b>(
         &'a self,
         parts: MlStartDatafeedParts<'b>,
     ) -> MlStartDatafeed<'a, 'b, ()> {
-        MlStartDatafeed::new(&self.client, parts)
+        MlStartDatafeed::new(self.transport(), parts)
     }
     #[doc = "[Ml Stop Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-stop-datafeed.html)\n\nStops one or more datafeeds."]
     pub fn stop_datafeed<'b>(
         &'a self,
         parts: MlStopDatafeedParts<'b>,
     ) -> MlStopDatafeed<'a, 'b, ()> {
-        MlStopDatafeed::new(&self.client, parts)
+        MlStopDatafeed::new(self.transport(), parts)
     }
     #[doc = "[Ml Update Datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-update-datafeed.html)\n\nUpdates certain properties of a datafeed."]
     pub fn update_datafeed<'b>(
         &'a self,
         parts: MlUpdateDatafeedParts<'b>,
     ) -> MlUpdateDatafeed<'a, 'b, ()> {
-        MlUpdateDatafeed::new(&self.client, parts)
+        MlUpdateDatafeed::new(self.transport(), parts)
     }
     #[doc = "[Ml Update Filter API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-update-filter.html)\n\nUpdates the description of a filter, adds items, or removes items."]
     pub fn update_filter<'b>(
         &'a self,
         parts: MlUpdateFilterParts<'b>,
     ) -> MlUpdateFilter<'a, 'b, ()> {
-        MlUpdateFilter::new(&self.client, parts)
+        MlUpdateFilter::new(self.transport(), parts)
     }
     #[doc = "[Ml Update Job API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-update-job.html)\n\nUpdates certain properties of an anomaly detection job."]
     pub fn update_job<'b>(&'a self, parts: MlUpdateJobParts<'b>) -> MlUpdateJob<'a, 'b, ()> {
-        MlUpdateJob::new(&self.client, parts)
+        MlUpdateJob::new(self.transport(), parts)
     }
     #[doc = "[Ml Update Model Snapshot API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/ml-update-snapshot.html)\n\nUpdates certain properties of a snapshot."]
     pub fn update_model_snapshot<'b>(
         &'a self,
         parts: MlUpdateModelSnapshotParts<'b>,
     ) -> MlUpdateModelSnapshot<'a, 'b, ()> {
-        MlUpdateModelSnapshot::new(&self.client, parts)
+        MlUpdateModelSnapshot::new(self.transport(), parts)
     }
     #[doc = "[Ml Validate API](https://www.elastic.co/guide/en/machine-learning/8.0/ml-jobs.html)\n\nValidates an anomaly detection job."]
     pub fn validate<'b>(&'a self) -> MlValidate<'a, 'b, ()> {
-        MlValidate::new(&self.client)
+        MlValidate::new(self.transport())
     }
     #[doc = "[Ml Validate Detector API](https://www.elastic.co/guide/en/machine-learning/8.0/ml-jobs.html)\n\nValidates an anomaly detection detector."]
     pub fn validate_detector<'b>(&'a self) -> MlValidateDetector<'a, 'b, ()> {
-        MlValidateDetector::new(&self.client)
+        MlValidateDetector::new(self.transport())
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Machine Learning APIs"]
     pub fn ml(&self) -> Ml {
-        Ml::new(&self)
+        Ml::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/mod.rs
+++ b/elasticsearch/src/generated/namespace_clients/mod.rs
@@ -26,6 +26,7 @@ pub mod async_search;
 pub mod cat;
 pub mod ccr;
 pub mod cluster;
+pub mod dangling_indices;
 pub mod enrich;
 pub mod graph;
 pub mod ilm;

--- a/elasticsearch/src/generated/namespace_clients/nodes.rs
+++ b/elasticsearch/src/generated/namespace_clients/nodes.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -66,7 +67,7 @@ impl<'b> NodesHotThreadsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Nodes Hot Threads API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-hot-threads.html)\n\nReturns information about hot threads on each node in the cluster."]
 pub struct NodesHotThreads<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: NodesHotThreadsParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -83,10 +84,10 @@ pub struct NodesHotThreads<'a, 'b> {
 }
 impl<'a, 'b> NodesHotThreads<'a, 'b> {
     #[doc = "Creates a new instance of [NodesHotThreads] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: NodesHotThreadsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: NodesHotThreadsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         NodesHotThreads {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -214,7 +215,7 @@ impl<'a, 'b> NodesHotThreads<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -276,7 +277,7 @@ impl<'b> NodesInfoParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Nodes Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-info.html)\n\nReturns information about nodes in the cluster."]
 pub struct NodesInfo<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: NodesInfoParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -289,10 +290,10 @@ pub struct NodesInfo<'a, 'b> {
 }
 impl<'a, 'b> NodesInfo<'a, 'b> {
     #[doc = "Creates a new instance of [NodesInfo] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: NodesInfoParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: NodesInfoParts<'b>) -> Self {
         let headers = HeaderMap::new();
         NodesInfo {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -384,7 +385,7 @@ impl<'a, 'b> NodesInfo<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -419,7 +420,7 @@ impl<'b> NodesReloadSecureSettingsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Nodes Reload Secure Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/secure-settings.html#reloadable-secure-settings)\n\nReloads secure settings."]
 pub struct NodesReloadSecureSettings<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: NodesReloadSecureSettingsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -435,10 +436,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [NodesReloadSecureSettings] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: NodesReloadSecureSettingsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: NodesReloadSecureSettingsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         NodesReloadSecureSettings {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -456,7 +457,7 @@ where
         T: Serialize,
     {
         NodesReloadSecureSettings {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -540,7 +541,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -647,7 +648,7 @@ impl<'b> NodesStatsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Nodes Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-stats.html)\n\nReturns statistical information about nodes in the cluster."]
 pub struct NodesStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: NodesStatsParts<'b>,
     completion_fields: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
@@ -666,10 +667,10 @@ pub struct NodesStats<'a, 'b> {
 }
 impl<'a, 'b> NodesStats<'a, 'b> {
     #[doc = "Creates a new instance of [NodesStats] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: NodesStatsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: NodesStatsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         NodesStats {
-            client,
+            transport,
             parts,
             headers,
             completion_fields: None,
@@ -821,7 +822,7 @@ impl<'a, 'b> NodesStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -884,7 +885,7 @@ impl<'b> NodesUsageParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Nodes Usage API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-usage.html)\n\nReturns low-level information about REST actions usage on nodes."]
 pub struct NodesUsage<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: NodesUsageParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -896,10 +897,10 @@ pub struct NodesUsage<'a, 'b> {
 }
 impl<'a, 'b> NodesUsage<'a, 'b> {
     #[doc = "Creates a new instance of [NodesUsage] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: NodesUsageParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: NodesUsageParts<'b>) -> Self {
         let headers = HeaderMap::new();
         NodesUsage {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -982,7 +983,7 @@ impl<'a, 'b> NodesUsage<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -990,40 +991,43 @@ impl<'a, 'b> NodesUsage<'a, 'b> {
 }
 #[doc = "Namespace client for Nodes APIs"]
 pub struct Nodes<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Nodes<'a> {
     #[doc = "Creates a new instance of [Nodes]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Nodes Hot Threads API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-hot-threads.html)\n\nReturns information about hot threads on each node in the cluster."]
     pub fn hot_threads<'b>(&'a self, parts: NodesHotThreadsParts<'b>) -> NodesHotThreads<'a, 'b> {
-        NodesHotThreads::new(&self.client, parts)
+        NodesHotThreads::new(self.transport(), parts)
     }
     #[doc = "[Nodes Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-info.html)\n\nReturns information about nodes in the cluster."]
     pub fn info<'b>(&'a self, parts: NodesInfoParts<'b>) -> NodesInfo<'a, 'b> {
-        NodesInfo::new(&self.client, parts)
+        NodesInfo::new(self.transport(), parts)
     }
     #[doc = "[Nodes Reload Secure Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/secure-settings.html#reloadable-secure-settings)\n\nReloads secure settings."]
     pub fn reload_secure_settings<'b>(
         &'a self,
         parts: NodesReloadSecureSettingsParts<'b>,
     ) -> NodesReloadSecureSettings<'a, 'b, ()> {
-        NodesReloadSecureSettings::new(&self.client, parts)
+        NodesReloadSecureSettings::new(self.transport(), parts)
     }
     #[doc = "[Nodes Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-stats.html)\n\nReturns statistical information about nodes in the cluster."]
     pub fn stats<'b>(&'a self, parts: NodesStatsParts<'b>) -> NodesStats<'a, 'b> {
-        NodesStats::new(&self.client, parts)
+        NodesStats::new(self.transport(), parts)
     }
     #[doc = "[Nodes Usage API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster-nodes-usage.html)\n\nReturns low-level information about REST actions usage on nodes."]
     pub fn usage<'b>(&'a self, parts: NodesUsageParts<'b>) -> NodesUsage<'a, 'b> {
-        NodesUsage::new(&self.client, parts)
+        NodesUsage::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Nodes APIs"]
     pub fn nodes(&self) -> Nodes {
-        Nodes::new(&self)
+        Nodes::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/security.rs
+++ b/elasticsearch/src/generated/namespace_clients/security.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -54,7 +55,7 @@ impl SecurityAuthenticateParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Authenticate API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-authenticate.html)\n\nEnables authentication as a user and retrieve information about the authenticated user."]
 pub struct SecurityAuthenticate<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityAuthenticateParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -65,10 +66,10 @@ pub struct SecurityAuthenticate<'a, 'b> {
 }
 impl<'a, 'b> SecurityAuthenticate<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityAuthenticate]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SecurityAuthenticate {
-            client,
+            transport,
             parts: SecurityAuthenticateParts::None,
             headers,
             error_trace: None,
@@ -142,7 +143,7 @@ impl<'a, 'b> SecurityAuthenticate<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -176,7 +177,7 @@ impl<'b> SecurityChangePasswordParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Change Password API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-change-password.html)\n\nChanges the passwords of users in the native realm and built-in users."]
 pub struct SecurityChangePassword<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityChangePasswordParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -192,10 +193,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityChangePassword] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityChangePasswordParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityChangePasswordParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityChangePassword {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -213,7 +214,7 @@ where
         T: Serialize,
     {
         SecurityChangePassword {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -297,7 +298,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -329,7 +330,7 @@ impl<'b> SecurityClearCachedRealmsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Clear Cached Realms API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-clear-cache.html)\n\nEvicts users from the user cache. Can completely clear the cache or evict specific users."]
 pub struct SecurityClearCachedRealms<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityClearCachedRealmsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -345,10 +346,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityClearCachedRealms] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityClearCachedRealmsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityClearCachedRealmsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityClearCachedRealms {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -366,7 +367,7 @@ where
         T: Serialize,
     {
         SecurityClearCachedRealms {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -453,7 +454,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -485,7 +486,7 @@ impl<'b> SecurityClearCachedRolesParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Clear Cached Roles API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-clear-role-cache.html)\n\nEvicts roles from the native role cache."]
 pub struct SecurityClearCachedRoles<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityClearCachedRolesParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -500,10 +501,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityClearCachedRoles] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityClearCachedRolesParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityClearCachedRolesParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityClearCachedRoles {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -520,7 +521,7 @@ where
         T: Serialize,
     {
         SecurityClearCachedRoles {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -595,7 +596,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -618,7 +619,7 @@ impl SecurityCreateApiKeyParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Create Api Key API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-create-api-key.html)\n\nCreates an API key for access without requiring basic authentication."]
 pub struct SecurityCreateApiKey<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityCreateApiKeyParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -634,10 +635,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityCreateApiKey]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SecurityCreateApiKey {
-            client,
+            transport,
             parts: SecurityCreateApiKeyParts::None,
             headers,
             body: None,
@@ -655,7 +656,7 @@ where
         T: Serialize,
     {
         SecurityCreateApiKey {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -739,7 +740,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -773,7 +774,7 @@ impl<'b> SecurityDeletePrivilegesParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Delete Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-delete-privilege.html)\n\nRemoves application privileges."]
 pub struct SecurityDeletePrivileges<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityDeletePrivilegesParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -785,10 +786,10 @@ pub struct SecurityDeletePrivileges<'a, 'b> {
 }
 impl<'a, 'b> SecurityDeletePrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeletePrivileges] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityDeletePrivilegesParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityDeletePrivilegesParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityDeletePrivileges {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -871,7 +872,7 @@ impl<'a, 'b> SecurityDeletePrivileges<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -900,7 +901,7 @@ impl<'b> SecurityDeleteRoleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Delete Role API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-delete-role.html)\n\nRemoves roles in the native realm."]
 pub struct SecurityDeleteRole<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityDeleteRoleParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -912,10 +913,10 @@ pub struct SecurityDeleteRole<'a, 'b> {
 }
 impl<'a, 'b> SecurityDeleteRole<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeleteRole] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityDeleteRoleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityDeleteRoleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityDeleteRole {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -998,7 +999,7 @@ impl<'a, 'b> SecurityDeleteRole<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1027,7 +1028,7 @@ impl<'b> SecurityDeleteRoleMappingParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Delete Role Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-delete-role-mapping.html)\n\nRemoves role mappings."]
 pub struct SecurityDeleteRoleMapping<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityDeleteRoleMappingParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1039,10 +1040,10 @@ pub struct SecurityDeleteRoleMapping<'a, 'b> {
 }
 impl<'a, 'b> SecurityDeleteRoleMapping<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeleteRoleMapping] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityDeleteRoleMappingParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityDeleteRoleMappingParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityDeleteRoleMapping {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1125,7 +1126,7 @@ impl<'a, 'b> SecurityDeleteRoleMapping<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1155,7 +1156,7 @@ impl<'b> SecurityDeleteUserParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Delete User API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-delete-user.html)\n\nDeletes users from the native realm."]
 pub struct SecurityDeleteUser<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityDeleteUserParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1167,10 +1168,10 @@ pub struct SecurityDeleteUser<'a, 'b> {
 }
 impl<'a, 'b> SecurityDeleteUser<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityDeleteUser] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityDeleteUserParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityDeleteUserParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityDeleteUser {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1253,7 +1254,7 @@ impl<'a, 'b> SecurityDeleteUser<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1284,7 +1285,7 @@ impl<'b> SecurityDisableUserParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Disable User API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-disable-user.html)\n\nDisables users in the native realm."]
 pub struct SecurityDisableUser<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityDisableUserParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1300,10 +1301,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityDisableUser] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityDisableUserParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityDisableUserParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityDisableUser {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1321,7 +1322,7 @@ where
         T: Serialize,
     {
         SecurityDisableUser {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1405,7 +1406,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1436,7 +1437,7 @@ impl<'b> SecurityEnableUserParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Enable User API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-enable-user.html)\n\nEnables users in the native realm."]
 pub struct SecurityEnableUser<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityEnableUserParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1452,10 +1453,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityEnableUser] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityEnableUserParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityEnableUserParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityEnableUser {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1473,7 +1474,7 @@ where
         T: Serialize,
     {
         SecurityEnableUser {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1557,7 +1558,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1580,7 +1581,7 @@ impl SecurityGetApiKeyParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Api Key API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-api-key.html)\n\nRetrieves information for one or more API keys."]
 pub struct SecurityGetApiKey<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityGetApiKeyParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1596,10 +1597,10 @@ pub struct SecurityGetApiKey<'a, 'b> {
 }
 impl<'a, 'b> SecurityGetApiKey<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetApiKey]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SecurityGetApiKey {
-            client,
+            transport,
             parts: SecurityGetApiKeyParts::None,
             headers,
             error_trace: None,
@@ -1718,7 +1719,7 @@ impl<'a, 'b> SecurityGetApiKey<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1741,7 +1742,7 @@ impl SecurityGetBuiltinPrivilegesParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Builtin Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-builtin-privileges.html)\n\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch."]
 pub struct SecurityGetBuiltinPrivileges<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityGetBuiltinPrivilegesParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1752,10 +1753,10 @@ pub struct SecurityGetBuiltinPrivileges<'a, 'b> {
 }
 impl<'a, 'b> SecurityGetBuiltinPrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetBuiltinPrivileges]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SecurityGetBuiltinPrivileges {
-            client,
+            transport,
             parts: SecurityGetBuiltinPrivilegesParts::None,
             headers,
             error_trace: None,
@@ -1829,7 +1830,7 @@ impl<'a, 'b> SecurityGetBuiltinPrivileges<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1876,7 +1877,7 @@ impl<'b> SecurityGetPrivilegesParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-privileges.html)\n\nRetrieves application privileges."]
 pub struct SecurityGetPrivileges<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityGetPrivilegesParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1887,10 +1888,10 @@ pub struct SecurityGetPrivileges<'a, 'b> {
 }
 impl<'a, 'b> SecurityGetPrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetPrivileges] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityGetPrivilegesParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityGetPrivilegesParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityGetPrivileges {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1964,7 +1965,7 @@ impl<'a, 'b> SecurityGetPrivileges<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1998,7 +1999,7 @@ impl<'b> SecurityGetRoleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Role API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-role.html)\n\nRetrieves roles in the native realm."]
 pub struct SecurityGetRole<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityGetRoleParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -2009,10 +2010,10 @@ pub struct SecurityGetRole<'a, 'b> {
 }
 impl<'a, 'b> SecurityGetRole<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetRole] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityGetRoleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityGetRoleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityGetRole {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -2086,7 +2087,7 @@ impl<'a, 'b> SecurityGetRole<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2120,7 +2121,7 @@ impl<'b> SecurityGetRoleMappingParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Role Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-role-mapping.html)\n\nRetrieves role mappings."]
 pub struct SecurityGetRoleMapping<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityGetRoleMappingParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -2131,10 +2132,10 @@ pub struct SecurityGetRoleMapping<'a, 'b> {
 }
 impl<'a, 'b> SecurityGetRoleMapping<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetRoleMapping] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityGetRoleMappingParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityGetRoleMappingParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityGetRoleMapping {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -2208,7 +2209,7 @@ impl<'a, 'b> SecurityGetRoleMapping<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2231,7 +2232,7 @@ impl SecurityGetTokenParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get Token API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-token.html)\n\nCreates a bearer token for access without requiring basic authentication."]
 pub struct SecurityGetToken<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityGetTokenParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -2246,10 +2247,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityGetToken]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SecurityGetToken {
-            client,
+            transport,
             parts: SecurityGetTokenParts::None,
             headers,
             body: None,
@@ -2266,7 +2267,7 @@ where
         T: Serialize,
     {
         SecurityGetToken {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -2341,7 +2342,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2375,7 +2376,7 @@ impl<'b> SecurityGetUserParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get User API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-user.html)\n\nRetrieves information about users in the native realm and built-in users."]
 pub struct SecurityGetUser<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityGetUserParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -2386,10 +2387,10 @@ pub struct SecurityGetUser<'a, 'b> {
 }
 impl<'a, 'b> SecurityGetUser<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetUser] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityGetUserParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityGetUserParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityGetUser {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -2463,7 +2464,7 @@ impl<'a, 'b> SecurityGetUser<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2486,7 +2487,7 @@ impl SecurityGetUserPrivilegesParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Get User Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-privileges.html)\n\nRetrieves application privileges."]
 pub struct SecurityGetUserPrivileges<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityGetUserPrivilegesParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -2497,10 +2498,10 @@ pub struct SecurityGetUserPrivileges<'a, 'b> {
 }
 impl<'a, 'b> SecurityGetUserPrivileges<'a, 'b> {
     #[doc = "Creates a new instance of [SecurityGetUserPrivileges]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SecurityGetUserPrivileges {
-            client,
+            transport,
             parts: SecurityGetUserPrivilegesParts::None,
             headers,
             error_trace: None,
@@ -2574,7 +2575,7 @@ impl<'a, 'b> SecurityGetUserPrivileges<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2607,7 +2608,7 @@ impl<'b> SecurityHasPrivilegesParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Has Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-has-privileges.html)\n\nDetermines whether the specified user has a specified list of privileges."]
 pub struct SecurityHasPrivileges<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityHasPrivilegesParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -2622,10 +2623,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityHasPrivileges] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityHasPrivilegesParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityHasPrivilegesParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityHasPrivileges {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -2642,7 +2643,7 @@ where
         T: Serialize,
     {
         SecurityHasPrivileges {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -2720,7 +2721,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2743,7 +2744,7 @@ impl SecurityInvalidateApiKeyParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Invalidate Api Key API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-invalidate-api-key.html)\n\nInvalidates one or more API keys."]
 pub struct SecurityInvalidateApiKey<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityInvalidateApiKeyParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -2758,10 +2759,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityInvalidateApiKey]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SecurityInvalidateApiKey {
-            client,
+            transport,
             parts: SecurityInvalidateApiKeyParts::None,
             headers,
             body: None,
@@ -2778,7 +2779,7 @@ where
         T: Serialize,
     {
         SecurityInvalidateApiKey {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -2853,7 +2854,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2876,7 +2877,7 @@ impl SecurityInvalidateTokenParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Invalidate Token API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-invalidate-token.html)\n\nInvalidates one or more access tokens or refresh tokens."]
 pub struct SecurityInvalidateToken<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityInvalidateTokenParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -2891,10 +2892,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityInvalidateToken]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SecurityInvalidateToken {
-            client,
+            transport,
             parts: SecurityInvalidateTokenParts::None,
             headers,
             body: None,
@@ -2911,7 +2912,7 @@ where
         T: Serialize,
     {
         SecurityInvalidateToken {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -2986,7 +2987,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3009,7 +3010,7 @@ impl SecurityPutPrivilegesParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Put Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-put-privileges.html)\n\nAdds or updates application privileges."]
 pub struct SecurityPutPrivileges<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityPutPrivilegesParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -3025,10 +3026,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityPutPrivileges]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SecurityPutPrivileges {
-            client,
+            transport,
             parts: SecurityPutPrivilegesParts::None,
             headers,
             body: None,
@@ -3046,7 +3047,7 @@ where
         T: Serialize,
     {
         SecurityPutPrivileges {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -3130,7 +3131,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3159,7 +3160,7 @@ impl<'b> SecurityPutRoleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Put Role API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-put-role.html)\n\nAdds and updates roles in the native realm."]
 pub struct SecurityPutRole<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityPutRoleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -3175,10 +3176,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityPutRole] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityPutRoleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityPutRoleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityPutRole {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -3196,7 +3197,7 @@ where
         T: Serialize,
     {
         SecurityPutRole {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -3280,7 +3281,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3309,7 +3310,7 @@ impl<'b> SecurityPutRoleMappingParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Put Role Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-put-role-mapping.html)\n\nCreates and updates role mappings."]
 pub struct SecurityPutRoleMapping<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityPutRoleMappingParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -3325,10 +3326,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityPutRoleMapping] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityPutRoleMappingParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityPutRoleMappingParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityPutRoleMapping {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -3346,7 +3347,7 @@ where
         T: Serialize,
     {
         SecurityPutRoleMapping {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -3430,7 +3431,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3460,7 +3461,7 @@ impl<'b> SecurityPutUserParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Security Put User API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-put-user.html)\n\nAdds and updates users in the native realm. These users are commonly referred to as native users."]
 pub struct SecurityPutUser<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SecurityPutUserParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -3476,10 +3477,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SecurityPutUser] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SecurityPutUserParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SecurityPutUserParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SecurityPutUser {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -3497,7 +3498,7 @@ where
         T: Serialize,
     {
         SecurityPutUser {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -3581,7 +3582,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3589,160 +3590,163 @@ where
 }
 #[doc = "Namespace client for Security APIs"]
 pub struct Security<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Security<'a> {
     #[doc = "Creates a new instance of [Security]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Security Authenticate API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-authenticate.html)\n\nEnables authentication as a user and retrieve information about the authenticated user."]
     pub fn authenticate<'b>(&'a self) -> SecurityAuthenticate<'a, 'b> {
-        SecurityAuthenticate::new(&self.client)
+        SecurityAuthenticate::new(self.transport())
     }
     #[doc = "[Security Change Password API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-change-password.html)\n\nChanges the passwords of users in the native realm and built-in users."]
     pub fn change_password<'b>(
         &'a self,
         parts: SecurityChangePasswordParts<'b>,
     ) -> SecurityChangePassword<'a, 'b, ()> {
-        SecurityChangePassword::new(&self.client, parts)
+        SecurityChangePassword::new(self.transport(), parts)
     }
     #[doc = "[Security Clear Cached Realms API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-clear-cache.html)\n\nEvicts users from the user cache. Can completely clear the cache or evict specific users."]
     pub fn clear_cached_realms<'b>(
         &'a self,
         parts: SecurityClearCachedRealmsParts<'b>,
     ) -> SecurityClearCachedRealms<'a, 'b, ()> {
-        SecurityClearCachedRealms::new(&self.client, parts)
+        SecurityClearCachedRealms::new(self.transport(), parts)
     }
     #[doc = "[Security Clear Cached Roles API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-clear-role-cache.html)\n\nEvicts roles from the native role cache."]
     pub fn clear_cached_roles<'b>(
         &'a self,
         parts: SecurityClearCachedRolesParts<'b>,
     ) -> SecurityClearCachedRoles<'a, 'b, ()> {
-        SecurityClearCachedRoles::new(&self.client, parts)
+        SecurityClearCachedRoles::new(self.transport(), parts)
     }
     #[doc = "[Security Create Api Key API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-create-api-key.html)\n\nCreates an API key for access without requiring basic authentication."]
     pub fn create_api_key<'b>(&'a self) -> SecurityCreateApiKey<'a, 'b, ()> {
-        SecurityCreateApiKey::new(&self.client)
+        SecurityCreateApiKey::new(self.transport())
     }
     #[doc = "[Security Delete Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-delete-privilege.html)\n\nRemoves application privileges."]
     pub fn delete_privileges<'b>(
         &'a self,
         parts: SecurityDeletePrivilegesParts<'b>,
     ) -> SecurityDeletePrivileges<'a, 'b> {
-        SecurityDeletePrivileges::new(&self.client, parts)
+        SecurityDeletePrivileges::new(self.transport(), parts)
     }
     #[doc = "[Security Delete Role API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-delete-role.html)\n\nRemoves roles in the native realm."]
     pub fn delete_role<'b>(
         &'a self,
         parts: SecurityDeleteRoleParts<'b>,
     ) -> SecurityDeleteRole<'a, 'b> {
-        SecurityDeleteRole::new(&self.client, parts)
+        SecurityDeleteRole::new(self.transport(), parts)
     }
     #[doc = "[Security Delete Role Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-delete-role-mapping.html)\n\nRemoves role mappings."]
     pub fn delete_role_mapping<'b>(
         &'a self,
         parts: SecurityDeleteRoleMappingParts<'b>,
     ) -> SecurityDeleteRoleMapping<'a, 'b> {
-        SecurityDeleteRoleMapping::new(&self.client, parts)
+        SecurityDeleteRoleMapping::new(self.transport(), parts)
     }
     #[doc = "[Security Delete User API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-delete-user.html)\n\nDeletes users from the native realm."]
     pub fn delete_user<'b>(
         &'a self,
         parts: SecurityDeleteUserParts<'b>,
     ) -> SecurityDeleteUser<'a, 'b> {
-        SecurityDeleteUser::new(&self.client, parts)
+        SecurityDeleteUser::new(self.transport(), parts)
     }
     #[doc = "[Security Disable User API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-disable-user.html)\n\nDisables users in the native realm."]
     pub fn disable_user<'b>(
         &'a self,
         parts: SecurityDisableUserParts<'b>,
     ) -> SecurityDisableUser<'a, 'b, ()> {
-        SecurityDisableUser::new(&self.client, parts)
+        SecurityDisableUser::new(self.transport(), parts)
     }
     #[doc = "[Security Enable User API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-enable-user.html)\n\nEnables users in the native realm."]
     pub fn enable_user<'b>(
         &'a self,
         parts: SecurityEnableUserParts<'b>,
     ) -> SecurityEnableUser<'a, 'b, ()> {
-        SecurityEnableUser::new(&self.client, parts)
+        SecurityEnableUser::new(self.transport(), parts)
     }
     #[doc = "[Security Get Api Key API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-api-key.html)\n\nRetrieves information for one or more API keys."]
     pub fn get_api_key<'b>(&'a self) -> SecurityGetApiKey<'a, 'b> {
-        SecurityGetApiKey::new(&self.client)
+        SecurityGetApiKey::new(self.transport())
     }
     #[doc = "[Security Get Builtin Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-builtin-privileges.html)\n\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch."]
     pub fn get_builtin_privileges<'b>(&'a self) -> SecurityGetBuiltinPrivileges<'a, 'b> {
-        SecurityGetBuiltinPrivileges::new(&self.client)
+        SecurityGetBuiltinPrivileges::new(self.transport())
     }
     #[doc = "[Security Get Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-privileges.html)\n\nRetrieves application privileges."]
     pub fn get_privileges<'b>(
         &'a self,
         parts: SecurityGetPrivilegesParts<'b>,
     ) -> SecurityGetPrivileges<'a, 'b> {
-        SecurityGetPrivileges::new(&self.client, parts)
+        SecurityGetPrivileges::new(self.transport(), parts)
     }
     #[doc = "[Security Get Role API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-role.html)\n\nRetrieves roles in the native realm."]
     pub fn get_role<'b>(&'a self, parts: SecurityGetRoleParts<'b>) -> SecurityGetRole<'a, 'b> {
-        SecurityGetRole::new(&self.client, parts)
+        SecurityGetRole::new(self.transport(), parts)
     }
     #[doc = "[Security Get Role Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-role-mapping.html)\n\nRetrieves role mappings."]
     pub fn get_role_mapping<'b>(
         &'a self,
         parts: SecurityGetRoleMappingParts<'b>,
     ) -> SecurityGetRoleMapping<'a, 'b> {
-        SecurityGetRoleMapping::new(&self.client, parts)
+        SecurityGetRoleMapping::new(self.transport(), parts)
     }
     #[doc = "[Security Get Token API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-token.html)\n\nCreates a bearer token for access without requiring basic authentication."]
     pub fn get_token<'b>(&'a self) -> SecurityGetToken<'a, 'b, ()> {
-        SecurityGetToken::new(&self.client)
+        SecurityGetToken::new(self.transport())
     }
     #[doc = "[Security Get User API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-user.html)\n\nRetrieves information about users in the native realm and built-in users."]
     pub fn get_user<'b>(&'a self, parts: SecurityGetUserParts<'b>) -> SecurityGetUser<'a, 'b> {
-        SecurityGetUser::new(&self.client, parts)
+        SecurityGetUser::new(self.transport(), parts)
     }
     #[doc = "[Security Get User Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-get-privileges.html)\n\nRetrieves application privileges."]
     pub fn get_user_privileges<'b>(&'a self) -> SecurityGetUserPrivileges<'a, 'b> {
-        SecurityGetUserPrivileges::new(&self.client)
+        SecurityGetUserPrivileges::new(self.transport())
     }
     #[doc = "[Security Has Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-has-privileges.html)\n\nDetermines whether the specified user has a specified list of privileges."]
     pub fn has_privileges<'b>(
         &'a self,
         parts: SecurityHasPrivilegesParts<'b>,
     ) -> SecurityHasPrivileges<'a, 'b, ()> {
-        SecurityHasPrivileges::new(&self.client, parts)
+        SecurityHasPrivileges::new(self.transport(), parts)
     }
     #[doc = "[Security Invalidate Api Key API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-invalidate-api-key.html)\n\nInvalidates one or more API keys."]
     pub fn invalidate_api_key<'b>(&'a self) -> SecurityInvalidateApiKey<'a, 'b, ()> {
-        SecurityInvalidateApiKey::new(&self.client)
+        SecurityInvalidateApiKey::new(self.transport())
     }
     #[doc = "[Security Invalidate Token API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-invalidate-token.html)\n\nInvalidates one or more access tokens or refresh tokens."]
     pub fn invalidate_token<'b>(&'a self) -> SecurityInvalidateToken<'a, 'b, ()> {
-        SecurityInvalidateToken::new(&self.client)
+        SecurityInvalidateToken::new(self.transport())
     }
     #[doc = "[Security Put Privileges API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-put-privileges.html)\n\nAdds or updates application privileges."]
     pub fn put_privileges<'b>(&'a self) -> SecurityPutPrivileges<'a, 'b, ()> {
-        SecurityPutPrivileges::new(&self.client)
+        SecurityPutPrivileges::new(self.transport())
     }
     #[doc = "[Security Put Role API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-put-role.html)\n\nAdds and updates roles in the native realm."]
     pub fn put_role<'b>(&'a self, parts: SecurityPutRoleParts<'b>) -> SecurityPutRole<'a, 'b, ()> {
-        SecurityPutRole::new(&self.client, parts)
+        SecurityPutRole::new(self.transport(), parts)
     }
     #[doc = "[Security Put Role Mapping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-put-role-mapping.html)\n\nCreates and updates role mappings."]
     pub fn put_role_mapping<'b>(
         &'a self,
         parts: SecurityPutRoleMappingParts<'b>,
     ) -> SecurityPutRoleMapping<'a, 'b, ()> {
-        SecurityPutRoleMapping::new(&self.client, parts)
+        SecurityPutRoleMapping::new(self.transport(), parts)
     }
     #[doc = "[Security Put User API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-put-user.html)\n\nAdds and updates users in the native realm. These users are commonly referred to as native users."]
     pub fn put_user<'b>(&'a self, parts: SecurityPutUserParts<'b>) -> SecurityPutUser<'a, 'b, ()> {
-        SecurityPutUser::new(&self.client, parts)
+        SecurityPutUser::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Security APIs"]
     pub fn security(&self) -> Security {
-        Security::new(&self)
+        Security::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/slm.rs
+++ b/elasticsearch/src/generated/namespace_clients/slm.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -61,7 +62,7 @@ impl<'b> SlmDeleteLifecycleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Delete Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-delete-policy.html)\n\nDeletes an existing snapshot lifecycle policy."]
 pub struct SlmDeleteLifecycle<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SlmDeleteLifecycleParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -72,10 +73,10 @@ pub struct SlmDeleteLifecycle<'a, 'b> {
 }
 impl<'a, 'b> SlmDeleteLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [SlmDeleteLifecycle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SlmDeleteLifecycleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SlmDeleteLifecycleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SlmDeleteLifecycle {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -149,7 +150,7 @@ impl<'a, 'b> SlmDeleteLifecycle<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -180,7 +181,7 @@ impl<'b> SlmExecuteLifecycleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Execute Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-execute-lifecycle.html)\n\nImmediately creates a snapshot according to the lifecycle policy, without waiting for the scheduled time."]
 pub struct SlmExecuteLifecycle<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SlmExecuteLifecycleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -195,10 +196,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SlmExecuteLifecycle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SlmExecuteLifecycleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SlmExecuteLifecycleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SlmExecuteLifecycle {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -215,7 +216,7 @@ where
         T: Serialize,
     {
         SlmExecuteLifecycle {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -290,7 +291,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -313,7 +314,7 @@ impl SlmExecuteRetentionParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Execute Retention API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-execute-retention.html)\n\nDeletes any snapshots that are expired according to the policy's retention rules."]
 pub struct SlmExecuteRetention<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SlmExecuteRetentionParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -328,10 +329,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SlmExecuteRetention]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SlmExecuteRetention {
-            client,
+            transport,
             parts: SlmExecuteRetentionParts::None,
             headers,
             body: None,
@@ -348,7 +349,7 @@ where
         T: Serialize,
     {
         SlmExecuteRetention {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -423,7 +424,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -457,7 +458,7 @@ impl<'b> SlmGetLifecycleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Get Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-get-policy.html)\n\nRetrieves one or more snapshot lifecycle policy definitions and information about the latest snapshot attempts."]
 pub struct SlmGetLifecycle<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SlmGetLifecycleParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -468,10 +469,10 @@ pub struct SlmGetLifecycle<'a, 'b> {
 }
 impl<'a, 'b> SlmGetLifecycle<'a, 'b> {
     #[doc = "Creates a new instance of [SlmGetLifecycle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SlmGetLifecycleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SlmGetLifecycleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SlmGetLifecycle {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -545,7 +546,7 @@ impl<'a, 'b> SlmGetLifecycle<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -568,7 +569,7 @@ impl SlmGetStatsParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Get Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-get-stats.html)\n\nReturns global and policy-level statistics about actions taken by snapshot lifecycle management."]
 pub struct SlmGetStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SlmGetStatsParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -579,10 +580,10 @@ pub struct SlmGetStats<'a, 'b> {
 }
 impl<'a, 'b> SlmGetStats<'a, 'b> {
     #[doc = "Creates a new instance of [SlmGetStats]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SlmGetStats {
-            client,
+            transport,
             parts: SlmGetStatsParts::None,
             headers,
             error_trace: None,
@@ -656,7 +657,7 @@ impl<'a, 'b> SlmGetStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -679,7 +680,7 @@ impl SlmGetStatusParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Get Status API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-get-status.html)\n\nRetrieves the status of snapshot lifecycle management (SLM)."]
 pub struct SlmGetStatus<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SlmGetStatusParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -690,10 +691,10 @@ pub struct SlmGetStatus<'a, 'b> {
 }
 impl<'a, 'b> SlmGetStatus<'a, 'b> {
     #[doc = "Creates a new instance of [SlmGetStatus]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SlmGetStatus {
-            client,
+            transport,
             parts: SlmGetStatusParts::None,
             headers,
             error_trace: None,
@@ -767,7 +768,7 @@ impl<'a, 'b> SlmGetStatus<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -797,7 +798,7 @@ impl<'b> SlmPutLifecycleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Put Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-put-policy.html)\n\nCreates or updates a snapshot lifecycle policy."]
 pub struct SlmPutLifecycle<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SlmPutLifecycleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -812,10 +813,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SlmPutLifecycle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SlmPutLifecycleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SlmPutLifecycleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SlmPutLifecycle {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -832,7 +833,7 @@ where
         T: Serialize,
     {
         SlmPutLifecycle {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -907,7 +908,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -930,7 +931,7 @@ impl SlmStartParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Start API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-start.html)\n\nTurns on snapshot lifecycle management (SLM)."]
 pub struct SlmStart<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SlmStartParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -945,10 +946,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SlmStart]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SlmStart {
-            client,
+            transport,
             parts: SlmStartParts::None,
             headers,
             body: None,
@@ -965,7 +966,7 @@ where
         T: Serialize,
     {
         SlmStart {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1040,7 +1041,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1063,7 +1064,7 @@ impl SlmStopParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Slm Stop API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-stop.html)\n\nTurns off snapshot lifecycle management (SLM)."]
 pub struct SlmStop<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SlmStopParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1078,10 +1079,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SlmStop]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SlmStop {
-            client,
+            transport,
             parts: SlmStopParts::None,
             headers,
             body: None,
@@ -1098,7 +1099,7 @@ where
         T: Serialize,
     {
         SlmStop {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1173,7 +1174,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1181,62 +1182,65 @@ where
 }
 #[doc = "Namespace client for Snapshot Lifecycle Management APIs"]
 pub struct Slm<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Slm<'a> {
     #[doc = "Creates a new instance of [Slm]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Slm Delete Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-delete-policy.html)\n\nDeletes an existing snapshot lifecycle policy."]
     pub fn delete_lifecycle<'b>(
         &'a self,
         parts: SlmDeleteLifecycleParts<'b>,
     ) -> SlmDeleteLifecycle<'a, 'b> {
-        SlmDeleteLifecycle::new(&self.client, parts)
+        SlmDeleteLifecycle::new(self.transport(), parts)
     }
     #[doc = "[Slm Execute Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-execute-lifecycle.html)\n\nImmediately creates a snapshot according to the lifecycle policy, without waiting for the scheduled time."]
     pub fn execute_lifecycle<'b>(
         &'a self,
         parts: SlmExecuteLifecycleParts<'b>,
     ) -> SlmExecuteLifecycle<'a, 'b, ()> {
-        SlmExecuteLifecycle::new(&self.client, parts)
+        SlmExecuteLifecycle::new(self.transport(), parts)
     }
     #[doc = "[Slm Execute Retention API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-execute-retention.html)\n\nDeletes any snapshots that are expired according to the policy's retention rules."]
     pub fn execute_retention<'b>(&'a self) -> SlmExecuteRetention<'a, 'b, ()> {
-        SlmExecuteRetention::new(&self.client)
+        SlmExecuteRetention::new(self.transport())
     }
     #[doc = "[Slm Get Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-get-policy.html)\n\nRetrieves one or more snapshot lifecycle policy definitions and information about the latest snapshot attempts."]
     pub fn get_lifecycle<'b>(&'a self, parts: SlmGetLifecycleParts<'b>) -> SlmGetLifecycle<'a, 'b> {
-        SlmGetLifecycle::new(&self.client, parts)
+        SlmGetLifecycle::new(self.transport(), parts)
     }
     #[doc = "[Slm Get Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-get-stats.html)\n\nReturns global and policy-level statistics about actions taken by snapshot lifecycle management."]
     pub fn get_stats<'b>(&'a self) -> SlmGetStats<'a, 'b> {
-        SlmGetStats::new(&self.client)
+        SlmGetStats::new(self.transport())
     }
     #[doc = "[Slm Get Status API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-get-status.html)\n\nRetrieves the status of snapshot lifecycle management (SLM)."]
     pub fn get_status<'b>(&'a self) -> SlmGetStatus<'a, 'b> {
-        SlmGetStatus::new(&self.client)
+        SlmGetStatus::new(self.transport())
     }
     #[doc = "[Slm Put Lifecycle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-put-policy.html)\n\nCreates or updates a snapshot lifecycle policy."]
     pub fn put_lifecycle<'b>(
         &'a self,
         parts: SlmPutLifecycleParts<'b>,
     ) -> SlmPutLifecycle<'a, 'b, ()> {
-        SlmPutLifecycle::new(&self.client, parts)
+        SlmPutLifecycle::new(self.transport(), parts)
     }
     #[doc = "[Slm Start API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-start.html)\n\nTurns on snapshot lifecycle management (SLM)."]
     pub fn start<'b>(&'a self) -> SlmStart<'a, 'b, ()> {
-        SlmStart::new(&self.client)
+        SlmStart::new(self.transport())
     }
     #[doc = "[Slm Stop API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/slm-api-stop.html)\n\nTurns off snapshot lifecycle management (SLM)."]
     pub fn stop<'b>(&'a self) -> SlmStop<'a, 'b, ()> {
-        SlmStop::new(&self.client)
+        SlmStop::new(self.transport())
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Snapshot Lifecycle Management APIs"]
     pub fn slm(&self) -> Slm {
-        Slm::new(&self)
+        Slm::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/snapshot.rs
+++ b/elasticsearch/src/generated/namespace_clients/snapshot.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -62,7 +63,7 @@ impl<'b> SnapshotCleanupRepositoryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Cleanup Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/clean-up-snapshot-repo-api.html)\n\nRemoves stale data from repository."]
 pub struct SnapshotCleanupRepository<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SnapshotCleanupRepositoryParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -79,10 +80,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SnapshotCleanupRepository] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SnapshotCleanupRepositoryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SnapshotCleanupRepositoryParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SnapshotCleanupRepository {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -101,7 +102,7 @@ where
         T: Serialize,
     {
         SnapshotCleanupRepository {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -194,7 +195,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -230,7 +231,7 @@ impl<'b> SnapshotCreateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Create API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nCreates a snapshot in a repository."]
 pub struct SnapshotCreate<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SnapshotCreateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -247,10 +248,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SnapshotCreate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SnapshotCreateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SnapshotCreateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SnapshotCreate {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -269,7 +270,7 @@ where
         T: Serialize,
     {
         SnapshotCreate {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -362,7 +363,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -392,7 +393,7 @@ impl<'b> SnapshotCreateRepositoryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Create Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nCreates a repository."]
 pub struct SnapshotCreateRepository<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SnapshotCreateRepositoryParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -410,10 +411,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SnapshotCreateRepository] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SnapshotCreateRepositoryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SnapshotCreateRepositoryParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SnapshotCreateRepository {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -433,7 +434,7 @@ where
         T: Serialize,
     {
         SnapshotCreateRepository {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -535,7 +536,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -572,7 +573,7 @@ impl<'b> SnapshotDeleteParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nDeletes one or more snapshots."]
 pub struct SnapshotDelete<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SnapshotDeleteParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -584,10 +585,10 @@ pub struct SnapshotDelete<'a, 'b> {
 }
 impl<'a, 'b> SnapshotDelete<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotDelete] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SnapshotDeleteParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SnapshotDeleteParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SnapshotDelete {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -670,7 +671,7 @@ impl<'a, 'b> SnapshotDelete<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -701,7 +702,7 @@ impl<'b> SnapshotDeleteRepositoryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Delete Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nDeletes a repository."]
 pub struct SnapshotDeleteRepository<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SnapshotDeleteRepositoryParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -714,10 +715,10 @@ pub struct SnapshotDeleteRepository<'a, 'b> {
 }
 impl<'a, 'b> SnapshotDeleteRepository<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotDeleteRepository] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SnapshotDeleteRepositoryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SnapshotDeleteRepositoryParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SnapshotDeleteRepository {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -809,7 +810,7 @@ impl<'a, 'b> SnapshotDeleteRepository<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -846,7 +847,7 @@ impl<'b> SnapshotGetParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nReturns information about a snapshot."]
 pub struct SnapshotGet<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SnapshotGetParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -860,10 +861,10 @@ pub struct SnapshotGet<'a, 'b> {
 }
 impl<'a, 'b> SnapshotGet<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotGet] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SnapshotGetParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SnapshotGetParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SnapshotGet {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -964,7 +965,7 @@ impl<'a, 'b> SnapshotGet<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -998,7 +999,7 @@ impl<'b> SnapshotGetRepositoryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Get Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nReturns information about a repository."]
 pub struct SnapshotGetRepository<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SnapshotGetRepositoryParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1011,10 +1012,10 @@ pub struct SnapshotGetRepository<'a, 'b> {
 }
 impl<'a, 'b> SnapshotGetRepository<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotGetRepository] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SnapshotGetRepositoryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SnapshotGetRepositoryParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SnapshotGetRepository {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1106,7 +1107,7 @@ impl<'a, 'b> SnapshotGetRepository<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1143,7 +1144,7 @@ impl<'b> SnapshotRestoreParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Restore API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nRestores a snapshot."]
 pub struct SnapshotRestore<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SnapshotRestoreParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1160,10 +1161,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SnapshotRestore] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SnapshotRestoreParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SnapshotRestoreParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SnapshotRestore {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1182,7 +1183,7 @@ where
         T: Serialize,
     {
         SnapshotRestore {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1275,7 +1276,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1327,7 +1328,7 @@ impl<'b> SnapshotStatusParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Status API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nReturns information about the status of a snapshot."]
 pub struct SnapshotStatus<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SnapshotStatusParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1340,10 +1341,10 @@ pub struct SnapshotStatus<'a, 'b> {
 }
 impl<'a, 'b> SnapshotStatus<'a, 'b> {
     #[doc = "Creates a new instance of [SnapshotStatus] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SnapshotStatusParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SnapshotStatusParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SnapshotStatus {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1435,7 +1436,7 @@ impl<'a, 'b> SnapshotStatus<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1466,7 +1467,7 @@ impl<'b> SnapshotVerifyRepositoryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Snapshot Verify Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nVerifies a repository."]
 pub struct SnapshotVerifyRepository<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SnapshotVerifyRepositoryParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1483,10 +1484,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SnapshotVerifyRepository] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SnapshotVerifyRepositoryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SnapshotVerifyRepositoryParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SnapshotVerifyRepository {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1505,7 +1506,7 @@ where
         T: Serialize,
     {
         SnapshotVerifyRepository {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1598,7 +1599,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1606,72 +1607,75 @@ where
 }
 #[doc = "Namespace client for Snapshot APIs"]
 pub struct Snapshot<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Snapshot<'a> {
     #[doc = "Creates a new instance of [Snapshot]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Snapshot Cleanup Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/clean-up-snapshot-repo-api.html)\n\nRemoves stale data from repository."]
     pub fn cleanup_repository<'b>(
         &'a self,
         parts: SnapshotCleanupRepositoryParts<'b>,
     ) -> SnapshotCleanupRepository<'a, 'b, ()> {
-        SnapshotCleanupRepository::new(&self.client, parts)
+        SnapshotCleanupRepository::new(self.transport(), parts)
     }
     #[doc = "[Snapshot Create API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nCreates a snapshot in a repository."]
     pub fn create<'b>(&'a self, parts: SnapshotCreateParts<'b>) -> SnapshotCreate<'a, 'b, ()> {
-        SnapshotCreate::new(&self.client, parts)
+        SnapshotCreate::new(self.transport(), parts)
     }
     #[doc = "[Snapshot Create Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nCreates a repository."]
     pub fn create_repository<'b>(
         &'a self,
         parts: SnapshotCreateRepositoryParts<'b>,
     ) -> SnapshotCreateRepository<'a, 'b, ()> {
-        SnapshotCreateRepository::new(&self.client, parts)
+        SnapshotCreateRepository::new(self.transport(), parts)
     }
     #[doc = "[Snapshot Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nDeletes one or more snapshots."]
     pub fn delete<'b>(&'a self, parts: SnapshotDeleteParts<'b>) -> SnapshotDelete<'a, 'b> {
-        SnapshotDelete::new(&self.client, parts)
+        SnapshotDelete::new(self.transport(), parts)
     }
     #[doc = "[Snapshot Delete Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nDeletes a repository."]
     pub fn delete_repository<'b>(
         &'a self,
         parts: SnapshotDeleteRepositoryParts<'b>,
     ) -> SnapshotDeleteRepository<'a, 'b> {
-        SnapshotDeleteRepository::new(&self.client, parts)
+        SnapshotDeleteRepository::new(self.transport(), parts)
     }
     #[doc = "[Snapshot Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nReturns information about a snapshot."]
     pub fn get<'b>(&'a self, parts: SnapshotGetParts<'b>) -> SnapshotGet<'a, 'b> {
-        SnapshotGet::new(&self.client, parts)
+        SnapshotGet::new(self.transport(), parts)
     }
     #[doc = "[Snapshot Get Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nReturns information about a repository."]
     pub fn get_repository<'b>(
         &'a self,
         parts: SnapshotGetRepositoryParts<'b>,
     ) -> SnapshotGetRepository<'a, 'b> {
-        SnapshotGetRepository::new(&self.client, parts)
+        SnapshotGetRepository::new(self.transport(), parts)
     }
     #[doc = "[Snapshot Restore API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nRestores a snapshot."]
     pub fn restore<'b>(&'a self, parts: SnapshotRestoreParts<'b>) -> SnapshotRestore<'a, 'b, ()> {
-        SnapshotRestore::new(&self.client, parts)
+        SnapshotRestore::new(self.transport(), parts)
     }
     #[doc = "[Snapshot Status API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nReturns information about the status of a snapshot."]
     pub fn status<'b>(&'a self, parts: SnapshotStatusParts<'b>) -> SnapshotStatus<'a, 'b> {
-        SnapshotStatus::new(&self.client, parts)
+        SnapshotStatus::new(self.transport(), parts)
     }
     #[doc = "[Snapshot Verify Repository API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-snapshots.html)\n\nVerifies a repository."]
     pub fn verify_repository<'b>(
         &'a self,
         parts: SnapshotVerifyRepositoryParts<'b>,
     ) -> SnapshotVerifyRepository<'a, 'b, ()> {
-        SnapshotVerifyRepository::new(&self.client, parts)
+        SnapshotVerifyRepository::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Snapshot APIs"]
     pub fn snapshot(&self) -> Snapshot {
-        Snapshot::new(&self)
+        Snapshot::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/ssl.rs
+++ b/elasticsearch/src/generated/namespace_clients/ssl.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -54,7 +55,7 @@ impl SslCertificatesParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ssl Certificates API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-ssl.html)\n\nRetrieves information about the X.509 certificates used to encrypt communications in the cluster."]
 pub struct SslCertificates<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SslCertificatesParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -65,10 +66,10 @@ pub struct SslCertificates<'a, 'b> {
 }
 impl<'a, 'b> SslCertificates<'a, 'b> {
     #[doc = "Creates a new instance of [SslCertificates]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         SslCertificates {
-            client,
+            transport,
             parts: SslCertificatesParts::None,
             headers,
             error_trace: None,
@@ -142,7 +143,7 @@ impl<'a, 'b> SslCertificates<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -150,21 +151,24 @@ impl<'a, 'b> SslCertificates<'a, 'b> {
 }
 #[doc = "Namespace client for Ssl APIs"]
 pub struct Ssl<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Ssl<'a> {
     #[doc = "Creates a new instance of [Ssl]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Ssl Certificates API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/security-api-ssl.html)\n\nRetrieves information about the X.509 certificates used to encrypt communications in the cluster."]
     pub fn certificates<'b>(&'a self) -> SslCertificates<'a, 'b> {
-        SslCertificates::new(&self.client)
+        SslCertificates::new(self.transport())
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Ssl APIs"]
     pub fn ssl(&self) -> Ssl {
-        Ssl::new(&self)
+        Ssl::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/tasks.rs
+++ b/elasticsearch/src/generated/namespace_clients/tasks.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -65,7 +66,7 @@ impl<'b> TasksCancelParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Tasks Cancel API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html)\n\nCancels a task, if it can be cancelled through an API."]
 pub struct TasksCancel<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TasksCancelParts<'b>,
     actions: Option<&'b [&'b str]>,
     body: Option<B>,
@@ -84,10 +85,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [TasksCancel] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: TasksCancelParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: TasksCancelParts<'b>) -> Self {
         let headers = HeaderMap::new();
         TasksCancel {
-            client,
+            transport,
             parts,
             headers,
             actions: None,
@@ -113,7 +114,7 @@ where
         T: Serialize,
     {
         TasksCancel {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             actions: self.actions,
@@ -222,7 +223,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -252,7 +253,7 @@ impl<'b> TasksGetParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Tasks Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html)\n\nReturns information about a task."]
 pub struct TasksGet<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TasksGetParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -265,10 +266,10 @@ pub struct TasksGet<'a, 'b> {
 }
 impl<'a, 'b> TasksGet<'a, 'b> {
     #[doc = "Creates a new instance of [TasksGet] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: TasksGetParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: TasksGetParts<'b>) -> Self {
         let headers = HeaderMap::new();
         TasksGet {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -360,7 +361,7 @@ impl<'a, 'b> TasksGet<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -383,7 +384,7 @@ impl TasksListParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Tasks List API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html)\n\nReturns a list of tasks."]
 pub struct TasksList<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TasksListParts,
     actions: Option<&'b [&'b str]>,
     detailed: Option<bool>,
@@ -401,10 +402,10 @@ pub struct TasksList<'a, 'b> {
 }
 impl<'a, 'b> TasksList<'a, 'b> {
     #[doc = "Creates a new instance of [TasksList]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         TasksList {
-            client,
+            transport,
             parts: TasksListParts::None,
             headers,
             actions: None,
@@ -544,7 +545,7 @@ impl<'a, 'b> TasksList<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -552,29 +553,32 @@ impl<'a, 'b> TasksList<'a, 'b> {
 }
 #[doc = "Namespace client for Tasks APIs"]
 pub struct Tasks<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Tasks<'a> {
     #[doc = "Creates a new instance of [Tasks]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Tasks Cancel API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html)\n\nCancels a task, if it can be cancelled through an API."]
     pub fn cancel<'b>(&'a self, parts: TasksCancelParts<'b>) -> TasksCancel<'a, 'b, ()> {
-        TasksCancel::new(&self.client, parts)
+        TasksCancel::new(self.transport(), parts)
     }
     #[doc = "[Tasks Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html)\n\nReturns information about a task."]
     pub fn get<'b>(&'a self, parts: TasksGetParts<'b>) -> TasksGet<'a, 'b> {
-        TasksGet::new(&self.client, parts)
+        TasksGet::new(self.transport(), parts)
     }
     #[doc = "[Tasks List API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/tasks.html)\n\nReturns a list of tasks."]
     pub fn list<'b>(&'a self) -> TasksList<'a, 'b> {
-        TasksList::new(&self.client)
+        TasksList::new(self.transport())
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Tasks APIs"]
     pub fn tasks(&self) -> Tasks {
-        Tasks::new(&self)
+        Tasks::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/transform.rs
+++ b/elasticsearch/src/generated/namespace_clients/transform.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -61,7 +62,7 @@ impl<'b> TransformDeleteTransformParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Transform Delete Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-transform.html)\n\nDeletes an existing transform."]
 pub struct TransformDeleteTransform<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TransformDeleteTransformParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -73,10 +74,10 @@ pub struct TransformDeleteTransform<'a, 'b> {
 }
 impl<'a, 'b> TransformDeleteTransform<'a, 'b> {
     #[doc = "Creates a new instance of [TransformDeleteTransform] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: TransformDeleteTransformParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: TransformDeleteTransformParts<'b>) -> Self {
         let headers = HeaderMap::new();
         TransformDeleteTransform {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -159,7 +160,7 @@ impl<'a, 'b> TransformDeleteTransform<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -192,7 +193,7 @@ impl<'b> TransformGetTransformParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Transform Get Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-transform.html)\n\nRetrieves configuration information for transforms."]
 pub struct TransformGetTransform<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TransformGetTransformParts<'b>,
     allow_no_match: Option<bool>,
     error_trace: Option<bool>,
@@ -206,10 +207,10 @@ pub struct TransformGetTransform<'a, 'b> {
 }
 impl<'a, 'b> TransformGetTransform<'a, 'b> {
     #[doc = "Creates a new instance of [TransformGetTransform] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: TransformGetTransformParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: TransformGetTransformParts<'b>) -> Self {
         let headers = HeaderMap::new();
         TransformGetTransform {
-            client,
+            transport,
             parts,
             headers,
             allow_no_match: None,
@@ -310,7 +311,7 @@ impl<'a, 'b> TransformGetTransform<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -341,7 +342,7 @@ impl<'b> TransformGetTransformStatsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Transform Get Transform Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-transform-stats.html)\n\nRetrieves usage information for transforms."]
 pub struct TransformGetTransformStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TransformGetTransformStatsParts<'b>,
     allow_no_match: Option<bool>,
     error_trace: Option<bool>,
@@ -355,10 +356,10 @@ pub struct TransformGetTransformStats<'a, 'b> {
 }
 impl<'a, 'b> TransformGetTransformStats<'a, 'b> {
     #[doc = "Creates a new instance of [TransformGetTransformStats] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: TransformGetTransformStatsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: TransformGetTransformStatsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         TransformGetTransformStats {
-            client,
+            transport,
             parts,
             headers,
             allow_no_match: None,
@@ -459,7 +460,7 @@ impl<'a, 'b> TransformGetTransformStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -482,7 +483,7 @@ impl TransformPreviewTransformParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Transform Preview Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/preview-transform.html)\n\nPreviews a transform."]
 pub struct TransformPreviewTransform<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TransformPreviewTransformParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -497,10 +498,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [TransformPreviewTransform]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         TransformPreviewTransform {
-            client,
+            transport,
             parts: TransformPreviewTransformParts::None,
             headers,
             body: None,
@@ -517,7 +518,7 @@ where
         T: Serialize,
     {
         TransformPreviewTransform {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -592,7 +593,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -622,7 +623,7 @@ impl<'b> TransformPutTransformParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Transform Put Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/put-transform.html)\n\nInstantiates a transform."]
 pub struct TransformPutTransform<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TransformPutTransformParts<'b>,
     body: Option<B>,
     defer_validation: Option<bool>,
@@ -638,10 +639,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [TransformPutTransform] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: TransformPutTransformParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: TransformPutTransformParts<'b>) -> Self {
         let headers = HeaderMap::new();
         TransformPutTransform {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -659,7 +660,7 @@ where
         T: Serialize,
     {
         TransformPutTransform {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             defer_validation: self.defer_validation,
@@ -743,7 +744,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -774,7 +775,7 @@ impl<'b> TransformStartTransformParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Transform Start Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/start-transform.html)\n\nStarts one or more transforms."]
 pub struct TransformStartTransform<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TransformStartTransformParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -790,10 +791,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [TransformStartTransform] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: TransformStartTransformParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: TransformStartTransformParts<'b>) -> Self {
         let headers = HeaderMap::new();
         TransformStartTransform {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -811,7 +812,7 @@ where
         T: Serialize,
     {
         TransformStartTransform {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -895,7 +896,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -926,7 +927,7 @@ impl<'b> TransformStopTransformParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Transform Stop Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/stop-transform.html)\n\nStops one or more transforms."]
 pub struct TransformStopTransform<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TransformStopTransformParts<'b>,
     allow_no_match: Option<bool>,
     body: Option<B>,
@@ -946,10 +947,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [TransformStopTransform] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: TransformStopTransformParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: TransformStopTransformParts<'b>) -> Self {
         let headers = HeaderMap::new();
         TransformStopTransform {
-            client,
+            transport,
             parts,
             headers,
             allow_no_match: None,
@@ -976,7 +977,7 @@ where
         T: Serialize,
     {
         TransformStopTransform {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_match: self.allow_no_match,
@@ -1091,7 +1092,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1122,7 +1123,7 @@ impl<'b> TransformUpdateTransformParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Transform Update Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/update-transform.html)\n\nUpdates certain properties of a transform."]
 pub struct TransformUpdateTransform<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TransformUpdateTransformParts<'b>,
     body: Option<B>,
     defer_validation: Option<bool>,
@@ -1138,10 +1139,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [TransformUpdateTransform] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: TransformUpdateTransformParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: TransformUpdateTransformParts<'b>) -> Self {
         let headers = HeaderMap::new();
         TransformUpdateTransform {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1159,7 +1160,7 @@ where
         T: Serialize,
     {
         TransformUpdateTransform {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             defer_validation: self.defer_validation,
@@ -1243,7 +1244,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1251,70 +1252,73 @@ where
 }
 #[doc = "Namespace client for Transform APIs"]
 pub struct Transform<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Transform<'a> {
     #[doc = "Creates a new instance of [Transform]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Transform Delete Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/delete-transform.html)\n\nDeletes an existing transform."]
     pub fn delete_transform<'b>(
         &'a self,
         parts: TransformDeleteTransformParts<'b>,
     ) -> TransformDeleteTransform<'a, 'b> {
-        TransformDeleteTransform::new(&self.client, parts)
+        TransformDeleteTransform::new(self.transport(), parts)
     }
     #[doc = "[Transform Get Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-transform.html)\n\nRetrieves configuration information for transforms."]
     pub fn get_transform<'b>(
         &'a self,
         parts: TransformGetTransformParts<'b>,
     ) -> TransformGetTransform<'a, 'b> {
-        TransformGetTransform::new(&self.client, parts)
+        TransformGetTransform::new(self.transport(), parts)
     }
     #[doc = "[Transform Get Transform Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/get-transform-stats.html)\n\nRetrieves usage information for transforms."]
     pub fn get_transform_stats<'b>(
         &'a self,
         parts: TransformGetTransformStatsParts<'b>,
     ) -> TransformGetTransformStats<'a, 'b> {
-        TransformGetTransformStats::new(&self.client, parts)
+        TransformGetTransformStats::new(self.transport(), parts)
     }
     #[doc = "[Transform Preview Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/preview-transform.html)\n\nPreviews a transform."]
     pub fn preview_transform<'b>(&'a self) -> TransformPreviewTransform<'a, 'b, ()> {
-        TransformPreviewTransform::new(&self.client)
+        TransformPreviewTransform::new(self.transport())
     }
     #[doc = "[Transform Put Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/put-transform.html)\n\nInstantiates a transform."]
     pub fn put_transform<'b>(
         &'a self,
         parts: TransformPutTransformParts<'b>,
     ) -> TransformPutTransform<'a, 'b, ()> {
-        TransformPutTransform::new(&self.client, parts)
+        TransformPutTransform::new(self.transport(), parts)
     }
     #[doc = "[Transform Start Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/start-transform.html)\n\nStarts one or more transforms."]
     pub fn start_transform<'b>(
         &'a self,
         parts: TransformStartTransformParts<'b>,
     ) -> TransformStartTransform<'a, 'b, ()> {
-        TransformStartTransform::new(&self.client, parts)
+        TransformStartTransform::new(self.transport(), parts)
     }
     #[doc = "[Transform Stop Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/stop-transform.html)\n\nStops one or more transforms."]
     pub fn stop_transform<'b>(
         &'a self,
         parts: TransformStopTransformParts<'b>,
     ) -> TransformStopTransform<'a, 'b, ()> {
-        TransformStopTransform::new(&self.client, parts)
+        TransformStopTransform::new(self.transport(), parts)
     }
     #[doc = "[Transform Update Transform API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/update-transform.html)\n\nUpdates certain properties of a transform."]
     pub fn update_transform<'b>(
         &'a self,
         parts: TransformUpdateTransformParts<'b>,
     ) -> TransformUpdateTransform<'a, 'b, ()> {
-        TransformUpdateTransform::new(&self.client, parts)
+        TransformUpdateTransform::new(self.transport(), parts)
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Transform APIs"]
     pub fn transform(&self) -> Transform {
-        Transform::new(&self)
+        Transform::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/watcher.rs
+++ b/elasticsearch/src/generated/namespace_clients/watcher.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -79,7 +80,7 @@ impl<'b> WatcherAckWatchParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Ack Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-ack-watch.html)\n\nAcknowledges a watch, manually throttling the execution of the watch's actions."]
 pub struct WatcherAckWatch<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: WatcherAckWatchParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -94,10 +95,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherAckWatch] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: WatcherAckWatchParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: WatcherAckWatchParts<'b>) -> Self {
         let headers = HeaderMap::new();
         WatcherAckWatch {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -114,7 +115,7 @@ where
         T: Serialize,
     {
         WatcherAckWatch {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -189,7 +190,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -220,7 +221,7 @@ impl<'b> WatcherActivateWatchParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Activate Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-activate-watch.html)\n\nActivates a currently inactive watch."]
 pub struct WatcherActivateWatch<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: WatcherActivateWatchParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -235,10 +236,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherActivateWatch] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: WatcherActivateWatchParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: WatcherActivateWatchParts<'b>) -> Self {
         let headers = HeaderMap::new();
         WatcherActivateWatch {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -255,7 +256,7 @@ where
         T: Serialize,
     {
         WatcherActivateWatch {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -330,7 +331,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -361,7 +362,7 @@ impl<'b> WatcherDeactivateWatchParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Deactivate Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-deactivate-watch.html)\n\nDeactivates a currently active watch."]
 pub struct WatcherDeactivateWatch<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: WatcherDeactivateWatchParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -376,10 +377,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherDeactivateWatch] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: WatcherDeactivateWatchParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: WatcherDeactivateWatchParts<'b>) -> Self {
         let headers = HeaderMap::new();
         WatcherDeactivateWatch {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -396,7 +397,7 @@ where
         T: Serialize,
     {
         WatcherDeactivateWatch {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -471,7 +472,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -500,7 +501,7 @@ impl<'b> WatcherDeleteWatchParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Delete Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-delete-watch.html)\n\nRemoves a watch from Watcher."]
 pub struct WatcherDeleteWatch<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: WatcherDeleteWatchParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -511,10 +512,10 @@ pub struct WatcherDeleteWatch<'a, 'b> {
 }
 impl<'a, 'b> WatcherDeleteWatch<'a, 'b> {
     #[doc = "Creates a new instance of [WatcherDeleteWatch] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: WatcherDeleteWatchParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: WatcherDeleteWatchParts<'b>) -> Self {
         let headers = HeaderMap::new();
         WatcherDeleteWatch {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -588,7 +589,7 @@ impl<'a, 'b> WatcherDeleteWatch<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -621,7 +622,7 @@ impl<'b> WatcherExecuteWatchParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Execute Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-execute-watch.html)\n\nForces the execution of a stored watch."]
 pub struct WatcherExecuteWatch<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: WatcherExecuteWatchParts<'b>,
     body: Option<B>,
     debug: Option<bool>,
@@ -637,10 +638,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherExecuteWatch] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: WatcherExecuteWatchParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: WatcherExecuteWatchParts<'b>) -> Self {
         let headers = HeaderMap::new();
         WatcherExecuteWatch {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -658,7 +659,7 @@ where
         T: Serialize,
     {
         WatcherExecuteWatch {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             debug: self.debug,
@@ -742,7 +743,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -771,7 +772,7 @@ impl<'b> WatcherGetWatchParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Get Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-get-watch.html)\n\nRetrieves a watch by its ID."]
 pub struct WatcherGetWatch<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: WatcherGetWatchParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -782,10 +783,10 @@ pub struct WatcherGetWatch<'a, 'b> {
 }
 impl<'a, 'b> WatcherGetWatch<'a, 'b> {
     #[doc = "Creates a new instance of [WatcherGetWatch] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: WatcherGetWatchParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: WatcherGetWatchParts<'b>) -> Self {
         let headers = HeaderMap::new();
         WatcherGetWatch {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -859,7 +860,7 @@ impl<'a, 'b> WatcherGetWatch<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -888,7 +889,7 @@ impl<'b> WatcherPutWatchParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Put Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-put-watch.html)\n\nCreates a new watch, or updates an existing one."]
 pub struct WatcherPutWatch<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: WatcherPutWatchParts<'b>,
     active: Option<bool>,
     body: Option<B>,
@@ -907,10 +908,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherPutWatch] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: WatcherPutWatchParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: WatcherPutWatchParts<'b>) -> Self {
         let headers = HeaderMap::new();
         WatcherPutWatch {
-            client,
+            transport,
             parts,
             headers,
             active: None,
@@ -936,7 +937,7 @@ where
         T: Serialize,
     {
         WatcherPutWatch {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             active: self.active,
@@ -1042,7 +1043,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1065,7 +1066,7 @@ impl WatcherStartParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Start API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-start.html)\n\nStarts Watcher if it is not already running."]
 pub struct WatcherStart<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: WatcherStartParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1080,10 +1081,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherStart]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         WatcherStart {
-            client,
+            transport,
             parts: WatcherStartParts::None,
             headers,
             body: None,
@@ -1100,7 +1101,7 @@ where
         T: Serialize,
     {
         WatcherStart {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1175,7 +1176,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1209,7 +1210,7 @@ impl<'b> WatcherStatsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-stats.html)\n\nRetrieves the current Watcher metrics."]
 pub struct WatcherStats<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: WatcherStatsParts<'b>,
     emit_stacktraces: Option<bool>,
     error_trace: Option<bool>,
@@ -1222,10 +1223,10 @@ pub struct WatcherStats<'a, 'b> {
 }
 impl<'a, 'b> WatcherStats<'a, 'b> {
     #[doc = "Creates a new instance of [WatcherStats] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: WatcherStatsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: WatcherStatsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         WatcherStats {
-            client,
+            transport,
             parts,
             headers,
             emit_stacktraces: None,
@@ -1317,7 +1318,7 @@ impl<'a, 'b> WatcherStats<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1340,7 +1341,7 @@ impl WatcherStopParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Watcher Stop API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-stop.html)\n\nStops Watcher if it is running."]
 pub struct WatcherStop<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: WatcherStopParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1355,10 +1356,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [WatcherStop]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         WatcherStop {
-            client,
+            transport,
             parts: WatcherStopParts::None,
             headers,
             body: None,
@@ -1375,7 +1376,7 @@ where
         T: Serialize,
     {
         WatcherStop {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1450,7 +1451,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1458,69 +1459,72 @@ where
 }
 #[doc = "Namespace client for Watcher APIs"]
 pub struct Watcher<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Watcher<'a> {
     #[doc = "Creates a new instance of [Watcher]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Watcher Ack Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-ack-watch.html)\n\nAcknowledges a watch, manually throttling the execution of the watch's actions."]
     pub fn ack_watch<'b>(&'a self, parts: WatcherAckWatchParts<'b>) -> WatcherAckWatch<'a, 'b, ()> {
-        WatcherAckWatch::new(&self.client, parts)
+        WatcherAckWatch::new(self.transport(), parts)
     }
     #[doc = "[Watcher Activate Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-activate-watch.html)\n\nActivates a currently inactive watch."]
     pub fn activate_watch<'b>(
         &'a self,
         parts: WatcherActivateWatchParts<'b>,
     ) -> WatcherActivateWatch<'a, 'b, ()> {
-        WatcherActivateWatch::new(&self.client, parts)
+        WatcherActivateWatch::new(self.transport(), parts)
     }
     #[doc = "[Watcher Deactivate Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-deactivate-watch.html)\n\nDeactivates a currently active watch."]
     pub fn deactivate_watch<'b>(
         &'a self,
         parts: WatcherDeactivateWatchParts<'b>,
     ) -> WatcherDeactivateWatch<'a, 'b, ()> {
-        WatcherDeactivateWatch::new(&self.client, parts)
+        WatcherDeactivateWatch::new(self.transport(), parts)
     }
     #[doc = "[Watcher Delete Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-delete-watch.html)\n\nRemoves a watch from Watcher."]
     pub fn delete_watch<'b>(
         &'a self,
         parts: WatcherDeleteWatchParts<'b>,
     ) -> WatcherDeleteWatch<'a, 'b> {
-        WatcherDeleteWatch::new(&self.client, parts)
+        WatcherDeleteWatch::new(self.transport(), parts)
     }
     #[doc = "[Watcher Execute Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-execute-watch.html)\n\nForces the execution of a stored watch."]
     pub fn execute_watch<'b>(
         &'a self,
         parts: WatcherExecuteWatchParts<'b>,
     ) -> WatcherExecuteWatch<'a, 'b, ()> {
-        WatcherExecuteWatch::new(&self.client, parts)
+        WatcherExecuteWatch::new(self.transport(), parts)
     }
     #[doc = "[Watcher Get Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-get-watch.html)\n\nRetrieves a watch by its ID."]
     pub fn get_watch<'b>(&'a self, parts: WatcherGetWatchParts<'b>) -> WatcherGetWatch<'a, 'b> {
-        WatcherGetWatch::new(&self.client, parts)
+        WatcherGetWatch::new(self.transport(), parts)
     }
     #[doc = "[Watcher Put Watch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-put-watch.html)\n\nCreates a new watch, or updates an existing one."]
     pub fn put_watch<'b>(&'a self, parts: WatcherPutWatchParts<'b>) -> WatcherPutWatch<'a, 'b, ()> {
-        WatcherPutWatch::new(&self.client, parts)
+        WatcherPutWatch::new(self.transport(), parts)
     }
     #[doc = "[Watcher Start API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-start.html)\n\nStarts Watcher if it is not already running."]
     pub fn start<'b>(&'a self) -> WatcherStart<'a, 'b, ()> {
-        WatcherStart::new(&self.client)
+        WatcherStart::new(self.transport())
     }
     #[doc = "[Watcher Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-stats.html)\n\nRetrieves the current Watcher metrics."]
     pub fn stats<'b>(&'a self, parts: WatcherStatsParts<'b>) -> WatcherStats<'a, 'b> {
-        WatcherStats::new(&self.client, parts)
+        WatcherStats::new(self.transport(), parts)
     }
     #[doc = "[Watcher Stop API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/watcher-api-stop.html)\n\nStops Watcher if it is running."]
     pub fn stop<'b>(&'a self) -> WatcherStop<'a, 'b, ()> {
-        WatcherStop::new(&self.client)
+        WatcherStop::new(self.transport())
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for Watcher APIs"]
     pub fn watcher(&self) -> Watcher {
-        Watcher::new(&self)
+        Watcher::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/namespace_clients/xpack.rs
+++ b/elasticsearch/src/generated/namespace_clients/xpack.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -54,7 +55,7 @@ impl XpackInfoParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Xpack Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/info-api.html)\n\nRetrieves information about the installed X-Pack features."]
 pub struct XpackInfo<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: XpackInfoParts,
     categories: Option<&'b [&'b str]>,
     error_trace: Option<bool>,
@@ -66,10 +67,10 @@ pub struct XpackInfo<'a, 'b> {
 }
 impl<'a, 'b> XpackInfo<'a, 'b> {
     #[doc = "Creates a new instance of [XpackInfo]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         XpackInfo {
-            client,
+            transport,
             parts: XpackInfoParts::None,
             headers,
             categories: None,
@@ -155,7 +156,7 @@ impl<'a, 'b> XpackInfo<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -178,7 +179,7 @@ impl XpackUsageParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Xpack Usage API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/usage-api.html)\n\nRetrieves usage information about the installed X-Pack features."]
 pub struct XpackUsage<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: XpackUsageParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -190,10 +191,10 @@ pub struct XpackUsage<'a, 'b> {
 }
 impl<'a, 'b> XpackUsage<'a, 'b> {
     #[doc = "Creates a new instance of [XpackUsage]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         XpackUsage {
-            client,
+            transport,
             parts: XpackUsageParts::None,
             headers,
             error_trace: None,
@@ -276,7 +277,7 @@ impl<'a, 'b> XpackUsage<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -284,25 +285,28 @@ impl<'a, 'b> XpackUsage<'a, 'b> {
 }
 #[doc = "Namespace client for X-Pack APIs"]
 pub struct Xpack<'a> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
 }
 impl<'a> Xpack<'a> {
     #[doc = "Creates a new instance of [Xpack]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
-        Self { client }
+    pub fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+    pub fn transport(&self) -> &Transport {
+        self.transport
     }
     #[doc = "[Xpack Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/info-api.html)\n\nRetrieves information about the installed X-Pack features."]
     pub fn info<'b>(&'a self) -> XpackInfo<'a, 'b> {
-        XpackInfo::new(&self.client)
+        XpackInfo::new(self.transport())
     }
     #[doc = "[Xpack Usage API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/usage-api.html)\n\nRetrieves usage information about the installed X-Pack features."]
     pub fn usage<'b>(&'a self) -> XpackUsage<'a, 'b> {
-        XpackUsage::new(&self.client)
+        XpackUsage::new(self.transport())
     }
 }
 impl Elasticsearch {
     #[doc = "Creates a namespace client for X-Pack APIs"]
     pub fn xpack(&self) -> Xpack {
-        Xpack::new(&self)
+        Xpack::new(self.transport())
     }
 }

--- a/elasticsearch/src/generated/root.rs
+++ b/elasticsearch/src/generated/root.rs
@@ -30,6 +30,7 @@ use crate::{
         headers::{HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE},
         request::{Body, JsonBody, NdBody, PARTS_ENCODED},
         response::Response,
+        transport::Transport,
         Method,
     },
     params::*,
@@ -79,7 +80,7 @@ impl<'b> BulkParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-bulk.html)\n\nAllows to perform multiple index/update/delete operations in a single request."]
 pub struct Bulk<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: BulkParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -103,10 +104,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Bulk] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: BulkParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: BulkParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Bulk {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -147,7 +148,7 @@ where
         T: Body,
     {
         Bulk {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(NdBody(body)),
             _source: self._source,
@@ -297,7 +298,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -331,7 +332,7 @@ impl<'b> ClearScrollParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Clear Scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-request-body.html#_clear_scroll_api)\n\nExplicitly clears the search context for a scroll."]
 pub struct ClearScroll<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ClearScrollParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -346,10 +347,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [ClearScroll] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ClearScrollParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: ClearScrollParts<'b>) -> Self {
         let headers = HeaderMap::new();
         ClearScroll {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -366,7 +367,7 @@ where
         T: Serialize,
     {
         ClearScroll {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -441,7 +442,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -476,7 +477,7 @@ impl<'b> CountParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Count API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-count.html)\n\nReturns number of documents matching a query."]
 pub struct Count<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CountParts<'b>,
     allow_no_indices: Option<bool>,
     analyze_wildcard: Option<bool>,
@@ -505,10 +506,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Count] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CountParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CountParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Count {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -554,7 +555,7 @@ where
         T: Serialize,
     {
         Count {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -749,7 +750,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -801,7 +802,7 @@ impl<'b> CreateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Create API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-index_.html)\n\nCreates a new document in the index.\n\nReturns a 409 response when a document with a same ID already exists in the index."]
 pub struct Create<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: CreateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -823,10 +824,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Create] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: CreateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: CreateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Create {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -850,7 +851,7 @@ where
         T: Serialize,
     {
         Create {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -988,7 +989,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1039,7 +1040,7 @@ impl<'b> DeleteParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-delete.html)\n\nRemoves a document from the index."]
 pub struct Delete<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: DeleteParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1058,10 +1059,10 @@ pub struct Delete<'a, 'b> {
 }
 impl<'a, 'b> Delete<'a, 'b> {
     #[doc = "Creates a new instance of [Delete] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: DeleteParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: DeleteParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Delete {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -1207,7 +1208,7 @@ impl<'a, 'b> Delete<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1239,7 +1240,7 @@ impl<'b> DeleteByQueryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Delete By Query API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-delete-by-query.html)\n\nDeletes documents matching the provided query."]
 pub struct DeleteByQuery<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: DeleteByQueryParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -1286,10 +1287,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [DeleteByQuery] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: DeleteByQueryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: DeleteByQueryParts<'b>) -> Self {
         let headers = HeaderMap::new();
         DeleteByQuery {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -1368,7 +1369,7 @@ where
         T: Serialize,
     {
         DeleteByQuery {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             _source: self._source,
@@ -1716,7 +1717,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1747,7 +1748,7 @@ impl<'b> DeleteByQueryRethrottleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Delete By Query Rethrottle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-delete-by-query.html)\n\nChanges the number of requests per second for a particular Delete By Query operation."]
 pub struct DeleteByQueryRethrottle<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: DeleteByQueryRethrottleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -1763,10 +1764,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [DeleteByQueryRethrottle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: DeleteByQueryRethrottleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: DeleteByQueryRethrottleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         DeleteByQueryRethrottle {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -1784,7 +1785,7 @@ where
         T: Serialize,
     {
         DeleteByQueryRethrottle {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -1868,7 +1869,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -1897,7 +1898,7 @@ impl<'b> DeleteScriptParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Delete Script API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-scripting.html)\n\nDeletes a script."]
 pub struct DeleteScript<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: DeleteScriptParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -1910,10 +1911,10 @@ pub struct DeleteScript<'a, 'b> {
 }
 impl<'a, 'b> DeleteScript<'a, 'b> {
     #[doc = "Creates a new instance of [DeleteScript] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: DeleteScriptParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: DeleteScriptParts<'b>) -> Self {
         let headers = HeaderMap::new();
         DeleteScript {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -2005,7 +2006,7 @@ impl<'a, 'b> DeleteScript<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2038,7 +2039,7 @@ impl<'b> ExistsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Exists API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html)\n\nReturns information about whether a document exists in an index."]
 pub struct Exists<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ExistsParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -2059,10 +2060,10 @@ pub struct Exists<'a, 'b> {
 }
 impl<'a, 'b> Exists<'a, 'b> {
     #[doc = "Creates a new instance of [Exists] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ExistsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: ExistsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Exists {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -2238,7 +2239,7 @@ impl<'a, 'b> Exists<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2290,7 +2291,7 @@ impl<'b> ExistsSourceParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Exists Source API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html)\n\nReturns information about whether a document source exists in an index."]
 pub struct ExistsSource<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ExistsSourceParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -2310,10 +2311,10 @@ pub struct ExistsSource<'a, 'b> {
 }
 impl<'a, 'b> ExistsSource<'a, 'b> {
     #[doc = "Creates a new instance of [ExistsSource] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ExistsSourceParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: ExistsSourceParts<'b>) -> Self {
         let headers = HeaderMap::new();
         ExistsSource {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -2477,7 +2478,7 @@ impl<'a, 'b> ExistsSource<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2510,7 +2511,7 @@ impl<'b> ExplainParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Explain API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-explain.html)\n\nReturns information about why a specific matches (or doesn't match) a query."]
 pub struct Explain<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ExplainParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -2537,10 +2538,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Explain] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ExplainParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: ExplainParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Explain {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -2594,7 +2595,7 @@ where
         T: Serialize,
     {
         Explain {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             _source: self._source,
@@ -2767,7 +2768,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -2802,7 +2803,7 @@ impl<'b> FieldCapsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Field Caps API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-field-caps.html)\n\nReturns the information about the capabilities of fields among multiple indices."]
 pub struct FieldCaps<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: FieldCapsParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -2822,10 +2823,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [FieldCaps] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: FieldCapsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: FieldCapsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         FieldCaps {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -2852,7 +2853,7 @@ where
         T: Serialize,
     {
         FieldCaps {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -2973,7 +2974,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3006,7 +3007,7 @@ impl<'b> GetParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html)\n\nReturns a document."]
 pub struct Get<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: GetParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -3027,10 +3028,10 @@ pub struct Get<'a, 'b> {
 }
 impl<'a, 'b> Get<'a, 'b> {
     #[doc = "Creates a new instance of [Get] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: GetParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: GetParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Get {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -3206,7 +3207,7 @@ impl<'a, 'b> Get<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3235,7 +3236,7 @@ impl<'b> GetScriptParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Get Script API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-scripting.html)\n\nReturns a script."]
 pub struct GetScript<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: GetScriptParts<'b>,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -3247,10 +3248,10 @@ pub struct GetScript<'a, 'b> {
 }
 impl<'a, 'b> GetScript<'a, 'b> {
     #[doc = "Creates a new instance of [GetScript] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: GetScriptParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: GetScriptParts<'b>) -> Self {
         let headers = HeaderMap::new();
         GetScript {
-            client,
+            transport,
             parts,
             headers,
             error_trace: None,
@@ -3333,7 +3334,7 @@ impl<'a, 'b> GetScript<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3366,7 +3367,7 @@ impl<'b> GetSourceParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Get Source API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html)\n\nReturns the source of a document."]
 pub struct GetSource<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: GetSourceParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -3386,10 +3387,10 @@ pub struct GetSource<'a, 'b> {
 }
 impl<'a, 'b> GetSource<'a, 'b> {
     #[doc = "Creates a new instance of [GetSource] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: GetSourceParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: GetSourceParts<'b>) -> Self {
         let headers = HeaderMap::new();
         GetSource {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -3553,7 +3554,7 @@ impl<'a, 'b> GetSource<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3597,7 +3598,7 @@ impl<'b> IndexParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Index API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-index_.html)\n\nCreates or updates a document in an index."]
 pub struct Index<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: IndexParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -3622,10 +3623,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Index] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: IndexParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: IndexParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Index {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -3652,7 +3653,7 @@ where
         T: Serialize,
     {
         Index {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -3817,7 +3818,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3840,7 +3841,7 @@ impl InfoParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/index.html)\n\nReturns basic information about the cluster."]
 pub struct Info<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: InfoParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -3851,10 +3852,10 @@ pub struct Info<'a, 'b> {
 }
 impl<'a, 'b> Info<'a, 'b> {
     #[doc = "Creates a new instance of [Info]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         Info {
-            client,
+            transport,
             parts: InfoParts::None,
             headers,
             error_trace: None,
@@ -3928,7 +3929,7 @@ impl<'a, 'b> Info<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -3962,7 +3963,7 @@ impl<'b> MgetParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Mget API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-multi-get.html)\n\nAllows to get multiple documents in one request."]
 pub struct Mget<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MgetParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -3985,10 +3986,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Mget] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MgetParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MgetParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Mget {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -4028,7 +4029,7 @@ where
         T: Serialize,
     {
         Mget {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             _source: self._source,
@@ -4175,7 +4176,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4210,7 +4211,7 @@ impl<'b> MsearchParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Msearch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-multi-search.html)\n\nAllows to execute several search operations in one request."]
 pub struct Msearch<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MsearchParts<'b>,
     body: Option<B>,
     ccs_minimize_roundtrips: Option<bool>,
@@ -4232,10 +4233,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Msearch] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MsearchParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MsearchParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Msearch {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -4259,7 +4260,7 @@ where
         T: Body,
     {
         Msearch {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(NdBody(body)),
             ccs_minimize_roundtrips: self.ccs_minimize_roundtrips,
@@ -4400,7 +4401,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4435,7 +4436,7 @@ impl<'b> MsearchTemplateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Msearch Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-multi-search.html)\n\nAllows to execute several search template operations in one request."]
 pub struct MsearchTemplate<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MsearchTemplateParts<'b>,
     body: Option<B>,
     ccs_minimize_roundtrips: Option<bool>,
@@ -4455,10 +4456,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [MsearchTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MsearchTemplateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MsearchTemplateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         MsearchTemplate {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -4480,7 +4481,7 @@ where
         T: Body,
     {
         MsearchTemplate {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(NdBody(body)),
             ccs_minimize_roundtrips: self.ccs_minimize_roundtrips,
@@ -4603,7 +4604,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4637,7 +4638,7 @@ impl<'b> MtermvectorsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Mtermvectors API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-multi-termvectors.html)\n\nReturns multiple termvectors in one request."]
 pub struct Mtermvectors<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: MtermvectorsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -4664,10 +4665,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Mtermvectors] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: MtermvectorsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: MtermvectorsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Mtermvectors {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -4696,7 +4697,7 @@ where
         T: Serialize,
     {
         Mtermvectors {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -4882,7 +4883,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -4905,7 +4906,7 @@ impl PingParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Ping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/index.html)\n\nReturns whether the cluster is running."]
 pub struct Ping<'a, 'b> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: PingParts,
     error_trace: Option<bool>,
     filter_path: Option<&'b [&'b str]>,
@@ -4916,10 +4917,10 @@ pub struct Ping<'a, 'b> {
 }
 impl<'a, 'b> Ping<'a, 'b> {
     #[doc = "Creates a new instance of [Ping]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         Ping {
-            client,
+            transport,
             parts: PingParts::None,
             headers,
             error_trace: None,
@@ -4993,7 +4994,7 @@ impl<'a, 'b> Ping<'a, 'b> {
         };
         let body = Option::<()>::None;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5036,7 +5037,7 @@ impl<'b> PutScriptParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Put Script API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-scripting.html)\n\nCreates or updates a script."]
 pub struct PutScript<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: PutScriptParts<'b>,
     body: Option<B>,
     context: Option<&'b str>,
@@ -5054,10 +5055,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [PutScript] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: PutScriptParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: PutScriptParts<'b>) -> Self {
         let headers = HeaderMap::new();
         PutScript {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -5077,7 +5078,7 @@ where
         T: Serialize,
     {
         PutScript {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             context: self.context,
@@ -5179,7 +5180,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5202,7 +5203,7 @@ impl ReindexParts {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Reindex API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-reindex.html)\n\nAllows to copy documents from one index to another, optionally filtering the source\ndocuments by a query, changing the destination index settings, or fetching the\ndocuments from a remote cluster."]
 pub struct Reindex<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ReindexParts,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -5225,10 +5226,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Reindex]"]
-    pub fn new(client: &'a Elasticsearch) -> Self {
+    pub fn new(transport: &'a Transport) -> Self {
         let headers = HeaderMap::new();
         Reindex {
-            client,
+            transport,
             parts: ReindexParts::None,
             headers,
             body: None,
@@ -5253,7 +5254,7 @@ where
         T: Serialize,
     {
         Reindex {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -5400,7 +5401,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5431,7 +5432,7 @@ impl<'b> ReindexRethrottleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Reindex Rethrottle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-reindex.html)\n\nChanges the number of requests per second for a particular Reindex operation."]
 pub struct ReindexRethrottle<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ReindexRethrottleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -5447,10 +5448,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [ReindexRethrottle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ReindexRethrottleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: ReindexRethrottleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         ReindexRethrottle {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -5468,7 +5469,7 @@ where
         T: Serialize,
     {
         ReindexRethrottle {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -5552,7 +5553,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5584,7 +5585,7 @@ impl<'b> RenderSearchTemplateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Render Search Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-template.html#_validating_templates)\n\nAllows to use the Mustache language to pre-render a search definition."]
 pub struct RenderSearchTemplate<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: RenderSearchTemplateParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -5599,10 +5600,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [RenderSearchTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: RenderSearchTemplateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: RenderSearchTemplateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         RenderSearchTemplate {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -5619,7 +5620,7 @@ where
         T: Serialize,
     {
         RenderSearchTemplate {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -5697,7 +5698,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5730,7 +5731,7 @@ impl<'b> ScrollParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-request-body.html#request-body-search-scroll)\n\nAllows to retrieve a large numbers of results from a single search request."]
 pub struct Scroll<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: ScrollParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -5748,10 +5749,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Scroll] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: ScrollParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: ScrollParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Scroll {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -5771,7 +5772,7 @@ where
         T: Serialize,
     {
         Scroll {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -5876,7 +5877,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -5911,7 +5912,7 @@ impl<'b> SearchParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Search API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-search.html)\n\nReturns results matching a query."]
 pub struct Search<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SearchParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -5968,10 +5969,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Search] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SearchParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SearchParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Search {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -6070,7 +6071,7 @@ where
         T: Serialize,
     {
         Search {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             _source: self._source,
@@ -6507,7 +6508,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6542,7 +6543,7 @@ impl<'b> SearchShardsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Search Shards API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-shards.html)\n\nReturns information about the indices and shards that a search request would be executed against."]
 pub struct SearchShards<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SearchShardsParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -6563,10 +6564,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SearchShards] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SearchShardsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SearchShardsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SearchShards {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -6594,7 +6595,7 @@ where
         T: Serialize,
     {
         SearchShards {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -6724,7 +6725,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -6759,7 +6760,7 @@ impl<'b> SearchTemplateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Search Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-template.html)\n\nAllows to use the Mustache language to pre-render a search definition."]
 pub struct SearchTemplate<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: SearchTemplateParts<'b>,
     allow_no_indices: Option<bool>,
     body: Option<B>,
@@ -6787,10 +6788,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [SearchTemplate] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: SearchTemplateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: SearchTemplateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         SearchTemplate {
-            client,
+            transport,
             parts,
             headers,
             allow_no_indices: None,
@@ -6825,7 +6826,7 @@ where
         T: Serialize,
     {
         SearchTemplate {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             allow_no_indices: self.allow_no_indices,
@@ -7021,7 +7022,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -7065,7 +7066,7 @@ impl<'b> TermvectorsParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Termvectors API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-termvectors.html)\n\nReturns information and statistics about terms in the fields of a particular document."]
 pub struct Termvectors<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: TermvectorsParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -7091,10 +7092,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Termvectors] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: TermvectorsParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: TermvectorsParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Termvectors {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -7122,7 +7123,7 @@ where
         T: Serialize,
     {
         Termvectors {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -7299,7 +7300,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -7351,7 +7352,7 @@ impl<'b> UpdateParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Update API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-update.html)\n\nUpdates a document with a script or partial document."]
 pub struct Update<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: UpdateParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -7377,10 +7378,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [Update] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: UpdateParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: UpdateParts<'b>) -> Self {
         let headers = HeaderMap::new();
         Update {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -7423,7 +7424,7 @@ where
         T: Serialize,
     {
         Update {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             _source: self._source,
@@ -7591,7 +7592,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -7623,7 +7624,7 @@ impl<'b> UpdateByQueryParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Update By Query API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-update-by-query.html)\n\nPerforms an update on every document in the index without changing the source,\nfor example to pick up a mapping change."]
 pub struct UpdateByQuery<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: UpdateByQueryParts<'b>,
     _source: Option<&'b [&'b str]>,
     _source_excludes: Option<&'b [&'b str]>,
@@ -7672,10 +7673,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [UpdateByQuery] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: UpdateByQueryParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: UpdateByQueryParts<'b>) -> Self {
         let headers = HeaderMap::new();
         UpdateByQuery {
-            client,
+            transport,
             parts,
             headers,
             _source: None,
@@ -7756,7 +7757,7 @@ where
         T: Serialize,
     {
         UpdateByQuery {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             _source: self._source,
@@ -8122,7 +8123,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -8153,7 +8154,7 @@ impl<'b> UpdateByQueryRethrottleParts<'b> {
 #[derive(Clone, Debug)]
 #[doc = "Builder for the [Update By Query Rethrottle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-update-by-query.html)\n\nChanges the number of requests per second for a particular Update By Query operation."]
 pub struct UpdateByQueryRethrottle<'a, 'b, B> {
-    client: &'a Elasticsearch,
+    transport: &'a Transport,
     parts: UpdateByQueryRethrottleParts<'b>,
     body: Option<B>,
     error_trace: Option<bool>,
@@ -8169,10 +8170,10 @@ where
     B: Body,
 {
     #[doc = "Creates a new instance of [UpdateByQueryRethrottle] with the specified API parts"]
-    pub fn new(client: &'a Elasticsearch, parts: UpdateByQueryRethrottleParts<'b>) -> Self {
+    pub fn new(transport: &'a Transport, parts: UpdateByQueryRethrottleParts<'b>) -> Self {
         let headers = HeaderMap::new();
         UpdateByQueryRethrottle {
-            client,
+            transport,
             parts,
             headers,
             body: None,
@@ -8190,7 +8191,7 @@ where
         T: Serialize,
     {
         UpdateByQueryRethrottle {
-            client: self.client,
+            transport: self.transport,
             parts: self.parts,
             body: Some(body.into()),
             error_trace: self.error_trace,
@@ -8274,7 +8275,7 @@ where
         };
         let body = self.body;
         let response = self
-            .client
+            .transport
             .send(method, &path, headers, query_string.as_ref(), body)
             .await?;
         Ok(response)
@@ -8283,168 +8284,168 @@ where
 impl Elasticsearch {
     #[doc = "[Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-bulk.html)\n\nAllows to perform multiple index/update/delete operations in a single request."]
     pub fn bulk<'a, 'b>(&'a self, parts: BulkParts<'b>) -> Bulk<'a, 'b, ()> {
-        Bulk::new(&self, parts)
+        Bulk::new(self.transport(), parts)
     }
     #[doc = "[Clear Scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-request-body.html#_clear_scroll_api)\n\nExplicitly clears the search context for a scroll."]
     pub fn clear_scroll<'a, 'b>(&'a self, parts: ClearScrollParts<'b>) -> ClearScroll<'a, 'b, ()> {
-        ClearScroll::new(&self, parts)
+        ClearScroll::new(self.transport(), parts)
     }
     #[doc = "[Count API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-count.html)\n\nReturns number of documents matching a query."]
     pub fn count<'a, 'b>(&'a self, parts: CountParts<'b>) -> Count<'a, 'b, ()> {
-        Count::new(&self, parts)
+        Count::new(self.transport(), parts)
     }
     #[doc = "[Create API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-index_.html)\n\nCreates a new document in the index.\n\nReturns a 409 response when a document with a same ID already exists in the index."]
     pub fn create<'a, 'b>(&'a self, parts: CreateParts<'b>) -> Create<'a, 'b, ()> {
-        Create::new(&self, parts)
+        Create::new(self.transport(), parts)
     }
     #[doc = "[Delete API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-delete.html)\n\nRemoves a document from the index."]
     pub fn delete<'a, 'b>(&'a self, parts: DeleteParts<'b>) -> Delete<'a, 'b> {
-        Delete::new(&self, parts)
+        Delete::new(self.transport(), parts)
     }
     #[doc = "[Delete By Query API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-delete-by-query.html)\n\nDeletes documents matching the provided query."]
     pub fn delete_by_query<'a, 'b>(
         &'a self,
         parts: DeleteByQueryParts<'b>,
     ) -> DeleteByQuery<'a, 'b, ()> {
-        DeleteByQuery::new(&self, parts)
+        DeleteByQuery::new(self.transport(), parts)
     }
     #[doc = "[Delete By Query Rethrottle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-delete-by-query.html)\n\nChanges the number of requests per second for a particular Delete By Query operation."]
     pub fn delete_by_query_rethrottle<'a, 'b>(
         &'a self,
         parts: DeleteByQueryRethrottleParts<'b>,
     ) -> DeleteByQueryRethrottle<'a, 'b, ()> {
-        DeleteByQueryRethrottle::new(&self, parts)
+        DeleteByQueryRethrottle::new(self.transport(), parts)
     }
     #[doc = "[Delete Script API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-scripting.html)\n\nDeletes a script."]
     pub fn delete_script<'a, 'b>(&'a self, parts: DeleteScriptParts<'b>) -> DeleteScript<'a, 'b> {
-        DeleteScript::new(&self, parts)
+        DeleteScript::new(self.transport(), parts)
     }
     #[doc = "[Exists API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html)\n\nReturns information about whether a document exists in an index."]
     pub fn exists<'a, 'b>(&'a self, parts: ExistsParts<'b>) -> Exists<'a, 'b> {
-        Exists::new(&self, parts)
+        Exists::new(self.transport(), parts)
     }
     #[doc = "[Exists Source API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html)\n\nReturns information about whether a document source exists in an index."]
     pub fn exists_source<'a, 'b>(&'a self, parts: ExistsSourceParts<'b>) -> ExistsSource<'a, 'b> {
-        ExistsSource::new(&self, parts)
+        ExistsSource::new(self.transport(), parts)
     }
     #[doc = "[Explain API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-explain.html)\n\nReturns information about why a specific matches (or doesn't match) a query."]
     pub fn explain<'a, 'b>(&'a self, parts: ExplainParts<'b>) -> Explain<'a, 'b, ()> {
-        Explain::new(&self, parts)
+        Explain::new(self.transport(), parts)
     }
     #[doc = "[Field Caps API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-field-caps.html)\n\nReturns the information about the capabilities of fields among multiple indices."]
     pub fn field_caps<'a, 'b>(&'a self, parts: FieldCapsParts<'b>) -> FieldCaps<'a, 'b, ()> {
-        FieldCaps::new(&self, parts)
+        FieldCaps::new(self.transport(), parts)
     }
     #[doc = "[Get API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html)\n\nReturns a document."]
     pub fn get<'a, 'b>(&'a self, parts: GetParts<'b>) -> Get<'a, 'b> {
-        Get::new(&self, parts)
+        Get::new(self.transport(), parts)
     }
     #[doc = "[Get Script API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-scripting.html)\n\nReturns a script."]
     pub fn get_script<'a, 'b>(&'a self, parts: GetScriptParts<'b>) -> GetScript<'a, 'b> {
-        GetScript::new(&self, parts)
+        GetScript::new(self.transport(), parts)
     }
     #[doc = "[Get Source API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-get.html)\n\nReturns the source of a document."]
     pub fn get_source<'a, 'b>(&'a self, parts: GetSourceParts<'b>) -> GetSource<'a, 'b> {
-        GetSource::new(&self, parts)
+        GetSource::new(self.transport(), parts)
     }
     #[doc = "[Index API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-index_.html)\n\nCreates or updates a document in an index."]
     pub fn index<'a, 'b>(&'a self, parts: IndexParts<'b>) -> Index<'a, 'b, ()> {
-        Index::new(&self, parts)
+        Index::new(self.transport(), parts)
     }
     #[doc = "[Info API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/index.html)\n\nReturns basic information about the cluster."]
     pub fn info<'a, 'b>(&'a self) -> Info<'a, 'b> {
-        Info::new(&self)
+        Info::new(self.transport())
     }
     #[doc = "[Mget API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-multi-get.html)\n\nAllows to get multiple documents in one request."]
     pub fn mget<'a, 'b>(&'a self, parts: MgetParts<'b>) -> Mget<'a, 'b, ()> {
-        Mget::new(&self, parts)
+        Mget::new(self.transport(), parts)
     }
     #[doc = "[Msearch API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-multi-search.html)\n\nAllows to execute several search operations in one request."]
     pub fn msearch<'a, 'b>(&'a self, parts: MsearchParts<'b>) -> Msearch<'a, 'b, ()> {
-        Msearch::new(&self, parts)
+        Msearch::new(self.transport(), parts)
     }
     #[doc = "[Msearch Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-multi-search.html)\n\nAllows to execute several search template operations in one request."]
     pub fn msearch_template<'a, 'b>(
         &'a self,
         parts: MsearchTemplateParts<'b>,
     ) -> MsearchTemplate<'a, 'b, ()> {
-        MsearchTemplate::new(&self, parts)
+        MsearchTemplate::new(self.transport(), parts)
     }
     #[doc = "[Mtermvectors API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-multi-termvectors.html)\n\nReturns multiple termvectors in one request."]
     pub fn mtermvectors<'a, 'b>(
         &'a self,
         parts: MtermvectorsParts<'b>,
     ) -> Mtermvectors<'a, 'b, ()> {
-        Mtermvectors::new(&self, parts)
+        Mtermvectors::new(self.transport(), parts)
     }
     #[doc = "[Ping API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/index.html)\n\nReturns whether the cluster is running."]
     pub fn ping<'a, 'b>(&'a self) -> Ping<'a, 'b> {
-        Ping::new(&self)
+        Ping::new(self.transport())
     }
     #[doc = "[Put Script API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-scripting.html)\n\nCreates or updates a script."]
     pub fn put_script<'a, 'b>(&'a self, parts: PutScriptParts<'b>) -> PutScript<'a, 'b, ()> {
-        PutScript::new(&self, parts)
+        PutScript::new(self.transport(), parts)
     }
     #[doc = "[Reindex API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-reindex.html)\n\nAllows to copy documents from one index to another, optionally filtering the source\ndocuments by a query, changing the destination index settings, or fetching the\ndocuments from a remote cluster."]
     pub fn reindex<'a, 'b>(&'a self) -> Reindex<'a, 'b, ()> {
-        Reindex::new(&self)
+        Reindex::new(self.transport())
     }
     #[doc = "[Reindex Rethrottle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-reindex.html)\n\nChanges the number of requests per second for a particular Reindex operation."]
     pub fn reindex_rethrottle<'a, 'b>(
         &'a self,
         parts: ReindexRethrottleParts<'b>,
     ) -> ReindexRethrottle<'a, 'b, ()> {
-        ReindexRethrottle::new(&self, parts)
+        ReindexRethrottle::new(self.transport(), parts)
     }
     #[doc = "[Render Search Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-template.html#_validating_templates)\n\nAllows to use the Mustache language to pre-render a search definition."]
     pub fn render_search_template<'a, 'b>(
         &'a self,
         parts: RenderSearchTemplateParts<'b>,
     ) -> RenderSearchTemplate<'a, 'b, ()> {
-        RenderSearchTemplate::new(&self, parts)
+        RenderSearchTemplate::new(self.transport(), parts)
     }
     #[doc = "[Scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-request-body.html#request-body-search-scroll)\n\nAllows to retrieve a large numbers of results from a single search request.\n\n# Examples\n\nTo initiate a scroll, make search API call with a specified `scroll` timeout,\nthen fetch the next set of hits using the `_scroll_id` returned in\nthe response. Once no more hits are returned, clear the scroll.\n\n```rust,no_run\n# use elasticsearch::{Elasticsearch, Error, SearchParts, ScrollParts, ClearScrollParts};\n# use serde_json::{json, Value};\n# async fn doc() -> Result<(), Box<dyn std::error::Error>> {\nlet client = Elasticsearch::default();\n\nfn print_hits(hits: &[Value]) {\n    for hit in hits {\n        println!(\n            \"id: '{}', source: '{}', score: '{}'\",\n            hit[\"_id\"].as_str().unwrap(),\n            hit[\"_source\"],\n            hit[\"_score\"].as_f64().unwrap()\n        );\n    }\n}\n\nlet scroll = \"1m\";\nlet mut response = client\n    .search(SearchParts::Index(&[\"tweets\"]))\n    .scroll(scroll)\n    .body(json!({\n        \"query\": {\n            \"match\": {\n                \"body\": {\n                    \"query\": \"Elasticsearch rust\",\n                    \"operator\": \"AND\"\n                }\n            }\n        }\n    }))\n    .send()\n    .await?;\n\nlet mut response_body = response.json::<Value>().await?;\nlet mut scroll_id = response_body[\"_scroll_id\"].as_str().unwrap();\nlet mut hits = response_body[\"hits\"][\"hits\"].as_array().unwrap();\n\nprint_hits(hits);\n\nwhile hits.len() > 0 {\n    response = client\n        .scroll(ScrollParts::None)\n        .body(json!({\n            \"scroll\": scroll,\n            \"scroll_id\": scroll_id\n        }))\n        .send()\n        .await?;\n\n    response_body = response.json::<Value>().await?;\n    scroll_id = response_body[\"_scroll_id\"].as_str().unwrap();\n    hits = response_body[\"hits\"][\"hits\"].as_array().unwrap();\n    print_hits(hits);\n}\n\nresponse = client\n    .clear_scroll(ClearScrollParts::None)\n    .body(json!({\n        \"scroll_id\": scroll_id\n    }))\n    .send()\n    .await?;\n    \n# Ok(())\n# }\n```"]
     pub fn scroll<'a, 'b>(&'a self, parts: ScrollParts<'b>) -> Scroll<'a, 'b, ()> {
-        Scroll::new(&self, parts)
+        Scroll::new(self.transport(), parts)
     }
     #[doc = "[Search API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-search.html)\n\nReturns results matching a query."]
     pub fn search<'a, 'b>(&'a self, parts: SearchParts<'b>) -> Search<'a, 'b, ()> {
-        Search::new(&self, parts)
+        Search::new(self.transport(), parts)
     }
     #[doc = "[Search Shards API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-shards.html)\n\nReturns information about the indices and shards that a search request would be executed against."]
     pub fn search_shards<'a, 'b>(
         &'a self,
         parts: SearchShardsParts<'b>,
     ) -> SearchShards<'a, 'b, ()> {
-        SearchShards::new(&self, parts)
+        SearchShards::new(self.transport(), parts)
     }
     #[doc = "[Search Template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/search-template.html)\n\nAllows to use the Mustache language to pre-render a search definition."]
     pub fn search_template<'a, 'b>(
         &'a self,
         parts: SearchTemplateParts<'b>,
     ) -> SearchTemplate<'a, 'b, ()> {
-        SearchTemplate::new(&self, parts)
+        SearchTemplate::new(self.transport(), parts)
     }
     #[doc = "[Termvectors API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-termvectors.html)\n\nReturns information and statistics about terms in the fields of a particular document."]
     pub fn termvectors<'a, 'b>(&'a self, parts: TermvectorsParts<'b>) -> Termvectors<'a, 'b, ()> {
-        Termvectors::new(&self, parts)
+        Termvectors::new(self.transport(), parts)
     }
     #[doc = "[Update API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-update.html)\n\nUpdates a document with a script or partial document."]
     pub fn update<'a, 'b>(&'a self, parts: UpdateParts<'b>) -> Update<'a, 'b, ()> {
-        Update::new(&self, parts)
+        Update::new(self.transport(), parts)
     }
     #[doc = "[Update By Query API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-update-by-query.html)\n\nPerforms an update on every document in the index without changing the source,\nfor example to pick up a mapping change."]
     pub fn update_by_query<'a, 'b>(
         &'a self,
         parts: UpdateByQueryParts<'b>,
     ) -> UpdateByQuery<'a, 'b, ()> {
-        UpdateByQuery::new(&self, parts)
+        UpdateByQuery::new(self.transport(), parts)
     }
     #[doc = "[Update By Query Rethrottle API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/docs-update-by-query.html)\n\nChanges the number of requests per second for a particular Update By Query operation."]
     pub fn update_by_query_rethrottle<'a, 'b>(
         &'a self,
         parts: UpdateByQueryRethrottleParts<'b>,
     ) -> UpdateByQueryRethrottle<'a, 'b, ()> {
-        UpdateByQueryRethrottle::new(&self, parts)
+        UpdateByQueryRethrottle::new(self.transport(), parts)
     }
 }


### PR DESCRIPTION
This PR proposes a breaking change to the client, to pass a reference to `Transport` to builder structs instead of a reference to `Elasticsearch`. 

Builder structs only use the `Transport` of the client, calling its `send()` function, currently performed through `Elasticsearch` client's `send()` function. By passing the `Transport` directly, the send indirection is removed. 