### PR TITLE
Makefile improvements.

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -202,13 +202,6 @@ cargo package %{CARGO_MAKE_CARGO_PACKAGE_FLAGS}
 clear = true
 script_runner = "@duckscript"
 script = ['''
-    env_prefix = set \\$
-    env_suffix = set ""
-    if is_windows
-        env_prefix = set %
-        env_suffix = set ${env_prefix}
-    end
-
     echo
     echo Main tasks:
     echo - generate-api: Generates Elasticsearch client from REST API specs
@@ -227,8 +220,13 @@ script = ['''
     echo       By default, peforms a dry run by passing --dry-run, but publish flags can be overridden with CARGO_MAKE_CARGO_PUBLISH_FLAGS environment variable
     echo
     echo Most tasks use these environment variables:
-    echo - STACK_VERSION (default '${env_prefix}STACK_VERSION${env_suffix}'): the version of Elasticsearch
-    echo - TEST_SUITE ('oss' or 'xpack', default '${env_prefix}TEST_SUITE${env_suffix}'): the distribution of Elasticsearch
+    if is_windows
+        echo - STACK_VERSION (default '%STACK_VERSION%'): the version of Elasticsearch
+        echo - TEST_SUITE ('oss' or 'xpack', default '%TEST_SUITE%'): the distribution of Elasticsearch
+    else
+        echo - STACK_VERSION (default '$STACK_VERSION'): the version of Elasticsearch
+        echo - TEST_SUITE ('oss' or 'xpack', default '$TEST_SUITE'): the distribution of Elasticsearch
+    end
     echo - CI (default not set): set when running on CI to determine whether to start Elasticsearch and format test output as JSON
     echo
     echo Run 'cargo make --list-all-steps' for a complete list of available tasks.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,16 +28,14 @@ Runs yaml_test_runner package to generate tests from yaml files for a given Elas
 The commit to use is retrieved from the running Elasticsearch instance
 '''
 private = true
-script = ["cargo run -p yaml_test_runner -- -u ${ELASTICSEARCH_URL}"]
+command = "cargo"
+args = ["run", "-p", "yaml_test_runner", "--", "-u", "${ELASTICSEARCH_URL}"]
 dependencies = ["start-elasticsearch"]
-
-[tasks.run-yaml-test-runner.windows]
-script = ["cargo run -p yaml_test_runner -- -u %ELASTICSEARCH_URL%"]
 
 [tasks.test-yaml-test-runner]
 category = "Elasticsearch"
 private = true
-condition = { env_set = [ "ELASTICSEARCH_URL" ], env_not_set = ["CI"] }
+condition = { env_set = [ "ELASTICSEARCH_URL" ], env_false = ["CARGO_MAKE_CI"] }
 command = "cargo"
 args = ["test", "-p", "yaml_test_runner", "--", "--test-threads=1"]
 dependencies = ["generate-yaml-tests"]
@@ -45,7 +43,7 @@ dependencies = ["generate-yaml-tests"]
 [tasks.test-yaml-test-runner-ci]
 category = "Elasticsearch"
 private = true
-condition = { env_set = [ "ELASTICSEARCH_URL", "CI" ] }
+condition = { env_set = [ "ELASTICSEARCH_URL" ], env_true = ["CARGO_MAKE_CI"] }
 script = ["cargo test -p yaml_test_runner -- --test-threads=1 -Z unstable-options --format json | tee test_results/results.json"]
 dependencies = ["generate-yaml-tests"]
 
@@ -66,7 +64,7 @@ args = ["run", "-p", "api_generator"]
 [tasks.create-test-results-dir]
 category = "Elasticsearch"
 private = true
-condition = { env_set = [ "CI" ] }
+condition = { env_true = [ "CARGO_MAKE_CI" ] }
 script = ["[ -d test_results ] || mkdir -p test_results"]
 
 [tasks.install-cargo2junit]
@@ -77,33 +75,30 @@ script = ["cargo install cargo2junit"]
 [tasks.convert-test-results-junit]
 category = "Elasticsearch"
 private = true
-condition = { env_set = [ "CI" ] }
+condition = { env_true = [ "CARGO_MAKE_CI" ] }
 script = ["cat test_results/results.json | cargo2junit > test_results/cargo-junit.xml"]
 dependencies = ["install-cargo2junit"]
+
+[tasks.run-elasticsearch]
+category = "Elasticsearch"
+condition = { env_set = [ "STACK_VERSION", "TEST_SUITE" ], env_false = ["CARGO_MAKE_CI"] }
+script_runner = "bash"
+script = { file = "./.ci/run-elasticsearch.sh" }
+dependencies = ["set-oss-env", "set-xpack-env"]
 
 # ============
 # Public tasks
 # ============
 
 [tasks.start-elasticsearch]
-category = "Elasticsearch"
+extend = "run-elasticsearch"
 description = "Starts Elasticsearch docker container with the given version and distribution"
-condition = { env_set = [ "STACK_VERSION", "TEST_SUITE" ], env_not_set = ["CI"] }
-script = ["DETACH=true bash .ci/run-elasticsearch.sh"]
-dependencies = ["set-oss-env", "set-xpack-env"]
-
-[tasks.start-elasticsearch.windows]
-script = ["bash -c \"STACK_VERSION=%STACK_VERSION% TEST_SUITE=%TEST_SUITE% DETACH=true bash .ci/run-elasticsearch.sh\""]
+env = { "CLEANUP" = false, "DETACH" = true }
 
 [tasks.stop-elasticsearch]
-category = "Elasticsearch"
+extend = "run-elasticsearch"
 description = "Stops Elasticsearch docker container, if running"
-condition = { env_set = [ "STACK_VERSION", "TEST_SUITE" ], env_not_set = ["CI"] }
-script = ["CLEANUP=true bash .ci/run-elasticsearch.sh"]
-dependencies = ["set-oss-env", "set-xpack-env"]
-
-[tasks.stop-elasticsearch.windows]
-script = ["bash -c \"STACK_VERSION=%STACK_VERSION% TEST_SUITE=%TEST_SUITE% CLEANUP=true bash .ci/run-elasticsearch.sh\""]
+env = { "CLEANUP" = true, "DETACH" = false }
 
 [tasks.test-yaml]
 category = "Elasticsearch"
@@ -142,29 +137,9 @@ run_task = "format"
 
 [tasks.default]
 clear = true
+script_runner = "@duckscript"
 script = ['''
     echo
-    echo "Main tasks:"
-    echo "- generate-api: Generates Elasticsearch client from REST API specs"
-    echo "- start-elasticsearch: Starts Elasticsearch docker container with the given version and distribution"
-    echo "- stop-elasticsearch: Stops Elasticsearch docker container, if running"
-    echo "- test-yaml: Generates and runs yaml_test_runner package xpack/oss tests against a given Elasticsearch version"
-    echo "- test-generator: Generates and runs api_generator package tests"
-    echo "- test: Runs elasticsearch package tests against a given Elasticsearch version"
-    echo
-    echo "Most tasks use these environment variables:"
-    echo "- STACK_VERSION (default '$STACK_VERSION'): the version of Elasticsearch"
-    echo "- TEST_SUITE ('oss' or 'xpack', default '$TEST_SUITE'): the distribution of Elasticsearch"
-    echo "- CI (default not set): set when running on CI to determine whether to start Elasticsearch and format test output as JSON"
-    echo
-    echo "Run 'cargo make --list-all-steps' for a complete list of available tasks."
-    echo
-''']
-
-[tasks.default.windows]
-script = ['''
-    @echo off
-    echo.
     echo Main tasks:
     echo - generate-api: Generates Elasticsearch client from REST API specs
     echo - start-elasticsearch: Starts Elasticsearch docker container with the given version and distribution
@@ -172,12 +147,12 @@ script = ['''
     echo - test-yaml: Generates and runs yaml_test_runner package xpack/oss tests against a given Elasticsearch version
     echo - test-generator: Generates and runs api_generator package tests
     echo - test: Runs elasticsearch package tests against a given Elasticsearch version
-    echo.
+    echo
     echo Most tasks use these environment variables:
     echo - STACK_VERSION (default '$STACK_VERSION'): the version of Elasticsearch
     echo - TEST_SUITE ('oss' or 'xpack', default '$TEST_SUITE'): the distribution of Elasticsearch
     echo - CI (default not set): set when running on CI to determine whether to start Elasticsearch and format test output as JSON
-    echo.
+    echo
     echo Run 'cargo make --list-all-steps' for a complete list of available tasks.
-    echo.
+    echo
 ''']

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -202,6 +202,13 @@ cargo package %{CARGO_MAKE_CARGO_PACKAGE_FLAGS}
 clear = true
 script_runner = "@duckscript"
 script = ['''
+    env_prefix = set \\$
+    env_suffix = set ""
+    if is_windows
+        env_prefix = set %
+        env_suffix = set ${env_prefix}
+    end
+
     echo
     echo Main tasks:
     echo - generate-api: Generates Elasticsearch client from REST API specs
@@ -220,8 +227,8 @@ script = ['''
     echo       By default, peforms a dry run by passing --dry-run, but publish flags can be overridden with CARGO_MAKE_CARGO_PUBLISH_FLAGS environment variable
     echo
     echo Most tasks use these environment variables:
-    echo - STACK_VERSION (default '$STACK_VERSION'): the version of Elasticsearch
-    echo - TEST_SUITE ('oss' or 'xpack', default '$TEST_SUITE'): the distribution of Elasticsearch
+    echo - STACK_VERSION (default '${env_prefix}STACK_VERSION${env_suffix}'): the version of Elasticsearch
+    echo - TEST_SUITE ('oss' or 'xpack', default '${env_prefix}TEST_SUITE${env_suffix}'): the distribution of Elasticsearch
     echo - CI (default not set): set when running on CI to determine whether to start Elasticsearch and format test output as JSON
     echo
     echo Run 'cargo make --list-all-steps' for a complete list of available tasks.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -220,13 +220,8 @@ script = ['''
     echo       By default, peforms a dry run by passing --dry-run, but publish flags can be overridden with CARGO_MAKE_CARGO_PUBLISH_FLAGS environment variable
     echo
     echo Most tasks use these environment variables:
-    if is_windows
-        echo - STACK_VERSION (default '%STACK_VERSION%'): the version of Elasticsearch
-        echo - TEST_SUITE ('oss' or 'xpack', default '%TEST_SUITE%'): the distribution of Elasticsearch
-    else
-        echo - STACK_VERSION (default '$STACK_VERSION'): the version of Elasticsearch
-        echo - TEST_SUITE ('oss' or 'xpack', default '$TEST_SUITE'): the distribution of Elasticsearch
-    end
+    echo - STACK_VERSION (default '${STACK_VERSION}'): the version of Elasticsearch
+    echo - TEST_SUITE ('oss' or 'xpack', default '${TEST_SUITE}'): the distribution of Elasticsearch
     echo - CI (default not set): set when running on CI to determine whether to start Elasticsearch and format test output as JSON
     echo
     echo Run 'cargo make --list-all-steps' for a complete list of available tasks.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -86,6 +86,10 @@ script_runner = "bash"
 script = { file = "./.ci/run-elasticsearch.sh" }
 dependencies = ["set-oss-env", "set-xpack-env"]
 
+[tasks.run-elasticsearch.windows]
+script_runner = "cmd"
+script = ["bash -c \"STACK_VERSION=%STACK_VERSION% TEST_SUITE=%TEST_SUITE% DETACH=%DETACH% CLEANUP=%CLEANUP% bash .ci/run-elasticsearch.sh\""]
+
 # ============
 # Public tasks
 # ============

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -155,7 +155,7 @@ script = ['''
     echo Most tasks use these environment variables:
     echo - STACK_VERSION (default '$STACK_VERSION'): the version of Elasticsearch
     echo - TEST_SUITE ('oss' or 'xpack', default '$TEST_SUITE'): the distribution of Elasticsearch
-    echo - CI (default not set): set when running on CI to determine whether to start Elasticsearch and format test output as JSON
+    echo - CARGO_MAKE_CI (default not set): set when running on CI to determine whether to start Elasticsearch and format test output as JSON
     echo
     echo Run 'cargo make --list-all-steps' for a complete list of available tasks.
     echo

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -88,7 +88,11 @@ dependencies = ["set-oss-env", "set-xpack-env"]
 
 [tasks.run-elasticsearch.windows]
 script_runner = "cmd"
-script = ["bash -c \"STACK_VERSION=%STACK_VERSION% TEST_SUITE=%TEST_SUITE% DETACH=%DETACH% CLEANUP=%CLEANUP% bash .ci/run-elasticsearch.sh\""]
+script = [
+'''
+bash -c "STACK_VERSION=%STACK_VERSION% TEST_SUITE=%TEST_SUITE% DETACH=%DETACH% CLEANUP=%CLEANUP% bash .ci/run-elasticsearch.sh"
+'''
+]
 
 # ============
 # Public tasks
@@ -155,7 +159,7 @@ script = ['''
     echo Most tasks use these environment variables:
     echo - STACK_VERSION (default '$STACK_VERSION'): the version of Elasticsearch
     echo - TEST_SUITE ('oss' or 'xpack', default '$TEST_SUITE'): the distribution of Elasticsearch
-    echo - CARGO_MAKE_CI (default not set): set when running on CI to determine whether to start Elasticsearch and format test output as JSON
+    echo - CI (default not set): set when running on CI to determine whether to start Elasticsearch and format test output as JSON
     echo
     echo Run 'cargo make --list-all-steps' for a complete list of available tasks.
     echo


### PR DESCRIPTION
Really cool crate. Trying to help a bit sort out and remove duplications in the makefile.

* Default message is now in duckscript so its same code for all platforms. no need for code duplication.
* start/stop search task has a base task so common code is there.
* start/stop search task no longer has a windows specific implementation
* Move CI env var which isn't supported for all CI vendors to CARGO_MAKE_CI which supports all.

Few questions/comments

1. I couldn't test it properly. i'm working on gitpod and i can't run docker. would love some help testing this.
2. why did you have the windows specific overrides? 
i understand why you need those when using script (that's why i converted to command+args which support var value replacement) but for start/stop elasticsearch tasks i'm not sure why it was needed.
I don't have a windows machine to test (again need help with that as well) so i would love to understand more why your original tasks didn't work.
because it looks like for those you simply also defined STACK_VERSION and TEST_SUITE on the command, but those env vars are already set. 