### PR TITLE
Create platform specific run-elasticsearch task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -83,9 +83,15 @@ dependencies = ["install-cargo2junit"]
 
 [tasks.run-elasticsearch]
 category = "Elasticsearch"
+private = true
 condition = { env_set = [ "STACK_VERSION", "TEST_SUITE" ], env_false = ["CARGO_MAKE_CI"] }
-command = "./.ci/run-elasticsearch.sh"
 dependencies = ["set-oss-env", "set-xpack-env"]
+
+[tasks.run-elasticsearch.linux]
+command = "./.ci/run-elasticsearch.sh"
+
+[tasks.run-elasticsearch.mac]
+command = "./.ci/run-elasticsearch.sh"
 
 [tasks.run-elasticsearch.windows]
 script_runner = "cmd"


### PR DESCRIPTION
This commit splits out the command and script/script runner elements of the run-elasticsearch task to fix a bug when running on Windows where the task on Linux and macOS uses a command whilst Windows uses a script to run via WSL2. The Windows specific
task ends up with multiple actions (command and script) which cargo make errors on.