### PR TITLE
Add x-elastic-client-meta header

### DIFF
--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -29,6 +29,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 base64 = "^0.11"
 bytes = "^1.0"
 dyn-clone = "~1"
+lazy_static = "1.4"
 percent-encoding = "2.1.0"
 reqwest = { version = "~0.11", default-features = false, features = ["gzip", "json"] }
 url = "^2.1"
@@ -45,6 +46,7 @@ futures = "0.3.1"
 http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["tcp", "stream", "server"] }
 os_type = "2.2"
+regex="1.4"
 sysinfo = "0.12.0"
 textwrap = "^0.11"
 tokio = { version = "1.0", default-features = false, features = ["macros", "net", "time", "rt-multi-thread"] }

--- a/elasticsearch/build.rs
+++ b/elasticsearch/build.rs
@@ -20,7 +20,8 @@ extern crate rustc_version;
 use rustc_version::{version_meta, Channel};
 
 fn main() {
-    match version_meta().unwrap().channel {
+    let version = version_meta().unwrap();
+    match version.channel {
         Channel::Stable => {
             println!("cargo:rustc-cfg=RUSTC_IS_STABLE");
         }
@@ -34,4 +35,11 @@ fn main() {
             println!("cargo:rustc-cfg=RUSTC_IS_DEV");
         }
     }
+
+    let semver = version.semver;
+    let mut rustcv: String = format!("{}.{}.{}", semver.major, semver.minor, semver.patch);
+    if version.channel != Channel::Stable {
+        rustcv.push('p');
+    }
+    println!("cargo:rustc-env=RUSTC_VERSION={}", rustcv);
 }


### PR DESCRIPTION
Adds a `X-Elastic-Client-Meta` header to http requests. This header contains information about the runtime environment that is meant to allow analyzing usage context by collecting this information on the receiving side of requests, like a proxy server in front of ES. 

Using a custom header allows client applications to change the `User-Agent` header for their own purpose without losing this information. 