### PR TITLE
Add client benchmarks

### DIFF
--- a/.ci/benchmarks/DockerFile
+++ b/.ci/benchmarks/DockerFile
@@ -1,0 +1,13 @@
+ARG RUST_VERSION=1.44.1-stretch
+FROM rust:${RUST_VERSION}
+
+# create app directory
+WORKDIR /usr/src/elasticsearch-rs
+
+COPY elasticsearch/Cargo.toml ./elasticsearch/Cargo.toml
+COPY elasticsearch/src ./elasticsearch/src
+COPY elasticsearch/build.rs ./elasticsearch/build.rs
+
+COPY benchmarks ./benchmarks
+
+RUN cd benchmarks && cargo build --release

--- a/.ci/jobs/elastic+elasticsearch-rs+benchmarks.yml
+++ b/.ci/jobs/elastic+elasticsearch-rs+benchmarks.yml
@@ -1,0 +1,17 @@
+---
+- job:
+    project-type: freestyle
+    node: linux && immutable
+    name: elastic+elasticsearch-rs+benchmarks
+    display-name: 'elastic / elasticsearch-rs # benchmarks'
+    description: Client benchmarks for the rust client
+    parameters:
+      - string: { name: branch_specifier, default: refs/heads/master }
+    triggers:
+      - timed: "H H/12 * * *"
+    vault:
+      role_id: "ddbd0d44-0e51-105b-177a-c8fdfd445126"
+    builders:
+      - shell: |-
+          #!/usr/local/bin/runbld
+          .ci/run-benchmarks

--- a/.ci/run-benchmarks
+++ b/.ci/run-benchmarks
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Licensed to Elasticsearch B.V. under one or more agreements.
+# Elasticsearch B.V. licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+set -euxo pipefail
+
+export WORKSPACE=${WORKSPACE:-$PWD}
+
+COMMIT="$(git rev-parse --short HEAD)"
+
+export CLIENT_IMAGE="eu.gcr.io/elastic-clients/elasticsearch-rs:$COMMIT"
+export CLIENT_BRANCH='master'
+export CLIENT_COMMAND='. /environment.sh && cd benchmarks && cargo run --release'
+
+set +x
+echo -e "\033[1mBuilding Docker image for commit [$COMMIT]\033[0m"
+set -x
+
+docker build \
+  --file .ci/benchmarks/DockerFile \
+  --tag elastic/elasticsearch-rs \
+  .
+
+set +u
+if [[ -n $JENKINS_URL ]]; then
+	set +x
+	VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+	export VAULT_TOKEN
+	set -x
+fi
+set -u
+
+mkdir -p "$WORKSPACE/tmp"
+vault read -field=gcp_service_account secret/clients-team/benchmarking > "$WORKSPACE/tmp/credentials.json"
+gcloud auth activate-service-account --key-file "$WORKSPACE/tmp/credentials.json"
+
+gcloud auth configure-docker --quiet
+gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://eu.gcr.io
+docker tag elastic/elasticsearch-rs "$CLIENT_IMAGE"
+docker push "$CLIENT_IMAGE"
+
+exec "$WORKSPACE/.ci/scripts/run-benchmarks.sh"

