### PR TITLE
Expose dangling indices APIs

### DIFF
--- a/elasticsearch/src/dangling_indices/mod.rs
+++ b/elasticsearch/src/dangling_indices/mod.rs
@@ -1,0 +1,28 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+//! Dangling Index APIs
+//!
+//! If Elasticsearch encounters index data that is absent from the current cluster state,
+//! those indices are considered to be _dangling_. For example, this can happen if you delete
+//! more than `cluster.indices.tombstones.size` number of indices while an Elasticsearch node
+//! is offline.
+//!
+//! The dangling indices APIs can list, import and delete dangling indices.
+
+pub use super::generated::namespace_clients::dangling_indices::*;

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -358,6 +358,7 @@ pub mod cat;
 pub mod ccr;
 pub mod cert;
 pub mod cluster;
+pub mod dangling_indices;
 pub mod enrich;
 pub mod graph;
 pub mod http;


### PR DESCRIPTION
This PR exposes the dangling indices APIs in a `dangling_indices` module