### PR TITLE
Add ElasticsearchException to model Elasticsearch exceptions

### DIFF
--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -31,6 +31,7 @@ url = "^2.1"
 serde = { version = "~1", features = ["derive"] }
 serde_json = "~1"
 serde_with = "~1"
+void = "1.0.2"
 
 [dev-dependencies]
 chrono = { version = "^0.4", features = ["serde"] }

--- a/elasticsearch/examples/search_questions_answers/main.rs
+++ b/elasticsearch/examples/search_questions_answers/main.rs
@@ -31,7 +31,6 @@ use std::env;
 use sysinfo::SystemExt;
 use url::Url;
 mod stack_overflow;
-use elasticsearch::http::response::Response;
 use stack_overflow::*;
 use textwrap::fill;
 

--- a/elasticsearch/src/cert.rs
+++ b/elasticsearch/src/cert.rs
@@ -229,8 +229,8 @@ impl Certificate {
         }
 
         if certs.is_empty() {
-            Err(Error::lib(
-                "could not find PEM certificate in input data".to_string(),
+            Err(crate::error::lib(
+                "could not find PEM certificate in input data",
             ))
         } else {
             Ok(Self(certs))

--- a/elasticsearch/src/cert.rs
+++ b/elasticsearch/src/cert.rs
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+//! Certificate components
 
 use crate::error::Error;
 use std::{

--- a/elasticsearch/src/error.rs
+++ b/elasticsearch/src/error.rs
@@ -38,7 +38,7 @@ use std::{error, fmt, io};
 /// An error with the client.
 ///
 /// Errors that can occur include IO and parsing errors, as well as specific
-/// errors from Elasticsearch and internal errors from this library
+/// errors from Elasticsearch and internal errors from the client.
 #[derive(Debug)]
 pub struct Error {
     kind: Kind,
@@ -121,6 +121,14 @@ impl Error {
     pub fn is_timeout(&self) -> bool {
         match &self.kind {
             Kind::Http(err) => err.is_timeout(),
+            _ => false,
+        }
+    }
+
+    /// Returns true if the error is related to serialization or deserialization
+    pub fn is_json(&self) -> bool {
+        match &self.kind {
+            Kind::Json(_) => true,
             _ => false,
         }
     }

--- a/elasticsearch/src/http/response.rs
+++ b/elasticsearch/src/http/response.rs
@@ -17,13 +17,14 @@
  * under the License.
  */
 //! HTTP response components
-
 use crate::{
-    error::Error,
+    error::Error as ClientError,
     http::{headers::HeaderMap, Method, StatusCode, Url},
 };
-use serde::de::DeserializeOwned;
-use std::fmt;
+use serde::{de, de::{MapAccess, Visitor, DeserializeOwned}, Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+use std::{collections::BTreeMap, fmt, str::FromStr};
+use void::Void;
 
 /// A response from Elasticsearch
 pub struct Response(reqwest::Response, Method);
@@ -55,7 +56,7 @@ impl Response {
     }
 
     /// Turn the response into an [Error] if Elasticsearch returned an error.
-    pub fn error_for_status_code(self) -> Result<Self, Error> {
+    pub fn error_for_status_code(self) -> Result<Self, ClientError> {
         match self.0.error_for_status_ref() {
             Ok(_) => Ok(self),
             Err(err) => Err(err.into()),
@@ -63,17 +64,30 @@ impl Response {
     }
 
     /// Turn the response into an [Error] if Elasticsearch returned an error.
-    pub fn error_for_status_code_ref(&self) -> Result<&Self, Error> {
+    pub fn error_for_status_code_ref(&self) -> Result<&Self, ClientError> {
         match self.0.error_for_status_ref() {
             Ok(_) => Ok(self),
             Err(err) => Err(err.into()),
         }
     }
 
+    /// Asynchronously reads the response body into an [ElasticsearchException] if
+    /// Elasticsearch returned an error.
+    ///
+    /// Reading the response body consumes `self`
+    pub async fn exception(self) -> Result<Option<ElasticsearchException>, ClientError> {
+        if self.status_code().is_client_error() || self.status_code().is_server_error() {
+            let ex = self.json().await?;
+            Ok(Some(ex))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Asynchronously reads the response body as JSON
     ///
     /// Reading the response body consumes `self`
-    pub async fn json<B>(self) -> Result<B, Error>
+    pub async fn json<B>(self) -> Result<B, ClientError>
     where
         B: DeserializeOwned,
     {
@@ -99,7 +113,7 @@ impl Response {
     /// Asynchronously reads the response body as plain text
     ///
     /// Reading the response body consumes `self`
-    pub async fn text(self) -> Result<String, Error> {
+    pub async fn text(self) -> Result<String, ClientError> {
         let body = self.0.text().await?;
         Ok(body)
     }
@@ -131,5 +145,307 @@ impl fmt::Debug for Response {
             .field("status_code", &self.status_code())
             .field("headers", self.headers())
             .finish()
+    }
+}
+
+/// An exception raised by Elasticsearch.
+///
+/// Contains details that indicate why the exception was raised which can help
+#[serde_with::skip_serializing_none]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct ElasticsearchException {
+    status: Option<u16>,
+    #[serde(deserialize_with = "crate::string_or_struct")]
+    error: Error,
+}
+
+impl ElasticsearchException {
+    /// The status code of the exception, if available.
+    pub fn status(&self) -> Option<u16> {
+        self.status
+    }
+
+    /// The error details for the exception
+    pub fn error(&self) -> &Error {
+        &self.error
+    }
+}
+
+/// Details about the exception raised by Elasticsearch
+#[serde_with::skip_serializing_none]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Error {
+    #[serde(default = "BTreeMap::new", deserialize_with = "header_map")]
+    header: BTreeMap<String, Vec<String>>,
+    #[serde(default = "Vec::new")]
+    root_cause: Vec<Cause>,
+    reason: Option<String>,
+    stack_trace: Option<String>,
+    #[serde(rename = "type")]
+    ty: String,
+    #[serde(default = "BTreeMap::new", flatten)]
+    additional_details: BTreeMap<String, Value>,
+}
+
+/// Deserializes the headers map where the map values may be a string or a sequence of strings
+fn header_map<'de, D>(deserializer: D) -> Result<BTreeMap<String, Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct Wrapper(#[serde(deserialize_with = "crate::string_or_seq_string")] Vec<String>);
+
+    let v: BTreeMap<String, Wrapper> = BTreeMap::deserialize(deserializer)?;
+    Ok(v.into_iter().map(|(k, Wrapper(v))| (k, v)).collect())
+}
+
+impl Error {
+    /// The root causes for the exception
+    pub fn root_cause(&self) -> &Vec<Cause> {
+        &self.root_cause
+    }
+
+    /// The headers
+    pub fn header(&self) -> &BTreeMap<String, Vec<String>> {
+        &self.header
+    }
+
+    /// The reason for the exception
+    pub fn reason(&self) -> Option<&str> {
+        self.reason.as_ref().map(|r| r.as_str())
+    }
+
+    /// The exception stack trace, if available.
+    ///
+    /// Available if `error_trace` is specified on the request
+    pub fn stack_trace(&self) -> Option<&str> {
+        self.stack_trace.as_ref().map(|r| r.as_str())
+    }
+
+    /// The type of exception
+    pub fn ty(&self) -> &str {
+        self.ty.as_str()
+    }
+
+    /// Additional details about the cause.
+    ///
+    /// Elasticsearch can return additional details about an exception, depending
+    /// on context, which do not map to fields on [Error]. These are collected here
+    pub fn additional_details(&self) -> &BTreeMap<String, Value> {
+        &self.additional_details
+    }
+}
+
+// An error in an Elasticsearch exception can be returned as a simple message string only, or
+// as a JSON object. Handle both cases by corralling the simple message into the reason field
+impl FromStr for Error {
+    type Err = Void;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Error {
+            header: Default::default(),
+            root_cause: Vec::new(),
+            reason: Some(s.to_string()),
+            stack_trace: None,
+            ty: String::new(),
+            additional_details: Default::default(),
+        })
+    }
+}
+
+/// The cause of an exception
+#[serde_with::skip_serializing_none]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Cause {
+    #[serde(deserialize_with = "option_box_cause", default)]
+    caused_by: Option<Box<Cause>>,
+    reason: Option<String>,
+    stack_trace: Option<String>,
+    #[serde(rename = "type")]
+    ty: String,
+    #[serde(default = "BTreeMap::new", flatten)]
+    additional_details: BTreeMap<String, Value>,
+}
+
+/// Deserializes a string or a map into Some boxed [Cause]. A missing field
+/// for `caused_by` is handled by serde's default attribute on the struct field,
+/// which will assign None to the field.
+fn option_box_cause<'de, D>(deserializer: D) -> Result<Option<Box<Cause>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct CauseVisitor;
+    impl<'de> Visitor<'de> for CauseVisitor {
+        type Value = Cause;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or map")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Cause {
+                caused_by: None,
+                reason: Some(value.to_string()),
+                stack_trace: None,
+                ty: String::new(),
+                additional_details: Default::default(),
+            })
+        }
+
+        fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+    }
+
+    deserializer
+        .deserialize_any(CauseVisitor)
+        .map(|c| Some(Box::new(c)))
+}
+
+impl Cause {
+    /// The cause of the exception
+    pub fn caused_by(&self) -> Option<&Box<Cause>> {
+        self.caused_by.as_ref()
+    }
+
+    /// The reason for the exception
+    pub fn reason(&self) -> Option<&str> {
+        self.reason.as_ref().map(|r| r.as_str())
+    }
+
+    /// The exception stack trace, if available.
+    ///
+    /// Available if `error_trace` is specified on the request
+    pub fn stack_trace(&self) -> Option<&str> {
+        self.stack_trace.as_ref().map(|r| r.as_str())
+    }
+
+    /// The type of exception
+    pub fn ty(&self) -> &str {
+        self.ty.as_str()
+    }
+
+    /// Additional details about the cause.
+    ///
+    /// Elasticsearch can return additional details about an exception, depending
+    /// on context, which do not map to fields on [Error]. These are collected here
+    pub fn additional_details(&self) -> &BTreeMap<String, Value> {
+        &self.additional_details
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::http::response::ElasticsearchException;
+    use serde_json::json;
+
+    #[test]
+    fn deserialize_exception_with_additional_details() -> Result<(), failure::Error> {
+        let json = r#"{
+            "error":{
+                "root_cause" : [
+                    {
+                        "type" : "parse_exception",
+                        "reason" : "failed to parse date field [-1m] with format [strict_date_optional_time||epoch_millis]",
+                        "caused_by" : {
+                            "type" : "parse_exception",
+                            "reason" : "failed to parse date field [-1m] with format [strict_date_optional_time||epoch_millis]",
+                            "index" : null,
+                            "resource.id" : ["alias1", "alias2"],
+                            "script_stack" : ["alias1", "alias2"],
+                            "unknown_prop" : ["alias1", "alias2"],
+                            "caused_by" : {
+                                "type" : "illegal_argument_exception",
+                                "reason" : "Parse failure at index [2] of [-1m]",
+                                "caused_by" : "x"
+                            }
+                        }
+                    }
+                ],
+                "type" : "search_phase_execution_exception",
+                "reason" : "all shards failed",
+                "phase" : "query",
+                "grouped" : true,
+                "failed_shards" : [
+                {
+                    "shard" : 0,
+                    "index" : "project",
+                    "node" : "Uo6PBln_QrmD8Y9o1NKdQw",
+                    "unknown_prop" : "x",
+                    "reason" : {
+                        "type" : "parse_exception",
+                        "reason" : "failed to parse date field [-1m] with format [strict_date_optional_time||epoch_millis]",
+                        "caused_by" : {
+                            "type" : "illegal_argument_exception",
+                            "reason" : "Parse failure at index [2] of [-1m]"
+                        }
+                    },
+                    "status" : "x"
+                }
+                ],
+                "header" : {
+                    "WWW-Authenticate" : "Bearer ...",
+                    "x" : ["y", "z"]
+                },
+                "license.expired.feature" : "ml",
+                "index" : "index",
+                "index_uuid" : "x9h1ks",
+                "unknown_prop" : {},
+                "unknown_prop2" : false,
+                "resource.type" : "aliases",
+                "resource.id" : "alias1",
+                "shard" : "1",
+                "line" : 12,
+                "col" : 199,
+                "bytes_wanted" : 1298312,
+                "bytes_limit" : 8912031,
+                "script_stack" : "x",
+                "script" : "some script",
+                "lang" : "painless"
+            }
+        }"#;
+
+        let ex: ElasticsearchException = serde_json::from_str(json)?;
+        let error = ex.error();
+
+        assert!(ex.status().is_none());
+        assert_eq!(error.reason(), Some("all shards failed"));
+        assert!(!error.additional_details().is_empty());
+        assert_eq!(
+            error.additional_details().get("script_stack"),
+            Some(&json!("x"))
+        );
+        assert_eq!(error.header().len(), 2);
+        assert_eq!(
+            error.header().get("x"),
+            Some(&vec!["y".to_string(), "z".to_string()])
+        );
+
+        assert!(!error.root_cause().is_empty());
+        let first_root_cause = &error.root_cause()[0];
+        assert!(first_root_cause.caused_by().is_some());
+        let caused_by = first_root_cause.caused_by().unwrap();
+        assert_eq!(caused_by.reason(), Some("failed to parse date field [-1m] with format [strict_date_optional_time||epoch_millis]"));
+
+        assert!(caused_by.caused_by().is_some());
+        let inner_caused_by = caused_by.caused_by().unwrap();
+        assert_eq!(
+            inner_caused_by.reason(),
+            Some("Parse failure at index [2] of [-1m]")
+        );
+
+        assert!(inner_caused_by.caused_by().is_some());
+        let inner_inner_caused_by = inner_caused_by.caused_by().unwrap();
+        assert_eq!(inner_inner_caused_by.reason(), Some("x"));
+
+        assert!(inner_inner_caused_by.caused_by().is_none());
+
+        Ok(())
     }
 }

--- a/elasticsearch/src/http/response.rs
+++ b/elasticsearch/src/http/response.rs
@@ -134,7 +134,7 @@ impl Response {
     pub fn warning_headers(&self) -> impl Iterator<Item = &str> {
         self.0.headers().get_all("Warning").iter().map(|w| {
             let s = w.to_str().unwrap();
-            let first_quote = s.find(r#"""#).unwrap();
+            let first_quote = s.find('"').unwrap();
             let last_quote = s.len() - 1;
             &s[first_quote + 1..last_quote]
         })
@@ -208,8 +208,8 @@ where
 
 impl Error {
     /// The cause of the exception
-    pub fn caused_by(&self) -> Option<&Box<Cause>> {
-        self.caused_by.as_ref()
+    pub fn caused_by(&self) -> Option<&Cause> {
+        self.caused_by.as_deref()
     }
 
     /// The root causes for the exception
@@ -224,19 +224,19 @@ impl Error {
 
     /// The reason for the exception, if available.
     pub fn reason(&self) -> Option<&str> {
-        self.reason.as_ref().map(|r| r.as_str())
+        self.reason.as_deref()
     }
 
     /// The exception stack trace, if available.
     ///
     /// Available if `error_trace` is specified on the request
     pub fn stack_trace(&self) -> Option<&str> {
-        self.stack_trace.as_ref().map(|r| r.as_str())
+        self.stack_trace.as_deref()
     }
 
     /// The type of exception, if available.
     pub fn ty(&self) -> Option<&str> {
-        self.ty.as_ref().map(|t| t.as_str())
+        self.ty.as_deref()
     }
 
     /// Additional details about the cause.
@@ -323,25 +323,25 @@ where
 
 impl Cause {
     /// The cause of the exception
-    pub fn caused_by(&self) -> Option<&Box<Cause>> {
-        self.caused_by.as_ref()
+    pub fn caused_by(&self) -> Option<&Cause> {
+        self.caused_by.as_deref()
     }
 
     /// The reason for the exception
     pub fn reason(&self) -> Option<&str> {
-        self.reason.as_ref().map(|r| r.as_str())
+        self.reason.as_deref()
     }
 
     /// The exception stack trace, if available.
     ///
     /// Available if `error_trace` is specified on the request
     pub fn stack_trace(&self) -> Option<&str> {
-        self.stack_trace.as_ref().map(|r| r.as_str())
+        self.stack_trace.as_deref()
     }
 
     /// The type of exception, if available.
     pub fn ty(&self) -> Option<&str> {
-        self.ty.as_ref().map(|t| t.as_str())
+        self.ty.as_deref()
     }
 
     /// Additional details about the cause.

--- a/elasticsearch/src/http/response.rs
+++ b/elasticsearch/src/http/response.rs
@@ -21,7 +21,11 @@ use crate::{
     error::Error as ClientError,
     http::{headers::HeaderMap, Method, StatusCode, Url},
 };
-use serde::{de, de::{MapAccess, Visitor, DeserializeOwned}, Deserialize, Deserializer, Serialize};
+use serde::{
+    de,
+    de::{DeserializeOwned, MapAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
 use serde_json::Value;
 use std::{collections::BTreeMap, fmt, str::FromStr};
 use void::Void;
@@ -72,7 +76,7 @@ impl Response {
     }
 
     /// Asynchronously reads the response body into an [ElasticsearchException] if
-    /// Elasticsearch returned an error.
+    /// Elasticsearch returned a HTTP status code in the 400-599 range.
     ///
     /// Reading the response body consumes `self`
     pub async fn exception(self) -> Result<Option<ElasticsearchException>, ClientError> {
@@ -165,7 +169,7 @@ impl ElasticsearchException {
         self.status
     }
 
-    /// The error details for the exception
+    /// The details for the exception
     pub fn error(&self) -> &Error {
         &self.error
     }

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -405,13 +405,7 @@ impl Transport {
         let response = request_builder.send().await;
         match response {
             Ok(r) => Ok(Response::new(r, method)),
-            Err(e) => {
-                if e.is_timeout() {
-                    Err(Error::lib(format!("Request timed out to {:?}", e.url())))
-                } else {
-                    Err(e.into())
-                }
-            }
+            Err(e) => Err(e.into()),
         }
     }
 }
@@ -482,7 +476,7 @@ impl CloudId {
     /// web console
     pub fn parse(cloud_id: &str) -> Result<CloudId, Error> {
         if cloud_id.is_empty() || !cloud_id.contains(':') {
-            return Err(Error::lib(
+            return Err(crate::error::lib(
                 "cloud_id should be of the form '<cluster name>:<base64 data>'",
             ));
         }
@@ -490,13 +484,16 @@ impl CloudId {
         let parts: Vec<&str> = cloud_id.splitn(2, ':').collect();
         let name: String = parts[0].into();
         if name.is_empty() {
-            return Err(Error::lib("cloud_id cluster name cannot be empty"));
+            return Err(crate::error::lib("cloud_id cluster name cannot be empty"));
         }
 
         let data = parts[1];
         let decoded_result = base64::decode(data);
         if decoded_result.is_err() {
-            return Err(Error::lib(format!("cannot base 64 decode '{}'", data)));
+            return Err(crate::error::lib(format!(
+                "cannot base 64 decode '{}'",
+                data
+            )));
         }
 
         let decoded = decoded_result.unwrap();
@@ -510,18 +507,18 @@ impl CloudId {
                     Ok(s) => {
                         domain_name = s.trim();
                         if domain_name.is_empty() {
-                            return Err(Error::lib("decoded '<base64 data>' must contain a domain name as the first part"));
+                            return Err(crate::error::lib("decoded '<base64 data>' must contain a domain name as the first part"));
                         }
                     }
                     Err(_) => {
-                        return Err(Error::lib(
+                        return Err(crate::error::lib(
                             "decoded '<base64 data>' must contain a domain name as the first part",
                         ))
                     }
                 }
             }
             None => {
-                return Err(Error::lib(
+                return Err(crate::error::lib(
                     "decoded '<base64 data>' must contain a domain name as the first part",
                 ));
             }
@@ -532,19 +529,19 @@ impl CloudId {
                 Ok(s) => {
                     uuid = s.trim();
                     if uuid.is_empty() {
-                        return Err(Error::lib(
+                        return Err(crate::error::lib(
                             "decoded '<base64 data>' must contain a uuid as the second part",
                         ));
                     }
                 }
                 Err(_) => {
-                    return Err(Error::lib(
+                    return Err(crate::error::lib(
                         "decoded '<base64 data>' must contain a uuid as the second part",
                     ))
                 }
             },
             None => {
-                return Err(Error::lib(
+                return Err(crate::error::lib(
                     "decoded '<base64 data>' must contain at least two parts",
                 ));
             }

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -387,6 +387,85 @@ mod root;
 
 // exposes types within modules at the library root level
 pub use crate::{client::*, error::*, http::transport::DEFAULT_ADDRESS, root::*};
+use serde::de::{MapAccess, Visitor};
+use serde::{de, Deserialize, Deserializer};
+use std::fmt;
+use std::marker::PhantomData;
+use std::str::FromStr;
+use void::Void;
+
+/// Deserializes a string or a map into a struct `T` that implements `FromStr`
+pub(crate) fn string_or_struct<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Deserialize<'de> + FromStr<Err = Void>,
+    D: Deserializer<'de>,
+{
+    // This is a Visitor that forwards string types to T's `FromStr` impl and
+    // forwards map types to T's `Deserialize` impl. The `PhantomData` is to
+    // keep the compiler from complaining about T being an unused generic type
+    // parameter. We need T in order to know the Value type for the Visitor
+    // impl.
+    struct StringOrStruct<T>(PhantomData<fn() -> T>);
+
+    impl<'de, T> Visitor<'de> for StringOrStruct<T>
+    where
+        T: Deserialize<'de> + FromStr<Err = Void>,
+    {
+        type Value = T;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or map")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<T, E>
+        where
+            E: de::Error,
+        {
+            Ok(FromStr::from_str(value).unwrap())
+        }
+
+        fn visit_map<M>(self, map: M) -> Result<T, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+    }
+
+    deserializer.deserialize_any(StringOrStruct(PhantomData))
+}
+
+/// Deserializes a string or a sequence of strings into a Vec<String>
+pub(crate) fn string_or_seq_string<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringOrVec(PhantomData<Vec<String>>);
+
+    impl<'de> de::Visitor<'de> for StringOrVec {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or seq of strings")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(vec![value.to_string()])
+        }
+
+        fn visit_seq<S>(self, visitor: S) -> Result<Self::Value, S::Error>
+        where
+            S: de::SeqAccess<'de>,
+        {
+            Deserialize::deserialize(de::value::SeqAccessDeserializer::new(visitor))
+        }
+    }
+
+    deserializer.deserialize_any(StringOrVec(PhantomData))
+}
 
 #[cfg(test)]
 pub mod tests {

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -387,11 +387,12 @@ mod root;
 
 // exposes types within modules at the library root level
 pub use crate::{client::*, error::*, http::transport::DEFAULT_ADDRESS, root::*};
-use serde::de::{MapAccess, Visitor};
-use serde::{de, Deserialize, Deserializer};
-use std::fmt;
-use std::marker::PhantomData;
-use std::str::FromStr;
+use serde::{
+    de,
+    de::{MapAccess, Visitor},
+    Deserialize, Deserializer,
+};
+use std::{fmt, marker::PhantomData, str::FromStr};
 use void::Void;
 
 /// Deserializes a string or a map into a struct `T` that implements `FromStr`
@@ -440,7 +441,7 @@ pub(crate) fn string_or_seq_string<'de, D>(deserializer: D) -> Result<Vec<String
 where
     D: Deserializer<'de>,
 {
-    struct StringOrVec(PhantomData<Vec<String>>);
+    struct StringOrVec;
 
     impl<'de> de::Visitor<'de> for StringOrVec {
         type Value = Vec<String>;
@@ -464,7 +465,7 @@ where
         }
     }
 
-    deserializer.deserialize_any(StringOrVec(PhantomData))
+    deserializer.deserialize_any(StringOrVec)
 }
 
 #[cfg(test)]

--- a/elasticsearch/tests/error.rs
+++ b/elasticsearch/tests/error.rs
@@ -66,7 +66,7 @@ async fn deserialize_exception() -> Result<(), failure::Error> {
     let error = ex.error();
 
     assert_eq!(ex.status().unwrap(), status_code.as_u16());
-    assert_eq!(error.ty(), "action_request_validation_exception");
+    assert_eq!(error.ty(), Some("action_request_validation_exception"));
     assert!(error.stack_trace().is_some());
     assert_eq!(
         error.reason(),


### PR DESCRIPTION
This commit adds an ElasticsearchException struct that models
exceptions returned by Elasticsearch in the event of an error.

An exception() function is exposed on Response to deserialize the
response body into ElasticsearchException when the status code is
in the 400-599 range.

Consideration was made to exposing this on
the Error struct, performing the deserialization inside
`error_for_status_code`, but this introduces some awkwardness into
the API:

- `error_for_status_code` would ideally be async because the .json()
  call is async
- .json() consumes the response, which would not be possible for
  `error_for_status_code_ref` which has a shared reference to Response.

Additional details about an exception are collected in a map and exposed
through additional_details function.

Closes #112