--- a/.ci/scripts/run-benchmarks.sh
+++ b/.ci/scripts/run-benchmarks.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Licensed to Elasticsearch B.V. under one or more agreements.
+# Elasticsearch B.V. licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+#
+# Runner for the client benchmarks.
+#
+# Export the following environment variables when running the script:
+#
+# * CLIENT_IMAGE
+# * CLIENT_BRANCH
+# * CLIENT_COMMAND
+#
+# The WORKSPACE environment variable is automatically set on Jenkins.
+#
+# The VAULT_ADDR is automatically set on Jenkins.
+
+set -euxo pipefail
+
+mkdir -p "$WORKSPACE/tmp"
+
+vault read -field=gcp_service_account secret/clients-team/benchmarking > "$WORKSPACE/tmp/credentials.json"
+
+export GOOGLE_CLOUD_KEYFILE_JSON="$WORKSPACE/tmp/credentials.json"
+export GOOGLE_APPLICATION_CREDENTIALS="$WORKSPACE/tmp/credentials.json"
+
+set +x
+report_url="$(vault read -field=reporting_url secret/clients-team/benchmarking)"
+report_password="$(vault read -field=reporting_password secret/clients-team/benchmarking)"
+export ELASTICSEARCH_REPORT_URL="$report_url"
+export ELASTICSEARCH_REPORT_PASSWORD="$report_password"
+
+export TF_VAR_reporting_url="$ELASTICSEARCH_REPORT_URL"
+export TF_VAR_reporting_password="$ELASTICSEARCH_REPORT_PASSWORD"
+
+runner_ssh_private_key="$(vault read -field=runner_ssh_private_key secret/clients-team/benchmarking)"
+runner_ssh_public_key="$(vault read -field=runner_ssh_public_key secret/clients-team/benchmarking)"
+export TF_VAR_runner_ssh_private_key="$runner_ssh_private_key"
+export TF_VAR_runner_ssh_public_key="$runner_ssh_public_key"
+echo "$runner_ssh_private_key" > "$WORKSPACE/tmp/runner_id_rsa"
+echo "$runner_ssh_public_key" > "$WORKSPACE/tmp/runner_id_rsa.pub"
+chmod go= "$WORKSPACE/tmp/runner_id_rsa"
+chmod go= "$WORKSPACE/tmp/runner_id_rsa.pub"
+set -x
+
+TERRAFORM=$(command -v terraform)
+GCLOUD=$(command -v gcloud)
+
+DESTROY=${DESTROY:-yes}
+
+function cleanup {
+  if [[ $DESTROY != "no" ]]; then
+    $TERRAFORM destroy --auto-approve --input=false --var client_image="$CLIENT_IMAGE"
+  fi
+}
+
+trap cleanup INT TERM EXIT;
+
+if [[ ! -d "$WORKSPACE/tmp/elasticsearch-clients-benchmarks" ]]; then
+  git clone --depth 1 git@github.com:elastic/elasticsearch-clients-benchmarks.git "$WORKSPACE/tmp/elasticsearch-clients-benchmarks"
+else
+  cd "$WORKSPACE/tmp/elasticsearch-clients-benchmarks" && git fetch --quiet && git reset origin/master --hard
+fi
+
+cd "$WORKSPACE/tmp/elasticsearch-clients-benchmarks/terraform/gcp"
+
+$TERRAFORM init --input=false
+$TERRAFORM apply --auto-approve --input=false --var client_image="$CLIENT_IMAGE"
+
+set +ex
+echo -e "\n\033[1mWaiting for instance [$($TERRAFORM output runner_instance_name)] to be ready...\033[0m"
+
+SECONDS=0
+while (( SECONDS < 900 )); do # Timeout: 15min
+  $GCLOUD compute --project 'elastic-clients' ssh runner@"$($TERRAFORM output runner_instance_name)" --zone='europe-west1-b' --ssh-key-file="$WORKSPACE/tmp/runner_id_rsa" --command="sudo su - runner -c 'docker container inspect -f \"{{.Name}}:{{.State.Status}}\" benchmarks-data'"
+  status=$?
+  if [[ $status -eq 0 ]]; then
+    break
+  else
+    sleep 1
+  fi
+done
+
+echo -e "\n\033[1mWaiting for cluster at [$($TERRAFORM output master_ip)] to be ready...\033[0m"
+
+SECONDS=0
+while (( SECONDS < 900 )); do # Timeout: 15min
+  $GCLOUD compute --project 'elastic-clients' ssh runner@"$($TERRAFORM output runner_instance_name)" --zone='europe-west1-b' --ssh-key-file="$WORKSPACE/tmp/runner_id_rsa" --command="sudo su - runner -c 'curl -sS $($TERRAFORM output master_ip):9200/_cat/nodes?v'"
+  status=$?
+  if [[ $status -eq 0 ]]; then
+    break
+  else
+    sleep 1
+  fi
+done
+
+echo -e "\n\033[1mRunning benchmarks for [$CLIENT_IMAGE]\033[0m"
+set -x
+
+$GCLOUD compute --project 'elastic-clients' ssh runner@"$($TERRAFORM output runner_instance_name)" \
+  --zone='europe-west1-b' \
+  --ssh-key-file="$WORKSPACE/tmp/runner_id_rsa" \
+  --ssh-flag='-t' \
+  --command="\
+  CLIENT_BRANCH=$CLIENT_BRANCH \
+  CLIENT_BENCHMARK_ENVIRONMENT=production \
+  /home/runner/runner.sh \"$CLIENT_COMMAND\""

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 
 *.sh text eol=lf
 .ci/run-tests text eol=lf
+.ci/run-benchmarks text eol=lf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "api_generator",
+    "benchmarks",
     "elasticsearch",
     "yaml_test_runner"
 ]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "benchmarks"
