### PR TITLE
Make _id optional on Bulk index operaton

### DIFF
--- a/elasticsearch/examples/index_questions_answers/main.rs
+++ b/elasticsearch/examples/index_questions_answers/main.rs
@@ -149,7 +149,7 @@ async fn index_posts(client: &Elasticsearch, posts: &[Post]) -> Result<(), Error
         .iter()
         .map(|p| {
             let id = p.id().to_string();
-            BulkOperation::index(&id, p).routing(&id).into()
+            BulkOperation::index(p).id(&id).routing(&id).into()
         })
         .collect();
 

--- a/elasticsearch/tests/common/client.rs
+++ b/elasticsearch/tests/common/client.rs
@@ -99,8 +99,10 @@ pub async fn index_documents(client: &Elasticsearch) -> Result<Response, Error> 
 
     if exists_response.status_code() == StatusCode::NOT_FOUND {
         let mut body: Vec<BulkOperation<_>> = vec![];
-        for i in 1..11 {
-            let op = BulkOperation::index(i.to_string(), json!({"title":"Elasticsearch"})).into();
+        for i in 1..=10 {
+            let op = BulkOperation::index(json!({"title":"Elasticsearch"}))
+                .id(i.to_string())
+                .into();
             body.push(op);
         }
 


### PR DESCRIPTION
This commit fixes a bug where the _id of a bulk index operation should be optional, allowing it to be omitted and have Elasticsearch generate a value.

Expose an `.id()` function to be able to set a value