### PR TITLE
Fix cargo make package

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -193,7 +193,11 @@ script = [
 """
 cd elasticsearch
 echo "packaging elasticsearch crate: cargo package %{CARGO_MAKE_CARGO_PACKAGE_FLAGS}"
-cargo package %{CARGO_MAKE_CARGO_PACKAGE_FLAGS}
+if is_empty %{CARGO_MAKE_CARGO_PACKAGE_FLAGS}
+    exec cargo package
+else
+    exec cargo package %{CARGO_MAKE_CARGO_PACKAGE_FLAGS}
+end
 """
 ]
 


### PR DESCRIPTION
- Missing exec
- Needs to run a different command depending on whether flags are passed.
  This is different to cargo publish, which ignores trailing whitespace
  when flags are empty.