+version = "8.0.0-alpha.1"
+publish = false
+description = "Runs benchmarks for the Elasticsearch Rust client"
+repository = "https://github.com/elastic/elasticsearch-rs"
+authors = ["Elastic and Contributors"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+chrono = { version = "^0.4", features = ["serde"] }
+elasticsearch = { path = "./../elasticsearch" }
+once_cell = "1.4.0"
+os_type = "2.2.0"
+tokio = "~0.2"
+serde = "~1"
+serde_json = "~1"
+serde_with = "~1"
+rustc_version_runtime = "~0.1"
+sys-info = "~0.7"
+sysinfo = "0.12.0"
+
+# always use all optimizations and link time optimizations
+[profile.dev]
+opt-level = 3
+lto = true
+codegen-units = 1
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1

--- a/benchmarks/src/actions/bulk.rs
+++ b/benchmarks/src/actions/bulk.rs
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use crate::{Action, Config};
+use elasticsearch::{
+    cluster::ClusterHealthParts,
+    http::response::Response,
+    indices::{IndicesCreateParts, IndicesDeleteParts},
+    BulkOperation, BulkParts, Error,
+};
+use serde_json::Value;
+use tokio::runtime::Runtime;
+
+pub fn bulk() -> Action {
+    Action {
+        action: "bulk".to_string(),
+        category: Some("core".to_string()),
+        warmups: 10,
+        environment: None,
+        repetitions: 1000,
+        operations: Some(OPERATIONS),
+        setup: Some(setup),
+        run,
+    }
+}
+
+static OPERATIONS: i32 = 10000;
+
+static INDEX: &str = "test-bench-bulk";
+
+static mut BODY: Vec<BulkOperation<Value>> = Vec::new();
+
+unsafe fn push_to_body(op: BulkOperation<Value>) {
+    BODY.push(op);
+}
+
+fn setup(config: &Config, runtime: &mut Runtime) -> Result<Response, Error> {
+    let client = config.runner_client();
+
+    for _ in 0..OPERATIONS {
+        unsafe {
+            push_to_body(
+                BulkOperation::index(config.data_sources("small").unwrap().clone()).into(),
+            );
+        }
+    }
+
+    runtime.block_on(async {
+        let _response = client
+            .indices()
+            .delete(IndicesDeleteParts::Index(&[INDEX]))
+            .send()
+            .await?;
+
+        let _response = client
+            .indices()
+            .create(IndicesCreateParts::Index(INDEX))
+            .body(json!({
+                "settings": {
+                    "number_of_shards": 3,
+                    "refresh_interval": "5s"
+                }
+            }))
+            .send()
+            .await?;
+
+        client
+            .cluster()
+            .health(ClusterHealthParts::Index(&[INDEX]))
+            .send()
+            .await
+    })
+}
+
+fn run(_i: i32, config: &Config, runtime: &mut Runtime) -> Result<Response, Error> {
+    let client = config.runner_client();
+    runtime.block_on(async {
+        unsafe {
+            client
+                .bulk(BulkParts::Index(INDEX))
+                .body(BODY.to_vec())
+                .send()
+                .await
+        }
+    })
+}

--- a/benchmarks/src/actions/get.rs
+++ b/benchmarks/src/actions/get.rs
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use crate::{Action, Config};
+use elasticsearch::{
+    http::response::Response, indices::IndicesDeleteParts, params::Refresh, Error, GetParts,
+    IndexParts,
+};
+use tokio::runtime::Runtime;
+
+pub fn get() -> Action {
+    Action {
+        action: "get".to_string(),
+        category: Some("core".to_string()),
+        warmups: 100,
+        environment: None,
+        repetitions: 10000,
+        operations: Some(1),
+        setup: Some(setup),
+        run,
+    }
+}
+
+static INDEX: &str = "test-bench-get";
+
+fn setup(config: &Config, runtime: &mut Runtime) -> Result<Response, Error> {
+    let client = config.runner_client();
+    runtime.block_on(async {
+        let _response = client
+            .indices()
+            .delete(IndicesDeleteParts::Index(&[INDEX]))
+            .send()
+            .await?;
+
+        client
+            .index(IndexParts::IndexId(INDEX, "1"))
+            .body(json!({"title":"Test"}))
+            .refresh(Refresh::WaitFor)
+            .send()
+            .await
+    })
+}
+
+fn run(_i: i32, config: &Config, runtime: &mut Runtime) -> Result<Response, Error> {
+    let client = config.runner_client();
+    runtime.block_on(async { client.get(GetParts::IndexId(INDEX, "1")).send().await })
+}

--- a/benchmarks/src/actions/index.rs
+++ b/benchmarks/src/actions/index.rs
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use crate::{Action, Config};
+use elasticsearch::{
+    cluster::ClusterHealthParts,
+    http::response::Response,
+    indices::{IndicesCreateParts, IndicesDeleteParts},
+    Error, IndexParts,
+};
+use tokio::runtime::Runtime;
+
+pub fn index() -> Action {
+    Action {
+        action: "index".to_string(),
+        category: Some("core".to_string()),
+        warmups: 100,
+        environment: None,
+        repetitions: 10000,
+        operations: Some(1),
+        setup: Some(setup),
+        run,
+    }
+}
+
+static INDEX: &str = "test-bench-index";
+
+fn setup(config: &Config, runtime: &mut Runtime) -> Result<Response, Error> {
+    let client = config.runner_client();
+    runtime.block_on(async {
+        let _response = client
+            .indices()
+            .delete(IndicesDeleteParts::Index(&[INDEX]))
+            .send()
+            .await?;
+
+        let _response = client
+            .indices()
+            .create(IndicesCreateParts::Index(INDEX))
+            .send()
+            .await?;
+
+        client
+            .cluster()
+            .health(ClusterHealthParts::Index(&[INDEX]))
+            .send()
+            .await
+    })
+}
+
+fn run(i: i32, config: &Config, runtime: &mut Runtime) -> Result<Response, Error> {
+    let client = config.runner_client();
+    let json = config.data_sources("small").unwrap();
+    runtime.block_on(async {
+        client
+            .index(IndexParts::IndexId(INDEX, i.to_string().as_str()))
+            .body(json)
+            .send()
+            .await
+    })
+}

--- a/benchmarks/src/actions/info.rs
+++ b/benchmarks/src/actions/info.rs
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use crate::{Action, Config};
+use elasticsearch::{http::response::Response, Error};
+use tokio::runtime::Runtime;
+
+pub fn info() -> Action {
+    Action {
+        action: "info".to_string(),
+        category: Some("core".to_string()),
+        warmups: 0,
+        environment: None,
+        repetitions: 10000,
+        operations: Some(1),
+        setup: None,
+        run,
+    }
+}
+
+fn run(_i: i32, config: &Config, runtime: &mut Runtime) -> Result<Response, Error> {
+    let client = config.runner_client();
+    runtime.block_on(async { client.info().send().await })
+}

--- a/benchmarks/src/actions/mod.rs
+++ b/benchmarks/src/actions/mod.rs
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+pub(crate) mod bulk;
+pub(crate) mod get;
+pub(crate) mod index;
+pub(crate) mod info;
+pub(crate) mod ping;

--- a/benchmarks/src/actions/ping.rs
+++ b/benchmarks/src/actions/ping.rs
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use crate::{Action, Config};
+use elasticsearch::{http::response::Response, Error};
+use tokio::runtime::Runtime;
+
+pub fn ping() -> Action {
+    Action {
+        action: "ping".to_string(),
+        category: Some("core".to_string()),
+        warmups: 0,
+        environment: None,
+        repetitions: 10000,
+        operations: Some(1),
+        setup: None,
+        run,
+    }
+}
+
+fn run(_i: i32, config: &Config, runtime: &mut Runtime) -> Result<Response, Error> {
+    let client = config.runner_client();
+    runtime.block_on(async { client.ping().send().await })
+}

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,0 +1,361 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+extern crate os_type;
+#[macro_use]
+extern crate serde_json;
+extern crate rustc_version_runtime;
+extern crate sys_info;
+
+mod actions;
+mod record;
+mod runner;
+
+use crate::{
+    actions::{bulk::bulk, get::get, index::index, info::info, ping::ping},
+    record::{Git, Os, Target},
+};
+use chrono::{DateTime, Duration, Utc};
+use elasticsearch::{
+    http::{response::Response, transport::Transport},
+    Elasticsearch,
+};
+use once_cell::sync::Lazy;
+use runner::Runner;
+use rustc_version_runtime::version;
+use serde_json::Value;
+use std::{collections::BTreeMap, error, fmt, fs, fs::File, io::BufReader, path::PathBuf};
+use tokio::runtime::Runtime;
+
+static CLIENT_BENCHMARK_CATEGORY: Lazy<String> =
+    Lazy::new(|| std::env::var("CLIENT_BENCHMARK_CATEGORY").unwrap_or_else(|_| "".to_string()));
+
+static FILTER: Lazy<String> =
+    Lazy::new(|| std::env::var("FILTER").unwrap_or_else(|_| "".to_string()));
+
+fn main() -> Result<(), Error> {
+    let rustc_version = version();
+    let config = Config::new(rustc_version.to_string())?;
+    let benchmarks = Benchmarks::new();
+    let mut runtime = Runtime::new().unwrap();
+
+    for operation in benchmarks.operations {
+        if !FILTER.is_empty() && !FILTER.contains(&operation.action) {
+            continue;
+        }
+
+        let mut runner = Runner::new(&config, &operation);
+
+        match runner.run(&mut runtime) {
+            Ok(results) => println!(
+                "{}, repetitions: {}, mean: {} ns, ops/sec: {}, errors: {}",
+                &results.action,
+                &results.repetitions,
+                &results.mean,
+                &results.ops_sec,
+                &results.errors.len()
+            ),
+            Err(e) => println!("{}", e.to_string()),
+        }
+    }
+
+    Ok(())
+}
+
+struct Benchmarks {
+    operations: Vec<Action>,
+}
+
+impl Benchmarks {
+    pub fn new() -> Self {
+        Self {
+            operations: vec![ping(), index(), get(), info(), bulk()],
+        }
+    }
+}
+
+pub struct Config {
+    build_id: String,
+    environment: String,
+    target: record::Target,
+    runner: record::Runner,
+    runner_client: Elasticsearch,
+    report_client: Elasticsearch,
+    data_sources: BTreeMap<String, Value>,
+}
+
+impl Config {
+    pub fn new(rustc_version: String) -> Result<Self, Error> {
+        let env_keys = vec![
+            "BUILD_ID",
+            "DATA_SOURCE",
+            "CLIENT_BRANCH",
+            "CLIENT_COMMIT",
+            "CLIENT_BENCHMARK_ENVIRONMENT",
+            "ELASTICSEARCH_TARGET_URL",
+            "ELASTICSEARCH_REPORT_URL",
+            "TARGET_SERVICE_TYPE",
+            "TARGET_SERVICE_NAME",
+            "TARGET_SERVICE_VERSION",
+            "TARGET_SERVICE_OS_FAMILY",
+        ];
+
+        let (vars, errors): (Vec<_>, Vec<_>) = env_keys
+            .iter()
+            .map(|e| match std::env::var(e) {
+                Ok(v) if !v.is_empty() => Ok((e.to_string(), v)),
+                Ok(_) => Err(Error::config(format!(
+                    "{} environment variable is empty",
+                    e
+                ))),
+                Err(err) => Err(Error::config(format!("{} {}", e, err.to_string()))),
+            })
+            .partition(Result::is_ok);
+
+        if !errors.is_empty() {
+            let errors: Vec<_> = errors
+                .into_iter()
+                .map(|e| e.unwrap_err().to_string())
+                .collect();
+            return Err(Error::config(errors.join("\n")));
+        }
+
+        let vars = vars
+            .into_iter()
+            .map(Result::unwrap)
+            .collect::<BTreeMap<String, String>>();
+
+        let data_source = PathBuf::from(vars.get("DATA_SOURCE").unwrap());
+        if !data_source.exists() {
+            return Err(Error::config(format!(
+                "Data source at {} does not exist",
+                data_source.to_str().unwrap()
+            )));
+        }
+
+        let mut data_sources = BTreeMap::new();
+        let entries = fs::read_dir(&data_source)?;
+        for entry in entries {
+            if let Ok(e) = entry {
+                if let Ok(f) = e.file_type() {
+                    if !f.is_dir() {
+                        continue;
+                    }
+
+                    let reader = {
+                        let mut path = e.path().clone();
+                        path.push("document.json");
+                        let file = File::open(path)?;
+                        BufReader::new(file)
+                    };
+                    let json: Value = serde_json::from_reader(reader)?;
+
+                    data_sources.insert(e.file_name().to_string_lossy().to_string(), json);
+                }
+            }
+        }
+
+        let service = record::Service {
+            ty: vars.get("TARGET_SERVICE_TYPE").unwrap().to_string(),
+            name: vars.get("TARGET_SERVICE_NAME").unwrap().to_string(),
+            version: vars.get("TARGET_SERVICE_VERSION").unwrap().to_string(),
+            git: Git {
+                commit: vars.get("CLIENT_COMMIT").unwrap().to_string(),
+                branch: vars.get("CLIENT_BRANCH").unwrap().to_string(),
+            },
+        };
+
+        let os = Os {
+            family: vars.get("TARGET_SERVICE_OS_FAMILY").unwrap().to_string(),
+        };
+
+        let current_os = os_type::current_platform();
+
+        Ok(Self {
+            build_id: vars.get("BUILD_ID").unwrap().to_string(),
+            environment: vars
+                .get("CLIENT_BENCHMARK_ENVIRONMENT")
+                .unwrap()
+                .to_string(),
+            target: Target {
+                service: service.clone(),
+                os: os.clone(),
+            },
+            runner: record::Runner {
+                service: record::Service {
+                    ty: "client".to_string(),
+                    name: "elasticsearch-rs".to_string(),
+                    version: elasticsearch::http::headers::DEFAULT_USER_AGENT.trim_start_matches("elasticsearch-rs/").to_string(),
+                    git: service.git,
+                },
+                runtime: record::Runtime {
+                    name: "rust".to_string(),
+                    version: rustc_version,
+                },
+                os: Os {
+                    family: format!("{:?} {}", &current_os.os_type, &current_os.version),
+                },
+            },
+            runner_client: Elasticsearch::new(
+                Transport::single_node(vars.get("ELASTICSEARCH_TARGET_URL").unwrap()).unwrap(),
+            ),
+            report_client: Elasticsearch::new(
+                Transport::single_node(vars.get("ELASTICSEARCH_REPORT_URL").unwrap()).unwrap(),
+            ),
+            data_sources,
+        })
+    }
+
+    pub fn runner_client(&self) -> &Elasticsearch {
+        &self.runner_client
+    }
+
+    pub fn report_client(&self) -> &Elasticsearch {
+        &self.report_client
+    }
+
+    pub fn environment(&self) -> &str {
+        self.environment.as_str()
+    }
+
+    pub fn data_sources(&self, key: &str) -> Option<&Value> {
+        self.data_sources.get(key)
+    }
+}
+
+#[derive(Clone)]
+struct Stats {
+    start: DateTime<Utc>,
+    duration: Duration,
+    outcome: String,
+    status_code: Option<u16>,
+}
+
+struct Results {
+    action: String,
+    repetitions: i32,
+    errors: Vec<String>,
+    mean: i64,
+    ops_sec: f64,
+}
+
+#[derive(Debug)]
+pub struct Error {
+    kind: Kind,
+}
+
+impl Error {
+    pub(crate) fn config(err: impl Into<String>) -> Self {
+        Error {
+            kind: Kind::Config(err.into()),
+        }
+    }
+
+    pub(crate) fn run(errs: Vec<String>) -> Self {
+        Error {
+            kind: Kind::Run(errs),
+        }
+    }
+}
+
+impl From<elasticsearch::Error> for Error {
+    fn from(err: elasticsearch::Error) -> Self {
+        Error {
+            kind: Kind::Response(err),
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Error {
+            kind: Kind::IO(err),
+        }
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Error {
+            kind: Kind::DataSource(err),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Kind {
+    Config(String),
+    IO(std::io::Error),
+    DataSource(serde_json::Error),
+    Response(elasticsearch::Error),
+    Run(Vec<String>),
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match &self.kind {
+            Kind::Config(_) => None,
+            Kind::IO(err) => Some(err),
+            Kind::DataSource(err) => Some(err),
+            Kind::Response(err) => Some(err),
+            Kind::Run(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.kind {
+            Kind::Config(err) => err.fmt(f),
+            Kind::DataSource(err) => err.fmt(f),
+            Kind::IO(err) => err.fmt(f),
+            Kind::Response(err) => err.fmt(f),
+            Kind::Run(errs) => errs.join("\n").fmt(f),
+        }
+    }
+}
+
+pub struct Action {
+    action: String,
+    category: Option<String>,
+    environment: Option<String>,
+    warmups: i32,
+    repetitions: i32,
+    operations: Option<i32>,
+    setup: Option<fn(&Config, &mut Runtime) -> Result<Response, elasticsearch::Error>>,
+    run: fn(i32, &Config, &mut Runtime) -> Result<Response, elasticsearch::Error>,
+}
+
+impl Action {
+    pub fn category(&self) -> Option<&str> {
+        self.category.as_deref()
+    }
+
+    pub fn environment(&self) -> Option<&str> {
+        self.environment.as_deref()
+    }
+
+    pub fn measure(
+        &self,
+        i: i32,
+        config: &Config,
+        runtime: &mut Runtime,
+    ) -> Result<Response, elasticsearch::Error> {
+        (self.run)(i, config, runtime)
+    }
+}

--- a/benchmarks/src/record.rs
+++ b/benchmarks/src/record.rs
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Record {
+    #[serde(rename = "@timestamp")]
+    pub timestamp: DateTime<Utc>,
+    pub labels: BTreeMap<String, String>,
+    pub tags: Vec<String>,
+    pub event: Event,
+    pub http: Http,
+    pub benchmark: Benchmark,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Event {
+    pub action: String,
+    pub duration: i64,
+    pub outcome: String,
+    pub dataset: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Http {
+    pub response: HttpResponse,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct HttpResponse {
+    pub status_code: Option<u16>,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Benchmark {
+    pub build_id: String,
+    pub repetitions: i32,
+    pub operations: i32,
+    pub runner: Runner,
+    pub target: Target,
+    pub category: String,
+    pub environment: String,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Runner {
+    pub service: Service,
+    pub runtime: Runtime,
+    pub os: Os,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Target {
+    pub service: Service,
+    pub os: Os,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Runtime {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Service {
+    #[serde(rename = "type")]
+    pub ty: String,
+    pub name: String,
+    pub version: String,
+    pub git: Git,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Git {
+    pub commit: String,
+    pub branch: String,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+pub struct Os {
+    pub family: String,
+}

--- a/benchmarks/src/runner.rs
+++ b/benchmarks/src/runner.rs
@@ -1,0 +1,225 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use crate::{
+    record::{Benchmark, Event, Http, HttpResponse, Record},
+    Action, Config, Error, Results, Stats, CLIENT_BENCHMARK_CATEGORY,
+};
+use chrono::Utc;
+use elasticsearch::{BulkOperation, BulkParts};
+use once_cell::sync::Lazy;
+use serde_json::Value;
+use std::{collections::BTreeMap, time::Instant};
+use tokio::runtime::Runtime;
+
+static STATS_INDEX: Lazy<String> =
+    Lazy::new(|| format!("metrics-intake-{}", Utc::now().format("%Y-%m")));
+
+pub(crate) struct Runner<'a> {
+    config: &'a Config,
+    stats: Vec<Stats>,
+    action: &'a Action,
+}
+
+impl<'a> Runner<'a> {
+    pub fn new(config: &'a Config, action: &'a Action) -> Self {
+        Self {
+            config,
+            stats: Vec::new(),
+            action,
+        }
+    }
+
+    pub fn run(&mut self, runtime: &mut Runtime) -> Result<Results, Error> {
+        let operations = self.action.operations.unwrap_or_else(|| 1);
+        let category = self
+            .action
+            .category()
+            .unwrap_or_else(|| CLIENT_BENCHMARK_CATEGORY.as_ref())
+            .to_string();
+        let environment = self
+            .action
+            .environment()
+            .unwrap_or_else(|| self.config.environment())
+            .to_string();
+
+        let mut errors: Vec<String> = Vec::with_capacity(
+            (self.action.warmups + (self.action.repetitions * operations)) as usize,
+        );
+
+        if let Some(f) = self.action.setup {
+            (f)(self.config, runtime)?;
+        }
+
+        for i in 0..self.action.warmups {
+            match self.action.measure(i, self.config, runtime) {
+                Ok(r) => {
+                    if !r.status_code().is_success() {
+                        let e = r.error_for_status_code().err().unwrap();
+                        errors.push(format!("warmup {}: {}", i, e.to_string()))
+                    }
+                }
+                Err(e) => errors.push(format!("warmup {}: {}", i, e.to_string())),
+            }
+        }
+
+        for i in 0..self.action.repetitions {
+            let start = Utc::now();
+            let now = Instant::now();
+            let result = self.action.measure(i, self.config, runtime);
+            let duration = now.elapsed();
+            let mut outcome = String::new();
+            let mut status_code: Option<u16> = None;
+            match result {
+                Ok(r) => {
+                    status_code = Some(r.status_code().as_u16());
+                    if !r.status_code().is_success() {
+                        let e = r.error_for_status_code().err().unwrap();
+                        errors.push(format!("run {}: {}", i, e.to_string()));
+                        outcome.push_str("failure");
+                    } else {
+                        outcome.push_str("success");
+                    }
+                }
+                Err(e) => {
+                    errors.push(format!("run {}: {}", i, e.to_string()));
+                    outcome.push_str("failure");
+                }
+            }
+
+            self.stats.push(Stats {
+                start,
+                duration: chrono::Duration::from_std(duration).unwrap(),
+                outcome,
+                status_code,
+            });
+        }
+
+        if errors.is_empty() {
+            self.save_stats(runtime, operations, category, environment)
+                .ok()
+                .unwrap();
+
+            let mean = {
+                (self
+                    .stats
+                    .iter()
+                    .map(|s| s.duration.num_nanoseconds().unwrap() as f64)
+                    .sum::<f64>()
+                    / self.stats.len() as f64) as i64
+            };
+
+            Ok(Results {
+                action: self.action.action.clone(),
+                repetitions: self.action.repetitions,
+                errors,
+                mean,
+                ops_sec: { 1e+9f64 / mean as f64 },
+            })
+        } else {
+            Err(Error::run(errors))
+        }
+    }
+
+    fn save_stats(
+        &self,
+        runtime: &mut Runtime,
+        operations: i32,
+        category: String,
+        environment: String,
+    ) -> Result<(), Error> {
+        let chunk_size = 1_000;
+        let client = self.config.report_client();
+        for chunk in self.stats.chunks(chunk_size) {
+            let mut body: Vec<BulkOperation<Record>> = Vec::with_capacity(1_000);
+
+            for stat in chunk {
+                body.push(
+                    BulkOperation::index(Record {
+                        timestamp: stat.start,
+                        labels: {
+                            let mut map = BTreeMap::new();
+                            map.insert("build_id".into(), self.config.build_id.clone());
+                            map.insert("client".into(), "elasticsearch-rs".into());
+                            map.insert("environment".into(), environment.clone());
+                            map
+                        },
+                        tags: vec!["bench".into(), "elasticsearch-rs".into()],
+                        event: Event {
+                            action: self.action.action.clone(),
+                            duration: stat.duration.num_nanoseconds().unwrap(),
+                            outcome: stat.outcome.clone(),
+                            dataset: None,
+                        },
+                        http: Http {
+                            response: HttpResponse {
+                                status_code: stat.status_code,
+                            },
+                        },
+                        benchmark: Benchmark {
+                            build_id: self.config.build_id.clone(),
+                            repetitions: self.action.repetitions,
+                            operations,
+                            runner: self.config.runner.clone(),
+                            target: self.config.target.clone(),
+                            category: category.clone(),
+                            environment: environment.clone(),
+                        },
+                    })
+                    .into(),
+                );
+            }
+
+            let response = runtime.block_on(async {
+                client
+                    .bulk(BulkParts::Index(STATS_INDEX.as_str()))
+                    .body(body)
+                    .send()
+                    .await
+            });
+
+            match response {
+                Ok(r) => {
+                    if !r.status_code().is_success() {
+                        println!("HTTP {} error saving stats", r.status_code().as_u16());
+                    } else {
+                        let de = runtime.block_on(async { r.json::<Value>().await });
+                        match de {
+                            Ok(json) => {
+                                if json["errors"].as_bool().unwrap() {
+                                    let error_count = json["items"]
+                                        .as_array()
+                                        .unwrap()
+                                        .iter()
+                                        .filter(|item| item["index"]["error"].is_object())
+                                        .count();
+
+                                    println!("{} errors saving stats", error_count);
+                                }
+                            }
+                            Err(e) => println!("Error saving stats: {}", e.to_string()),
+                        }
+                    }
+                }
+                Err(e) => println!("Error saving stats: {}", e.to_string()),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/elasticsearch/src/root/bulk.rs
+++ b/elasticsearch/src/root/bulk.rs
@@ -48,7 +48,7 @@ enum BulkAction {
 ///
 /// the specific bulk action metadata such as the id of the source document, index, etc.
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Default)]
+#[derive(Serialize, Default, Clone)]
 struct BulkMetadata {
     _index: Option<String>,
     // TODO: intentionally omit type for now, as it's going away.
@@ -68,6 +68,7 @@ struct BulkMetadata {
 ///
 /// The header contains the bulk action and the specific action metadata
 /// such as the id of the source document, index, etc.
+#[derive(Clone)]
 struct BulkHeader {
     action: BulkAction,
     metadata: BulkMetadata,
@@ -152,6 +153,7 @@ impl Serialize for BulkHeader {
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Clone)]
 pub struct BulkOperation<B> {
     header: BulkHeader,
     source: Option<B>,


### PR DESCRIPTION
Supersedes: #144, benchmarks branch has been rebased against master and squashed

This commit adds a benchmarking project to the repository, to benchmark the client in fashion that is common across all clients.

The output of benchmarking is common across clients to allow data to be persisted in the same datastore and viewable at https://clients-benchmarks.elastic.co/