### PR TITLE
Implement Multinode connection pool

### DIFF
--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -27,7 +27,9 @@ bytes = "^0.5"
 dyn-clone = "~1"
 percent-encoding = "2.1.0"
 reqwest = { version = "~0.10", default-features = false, features = ["gzip", "json"] }
+lazy_static = "^1.4"
 url = "^2.1"
+regex = "1.3"
 serde = { version = "~1", features = ["derive"] }
 serde_json = "~1"
 serde_with = "~1"

--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -33,6 +33,7 @@ regex = "1.3"
 serde = { version = "~1", features = ["derive"] }
 serde_json = "~1"
 serde_with = "~1"
+tokio = { version = "0.2.0", default-features = false, features = ["macros", "tcp", "time"] }
 void = "1.0.2"
 
 [dev-dependencies]

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -349,13 +349,30 @@ impl Transport {
     }
 
     /// Creates a new instance of a [Transport] configured with a
-    /// [StaticNodeListConnectionPool]
+    /// [MultiNodeConnectionPool] that does not refresh
     pub fn static_node_list(urls: Vec<&str>) -> Result<Transport, Error> {
         let urls: Vec<Url> = urls
             .iter()
             .map(|url| Url::parse(url))
             .collect::<Result<Vec<_>, _>>()?;
         let conn_pool = MultiNodeConnectionPool::round_robin(urls, None);
+        let transport = TransportBuilder::new(conn_pool).build()?;
+        Ok(transport)
+    }
+
+    /// Creates a new instance of a [Transport] configured with a
+    /// [MultiNodeConnectionPool]
+    ///
+    /// * `reseed_frequency` - frequency at which connections should be refreshed in seconds
+    pub fn sniffing_node_list(
+        urls: Vec<&str>,
+        reseed_frequency: Duration,
+    ) -> Result<Transport, Error> {
+        let urls: Vec<Url> = urls
+            .iter()
+            .map(|url| Url::parse(url))
+            .collect::<Result<Vec<_>, _>>()?;
+        let conn_pool = MultiNodeConnectionPool::round_robin(urls, Some(reseed_frequency));
         let transport = TransportBuilder::new(conn_pool).build()?;
         Ok(transport)
     }

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -344,7 +344,10 @@ impl Transport {
     /// Creates a new instance of a [Transport] configured with a
     /// [StaticNodeListConnectionPool]
     pub fn static_node_list(urls: Vec<&str>) -> Result<Transport, Error> {
-        let urls = urls.iter().map(|url| Url::parse(url).unwrap()).collect();
+        let urls: Vec<Url> = urls
+            .iter()
+            .map(|url| Url::parse(url))
+            .collect::<Result<Vec<_>, _>>()?;
         let conn_pool = StaticNodeListConnectionPool::round_robin(urls);
         let transport = TransportBuilder::new(conn_pool).build()?;
         Ok(transport)

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -38,6 +38,7 @@ use crate::{
 use base64::write::EncoderWriter as Base64Encoder;
 use bytes::BytesMut;
 use serde::Serialize;
+use serde_json::Value;
 use std::{
     error, fmt,
     fmt::Debug,
@@ -288,7 +289,7 @@ impl Default for TransportBuilder {
 /// A connection to an Elasticsearch node, used to send an API request
 #[derive(Debug, Clone)]
 pub struct Connection {
-    url: Url,
+    url: Arc<Url>,
 }
 
 impl Connection {
@@ -303,7 +304,13 @@ impl Connection {
             url
         };
 
+        let url = Arc::new(url);
+
         Self { url }
+    }
+
+    pub fn url(&self) -> Arc<Url> {
+        self.url.clone()
     }
 }
 
@@ -365,27 +372,22 @@ impl Transport {
         Ok(transport)
     }
 
-    /// Creates an asynchronous request that can be awaited
-    pub async fn send<B, Q>(
+    pub fn request_builder<B, Q>(
         &self,
+        connection: &Connection,
         method: Method,
         path: &str,
         headers: HeaderMap,
         query_string: Option<&Q>,
         body: Option<B>,
         timeout: Option<Duration>,
-    ) -> Result<Response, Error>
+    ) -> Result<reqwest::RequestBuilder, Error>
     where
         B: Body,
         Q: Serialize + ?Sized,
     {
-        if self.conn_pool.reseedable() {
-            // Reseed nodes
-            println!("Reseeding!");
-        }
-        let connection = self.conn_pool.next();
-        let url = connection.url.join(path.trim_start_matches('/'))?;
         let reqwest_method = self.method(method);
+        let url = connection.url.join(path.trim_start_matches('/'))?;
         let mut request_builder = self.client.request(reqwest_method, url);
 
         if let Some(t) = timeout {
@@ -442,6 +444,70 @@ impl Transport {
         if let Some(q) = query_string {
             request_builder = request_builder.query(q);
         }
+        Ok(request_builder)
+    }
+
+    /// Creates an asynchronous request that can be awaited
+    pub async fn send<B, Q>(
+        &self,
+        method: Method,
+        path: &str,
+        headers: HeaderMap,
+        query_string: Option<&Q>,
+        body: Option<B>,
+        timeout: Option<Duration>,
+    ) -> Result<Response, Error>
+    where
+        B: Body,
+        Q: Serialize + ?Sized,
+    {
+        // Threads will execute against old connection pool during reseed
+        if self.conn_pool.reseedable() {
+            // Set as reseeding prevents another thread from attempting
+            // to reseed during es request and reseed
+            self.conn_pool.reseeding();
+
+            let connection = self.conn_pool.next();
+            let scheme = &connection.url.scheme();
+            // Build node info request
+            let node_request = self.request_builder(
+                &connection,
+                Method::Get,
+                "_nodes/_all/http",
+                headers.clone(),
+                None::<&Q>,
+                None::<B>,
+                timeout,
+            )?;
+            let resp = node_request.send().await?;
+            let json: Value = resp.json().await?;
+            let connections: Vec<Connection> = json["nodes"]
+                .as_object()
+                .unwrap()
+                .iter()
+                .map(|h| {
+                    let url = format!(
+                        "{}://{}",
+                        scheme,
+                        h.1["http"]["publish_address"].as_str().unwrap()
+                    );
+                    let url = Url::parse(&url).unwrap();
+                    Connection::new(url)
+                })
+                .collect();
+            self.conn_pool.reseed(connections);
+        }
+
+        let connection = self.conn_pool.next();
+        let request_builder = self.request_builder(
+            &connection,
+            method,
+            path,
+            headers,
+            query_string,
+            body,
+            timeout,
+        )?;
 
         let response = request_builder.send().await;
         match response {
@@ -470,6 +536,9 @@ pub trait ConnectionPool: Debug + dyn_clone::DynClone + Sync + Send {
     fn reseedable(&self) -> bool {
         false
     }
+
+    // NOOP
+    fn reseeding(&self) {}
 
     // NOOP by default
     fn reseed(&self, _connection: Vec<Connection>) {}
@@ -629,38 +698,46 @@ impl ConnectionPool for CloudConnectionPool {
 
 /// A Connection Pool that manages a static connection of nodes
 #[derive(Debug, Clone)]
-pub struct MultiNodeConnectionPool<TStrategy = RoundRobin> {
+pub struct MultiNodeConnectionPool<LoadBalancing = RoundRobin> {
     inner: Arc<RwLock<MultiNodeConnectionPoolInner>>,
-    wait: Option<Duration>,
-    strategy: TStrategy,
+    reseed_frequency: Option<Duration>,
+    load_balancing_strategy: LoadBalancing,
 }
 
 #[derive(Debug, Clone)]
 pub struct MultiNodeConnectionPoolInner {
+    reseeding: bool,
     last_update: Option<Instant>,
     connections: Vec<Connection>,
 }
 
-impl<TStrategy> ConnectionPool for MultiNodeConnectionPool<TStrategy>
+impl<LoadBalancing> ConnectionPool for MultiNodeConnectionPool<LoadBalancing>
 where
-    TStrategy: Strategy + Clone,
+    LoadBalancing: LoadBalancingStrategy + Clone,
 {
     fn next(&self) -> Connection {
         let inner = self.inner.read().expect("lock poisoned");
-        self.strategy.try_next(&inner.connections).unwrap()
+        self.load_balancing_strategy
+            .try_next(&inner.connections)
+            .unwrap()
     }
 
     fn reseedable(&self) -> bool {
         let inner = self.inner.read().expect("lock poisoned");
-        let wait = match self.wait {
+        let reseed_frequency = match self.reseed_frequency {
             Some(wait) => wait,
             None => return false,
         };
         let last_update_is_stale = inner
             .last_update
             .as_ref()
-            .map(|last_update| last_update.elapsed() > wait);
-        last_update_is_stale.unwrap_or(true)
+            .map(|last_update| last_update.elapsed() > reseed_frequency);
+        last_update_is_stale.unwrap_or(true) && !inner.reseeding
+    }
+
+    fn reseeding(&self) {
+        let mut inner = self.inner.write().expect("Lock Poisoned");
+        inner.reseeding = true
     }
 
     fn reseed(&self, mut connection: Vec<Connection>) {
@@ -668,31 +745,33 @@ where
         inner.last_update = Some(Instant::now());
         inner.connections.clear();
         inner.connections.append(&mut connection);
+        inner.reseeding = false;
     }
 }
 
 impl MultiNodeConnectionPool<RoundRobin> {
     /** Use a round-robin strategy for balancing traffic over the given set of nodes. */
-    pub fn round_robin(urls: Vec<Url>, wait: Option<Duration>) -> Self {
+    pub fn round_robin(urls: Vec<Url>, reseed_frequency: Option<Duration>) -> Self {
         let connections = urls.into_iter().map(Connection::new).collect();
 
         let inner: Arc<RwLock<MultiNodeConnectionPoolInner>> =
             Arc::new(RwLock::new(MultiNodeConnectionPoolInner {
+                reseeding: false,
                 last_update: None,
                 connections,
             }));
 
-        let strategy = RoundRobin::default();
+        let load_balancing_strategy = RoundRobin::default();
         Self {
             inner,
-            strategy,
-            wait,
+            load_balancing_strategy,
+            reseed_frequency,
         }
     }
 }
 
 /** The strategy selects an address from a given collection. */
-pub trait Strategy: Send + Sync + Debug {
+pub trait LoadBalancingStrategy: Send + Sync + Debug {
     /** Try get the next connection. */
     fn try_next<'a>(&self, connections: &'a [Connection]) -> Result<Connection, Error>;
 }
@@ -711,7 +790,7 @@ impl Default for RoundRobin {
     }
 }
 
-impl Strategy for RoundRobin {
+impl LoadBalancingStrategy for RoundRobin {
     fn try_next<'a>(&self, connections: &'a [Connection]) -> Result<Connection, Error> {
         if connections.is_empty() {
             Err(crate::error::lib("Connection list empty"))

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -353,6 +353,9 @@ type _DoctestReadme = ();
 #[macro_use]
 extern crate dyn_clone;
 
+#[macro_use]
+extern crate lazy_static;
+
 pub mod auth;
 pub mod cert;
 pub mod http;


### PR DESCRIPTION
* This commit adds a connection pool that takes a static
  list of nodes and distributes the load.

* trait for setting connection distribution.
  Defaults to RoundRobin.

#57 