### PR TITLE
Add Debug impl for Response

### DIFF
--- a/elasticsearch/src/http/response.rs
+++ b/elasticsearch/src/http/response.rs
@@ -23,6 +23,7 @@ use crate::{
     http::{headers::HeaderMap, Method, StatusCode, Url},
 };
 use serde::de::DeserializeOwned;
+use std::fmt;
 
 /// A response from Elasticsearch
 pub struct Response(reqwest::Response, Method);
@@ -118,5 +119,16 @@ impl Response {
             .get_all("Warning")
             .iter()
             .map(|w| w.to_str().unwrap())
+    }
+}
+
+impl fmt::Debug for Response {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Response")
+            .field("method", &self.method())
+            .field("url", self.url())
+            .field("status_code", &self.status_code())
+            .field("headers", self.headers())
+            .finish()
     }
 }

--- a/elasticsearch/tests/client.rs
+++ b/elasticsearch/tests/client.rs
@@ -210,6 +210,12 @@ async fn search_with_body() -> Result<(), failure::Error> {
     assert_eq!(response.url(), &expected_url);
     assert_eq!(response.status_code(), StatusCode::OK);
     assert_eq!(response.method(), elasticsearch::http::Method::Post);
+    let debug = format!("{:?}", &response);
+    assert_eq!(
+        format!("Response {{ method: Post, url: \"{}\", status_code: 200, headers: {{\"content-type\": \"application/json; charset=UTF-8\"}} }}",
+                expected_url.as_str()),
+        debug);
+
     let response_body = response.json::<Value>().await?;
     assert!(response_body["took"].as_i64().is_some());
 


### PR DESCRIPTION
This commit adds a Debug implementation for Response.

Closes #113