### PR TITLE
ci: improve scripts for local development

### DIFF
--- a/.ci/functions/wait-for-container.sh
+++ b/.ci/functions/wait-for-container.sh
@@ -17,8 +17,8 @@ function wait_for_container {
     sleep 2;
   done;
 
-  # Always show logs if the container is running, this is very useful both on CI as well as while developing
-  if container_running $1; then
+  # Always show logs, this is very useful both on CI as well as while developing
+  if container_exists $1; then
     docker logs $1
   fi
 


### PR DESCRIPTION
I picked up this repo recently to work on while commuting, when I'm often offline. This PR implements some tidyups I found useful.

### Support offline test running

Currently `cargo make test` will fail if you're offline, as it will always attempt to pull the remote docker image.

This PR implements the environment variable `DOCKER_PULL_ATTEMPTS` to make this optional:

```bash
DOCKER_PULL_ATTEMPTS=0 STACK_VERSION=7.14.0 cargo make test
```

### Dump logs for shutdown/errored containers

My test elasticsearch instance failed to start (I was running an older version, `7.10.0`, which wasn't supported). This was opaque to debug as the container is instantly deleted on shutdown (`docker run --rm`).

This PR implements always dumping logging from the elasticsearch instance. It does this by not deleting the container automatically, and instead deleting it explicitly after dumping logs. Previous containers also deleted if found by the next test run.

Please note that the impact of this is that some containers may still be left from the test run on the user's system. I believe this is desirable anyway for inspection after failure.