### PR TITLE
Return warning description only from warning headers

### DIFF
--- a/elasticsearch/src/http/response.rs
+++ b/elasticsearch/src/http/response.rs
@@ -114,11 +114,12 @@ impl Response {
     /// Deprecation headers signal the use of Elasticsearch functionality
     /// or features that are deprecated and will be removed in a future release.
     pub fn warning_headers(&self) -> impl Iterator<Item = &str> {
-        self.0
-            .headers()
-            .get_all("Warning")
-            .iter()
-            .map(|w| w.to_str().unwrap())
+        self.0.headers().get_all("Warning").iter().map(|w| {
+            let s = w.to_str().unwrap();
+            let first_quote = s.find(r#"""#).unwrap();
+            let last_quote = s.len() - 1;
+            &s[first_quote + 1..last_quote]
+        })
     }
 }
 


### PR DESCRIPTION
This commit updates the warning_headers implementation
on Response to return a string slice of the warning value
from the value of a warning header that is formatted
according to RFC 7234.