### PR TITLE
Remove [types removal] warning headers from yaml runner tests

### DIFF
--- a/yaml_test_runner/src/step/do.rs
+++ b/yaml_test_runner/src/step/do.rs
@@ -91,10 +91,14 @@ impl Do {
     pub fn to_tokens(&self, mut read_response: bool, tokens: &mut Tokens) -> bool {
         self.api_call.to_tokens(tokens);
 
-        // only assert that there are no warnings if expected warnings is empty and not allowing warnings
+        // Filter out [types removal] warnings in all cases, same as the java runner. This should
+        // really be in the yaml tests themselves
         if !self.warnings.is_empty() {
             tokens.append(quote! {
-                let warnings: Vec<&str> = response.warning_headers().collect();
+                let warnings: Vec<&str> = response
+                    .warning_headers()
+                    .filter(|w| !w.starts_with("[types removal]"))
+                    .collect();
             });
             for warning in &self.warnings {
                 tokens.append(quote! {
@@ -106,7 +110,7 @@ impl Do {
             tokens.append(quote! {
                 let allowed_warnings = vec![#(#allowed),*];
                 let warnings: Vec<&str> = response.warning_headers()
-                    .filter(|w| !allowed_warnings.iter().any(|a| w.contains(a)))
+                    .filter(|w| !w.starts_with("[types removal]") || !allowed_warnings.iter().any(|a| w.contains(a)))
                     .collect();
                 assert_warnings_is_empty!(warnings);
             });
@@ -122,11 +126,10 @@ impl Do {
             c.to_tokens(tokens);
         }
 
-        match &self.api_call.ignore {
-            Some(i) => tokens.append(quote! {
+        if let Some(i) = &self.api_call.ignore {
+            tokens.append(quote! {
                 assert_response_success_or!(response, #i);
-            }),
-            None => (),
+            });
         }
 
         read_response


### PR DESCRIPTION
This commit removes [types removal] warning headers when
making assertions on warnings of allowed_warnings in yaml
tests.