### PR TITLE
feature: Add multi-node connection pool

### DIFF
--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -32,7 +32,6 @@ dyn-clone = "1"
 lazy_static = "1"
 percent-encoding = "2"
 reqwest = { version = "0.12", default-features = false, features = ["gzip", "json"] }
-regex="1"
 url = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -49,6 +48,7 @@ http = "1"
 axum = "0.7"
 hyper = { version = "1", features = ["server", "http1"] }
 os_type = "2"
+regex="1"
 #sysinfo = "0.31"
 textwrap = "0.16"
 xml-rs = "0.8"

--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -32,6 +32,7 @@ dyn-clone = "1"
 lazy_static = "1"
 percent-encoding = "2"
 reqwest = { version = "0.12", default-features = false, features = ["gzip", "json"] }
+regex="1"
 url = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -47,7 +48,6 @@ http = "1"
 axum = "0.7"
 hyper = { version = "1", features = ["server", "http1"] }
 os_type = "2"
-regex="1"
 #sysinfo = "0.31"
 textwrap = "0.16"
 tokio = { version = "1", default-features = false, features = ["macros", "net", "time", "rt-multi-thread"] }

--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -37,6 +37,7 @@ url = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3"
+tokio = { version = "1", default-features = false, features = ["macros", "net", "time", "rt-multi-thread"] }
 void = "1"
 
 [dev-dependencies]
@@ -50,7 +51,6 @@ hyper = { version = "1", features = ["server", "http1"] }
 os_type = "2"
 #sysinfo = "0.31"
 textwrap = "0.16"
-tokio = { version = "1", default-features = false, features = ["macros", "net", "time", "rt-multi-thread"] }
 xml-rs = "0.8"
 
 [build-dependencies]

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -413,13 +413,30 @@ impl Transport {
     }
 
     /// Creates a new instance of a [Transport] configured with a
-    /// [StaticNodeListConnectionPool]
+    /// [MultiNodeConnectionPool] that does not refresh
     pub fn static_node_list(urls: Vec<&str>) -> Result<Transport, Error> {
         let urls: Vec<Url> = urls
             .iter()
             .map(|url| Url::parse(url))
             .collect::<Result<Vec<_>, _>>()?;
         let conn_pool = MultiNodeConnectionPool::round_robin(urls, None);
+        let transport = TransportBuilder::new(conn_pool).build()?;
+        Ok(transport)
+    }
+
+    /// Creates a new instance of a [Transport] configured with a
+    /// [MultiNodeConnectionPool]
+    ///
+    /// * `reseed_frequency` - frequency at which connections should be refreshed in seconds
+    pub fn sniffing_node_list(
+        urls: Vec<&str>,
+        reseed_frequency: Duration,
+    ) -> Result<Transport, Error> {
+        let urls: Vec<Url> = urls
+            .iter()
+            .map(|url| Url::parse(url))
+            .collect::<Result<Vec<_>, _>>()?;
+        let conn_pool = MultiNodeConnectionPool::round_robin(urls, Some(reseed_frequency));
         let transport = TransportBuilder::new(conn_pool).build()?;
         Ok(transport)
     }

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -408,7 +408,10 @@ impl Transport {
     /// Creates a new instance of a [Transport] configured with a
     /// [StaticNodeListConnectionPool]
     pub fn static_node_list(urls: Vec<&str>) -> Result<Transport, Error> {
-        let urls = urls.iter().map(|url| Url::parse(url).unwrap()).collect();
+        let urls: Vec<Url> = urls
+            .iter()
+            .map(|url| Url::parse(url))
+            .collect::<Result<Vec<_>, _>>()?;
         let conn_pool = StaticNodeListConnectionPool::round_robin(urls);
         let transport = TransportBuilder::new(conn_pool).build()?;
         Ok(transport)

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -47,7 +47,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc, RwLock,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 use url::Url;
 
@@ -412,7 +412,7 @@ impl Transport {
             .iter()
             .map(|url| Url::parse(url))
             .collect::<Result<Vec<_>, _>>()?;
-        let conn_pool = MultiNodeConnectionPool::round_robin(urls);
+        let conn_pool = MultiNodeConnectionPool::round_robin(urls, None);
         let transport = TransportBuilder::new(conn_pool).build()?;
         Ok(transport)
     }
@@ -443,6 +443,10 @@ impl Transport {
         B: Body,
         Q: Serialize + ?Sized,
     {
+        if self.conn_pool.reseedable() {
+            // Reseed nodes
+            println!("Reseeding!");
+        }
         let connection = self.conn_pool.next();
         let url = connection.url.join(path.trim_start_matches('/'))?;
         let reqwest_method = self.method(method);
@@ -533,6 +537,13 @@ impl Default for Transport {
 pub trait ConnectionPool: Debug + dyn_clone::DynClone + Sync + Send {
     /// Gets a reference to the next [Connection]
     fn next(&self) -> Connection;
+
+    fn reseedable(&self) -> bool {
+        false
+    }
+
+    // NOOP by default
+    fn reseed(&self, _connection: Vec<Connection>) {}
 }
 
 clone_trait_object!(ConnectionPool);
@@ -691,8 +702,15 @@ impl ConnectionPool for CloudConnectionPool {
 /// A Connection Pool that manages a static connection of nodes
 #[derive(Debug, Clone)]
 pub struct MultiNodeConnectionPool<TStrategy = RoundRobin> {
-    connections: Arc<RwLock<Vec<Connection>>>,
+    inner: Arc<RwLock<MultiNodeConnectionPoolInner>>,
+    wait: Option<Duration>,
     strategy: TStrategy,
+}
+
+#[derive(Debug, Clone)]
+pub struct MultiNodeConnectionPoolInner {
+    last_update: Option<Instant>,
+    connections: Vec<Connection>,
 }
 
 impl<TStrategy> ConnectionPool for MultiNodeConnectionPool<TStrategy>
@@ -700,22 +718,47 @@ where
     TStrategy: Strategy + Clone,
 {
     fn next(&self) -> Connection {
-        let inner = self.connections.read().expect("lock poisoned");
-        self.strategy.try_next(&inner).unwrap()
+        let inner = self.inner.read().expect("lock poisoned");
+        self.strategy.try_next(&inner.connections).unwrap()
+    }
+
+    fn reseedable(&self) -> bool {
+        let inner = self.inner.read().expect("lock poisoned");
+        let wait = match self.wait {
+            Some(wait) => wait,
+            None => return false,
+        };
+        let last_update_is_stale = inner
+            .last_update
+            .as_ref()
+            .map(|last_update| last_update.elapsed() > wait);
+        last_update_is_stale.unwrap_or(true)
+    }
+
+    fn reseed(&self, mut connection: Vec<Connection>) {
+        let mut inner = self.inner.write().expect("lock poisoned");
+        inner.last_update = Some(Instant::now());
+        inner.connections.clear();
+        inner.connections.append(&mut connection);
     }
 }
 
 impl MultiNodeConnectionPool<RoundRobin> {
     /** Use a round-robin strategy for balancing traffic over the given set of nodes. */
-    pub fn round_robin(urls: Vec<Url>) -> Self {
-        let connections: Arc<RwLock<Vec<_>>> =
-            Arc::new(RwLock::new(urls.into_iter().map(Connection::new).collect()));
+    pub fn round_robin(urls: Vec<Url>, wait: Option<Duration>) -> Self {
+        let connections = urls.into_iter().map(Connection::new).collect();
+
+        let inner: Arc<RwLock<MultiNodeConnectionPoolInner>> =
+            Arc::new(RwLock::new(MultiNodeConnectionPoolInner {
+                last_update: None,
+                connections,
+            }));
 
         let strategy = RoundRobin::default();
-
         Self {
-            connections,
+            inner,
             strategy,
+            wait,
         }
     }
 }
@@ -757,10 +800,11 @@ pub mod tests {
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     use crate::auth::ClientCertificate;
     use crate::http::transport::{
-        CloudId, Connection, ConnectionPool, MultiNodeConnectionPool, RoundRobin,
-        SingleNodeConnectionPool, TransportBuilder,
+        CloudId, Connection, ConnectionPool, MultiNodeConnectionPool, SingleNodeConnectionPool,
+        TransportBuilder,
     };
     use regex::Regex;
+    use std::time::{Duration, Instant};
     use url::Url;
 
     #[test]
@@ -909,10 +953,6 @@ pub mod tests {
         assert!(re.is_match(x));
     }
 
-    fn round_robin(addresses: Vec<Url>) -> MultiNodeConnectionPool<RoundRobin> {
-        MultiNodeConnectionPool::round_robin(addresses)
-    }
-
     fn expected_addresses() -> Vec<Url> {
         vec!["http://a:9200/", "http://b:9200/", "http://c:9200/"]
             .iter()
@@ -921,8 +961,55 @@ pub mod tests {
     }
 
     #[test]
+    fn test_reseedable_false_on_no_duration() {
+        let connections = MultiNodeConnectionPool::round_robin(expected_addresses(), None);
+        assert!(!connections.reseedable());
+    }
+
+    #[test]
+    fn test_reseed() {
+        let connection_pool =
+            MultiNodeConnectionPool::round_robin(vec![], Some(Duration::from_secs(28800)));
+
+        let connections = expected_addresses()
+            .into_iter()
+            .map(Connection::new)
+            .collect();
+
+        connection_pool.reseeding();
+        connection_pool.reseed(connections);
+        for _ in 0..10 {
+            for expected in expected_addresses() {
+                let actual = connection_pool.next();
+
+                assert_eq!(expected.as_str(), actual.url.as_str());
+            }
+        }
+        // Check connection pool not reseedable after reseed
+        assert!(!connection_pool.reseedable());
+
+        let inner = connection_pool.inner.read().expect("lock poisoned");
+        assert!(!inner.reseeding);
+    }
+
+    #[test]
+    fn test_reseedable_after_duration() {
+        let connection_pool = MultiNodeConnectionPool::round_robin(
+            expected_addresses(),
+            Some(Duration::from_secs(30)),
+        );
+
+        // Set internal last_update to a minute ago
+        let mut inner = connection_pool.inner.write().expect("lock poisoned");
+        inner.last_update = Some(Instant::now() - Duration::from_secs(60));
+        drop(inner);
+
+        assert!(connection_pool.reseedable());
+    }
+
+    #[test]
     fn round_robin_next_multi() {
-        let connections = round_robin(expected_addresses());
+        let connections = MultiNodeConnectionPool::round_robin(expected_addresses(), None);
 
         for _ in 0..10 {
             for expected in expected_addresses() {
@@ -936,7 +1023,7 @@ pub mod tests {
     #[test]
     fn round_robin_next_single() {
         let expected = Url::parse("http://a:9200/").unwrap();
-        let connections = round_robin(vec![expected.clone()]);
+        let connections = MultiNodeConnectionPool::round_robin(vec![expected.clone()], None);
 
         for _ in 0..10 {
             let actual = connections.next();
@@ -948,7 +1035,7 @@ pub mod tests {
     #[test]
     #[should_panic]
     fn round_robin_next_empty_fails() {
-        let connections = round_robin(vec![]);
+        let connections = MultiNodeConnectionPool::round_robin(vec![], None);
         connections.next();
     }
 }

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -45,7 +45,7 @@ use std::{
     io::{self, Write},
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, RwLock,
     },
     time::Duration,
 };
@@ -412,7 +412,7 @@ impl Transport {
             .iter()
             .map(|url| Url::parse(url))
             .collect::<Result<Vec<_>, _>>()?;
-        let conn_pool = StaticNodeListConnectionPool::round_robin(urls);
+        let conn_pool = MultiNodeConnectionPool::round_robin(urls);
         let transport = TransportBuilder::new(conn_pool).build()?;
         Ok(transport)
     }
@@ -532,7 +532,7 @@ impl Default for Transport {
 /// dynamically at runtime, based upon the response to API calls.
 pub trait ConnectionPool: Debug + dyn_clone::DynClone + Sync + Send {
     /// Gets a reference to the next [Connection]
-    fn next(&self) -> &Connection;
+    fn next(&self) -> Connection;
 }
 
 clone_trait_object!(ConnectionPool);
@@ -561,8 +561,8 @@ impl Default for SingleNodeConnectionPool {
 
 impl ConnectionPool for SingleNodeConnectionPool {
     /// Gets a reference to the next [Connection]
-    fn next(&self) -> &Connection {
-        &self.connection
+    fn next(&self) -> Connection {
+        self.connection.clone()
     }
 }
 
@@ -683,31 +683,33 @@ impl CloudConnectionPool {
 
 impl ConnectionPool for CloudConnectionPool {
     /// Gets a reference to the next [Connection]
-    fn next(&self) -> &Connection {
-        &self.connection
+    fn next(&self) -> Connection {
+        self.connection.clone()
     }
 }
 
 /// A Connection Pool that manages a static connection of nodes
 #[derive(Debug, Clone)]
-pub struct StaticNodeListConnectionPool<TStrategy = RoundRobin> {
-    connections: Vec<Connection>,
+pub struct MultiNodeConnectionPool<TStrategy = RoundRobin> {
+    connections: Arc<RwLock<Vec<Connection>>>,
     strategy: TStrategy,
 }
 
-impl<TStrategy> ConnectionPool for StaticNodeListConnectionPool<TStrategy>
+impl<TStrategy> ConnectionPool for MultiNodeConnectionPool<TStrategy>
 where
     TStrategy: Strategy + Clone,
 {
-    fn next(&self) -> &Connection {
-        self.strategy.try_next(&self.connections).unwrap()
+    fn next(&self) -> Connection {
+        let inner = self.connections.read().expect("lock poisoned");
+        self.strategy.try_next(&inner).unwrap()
     }
 }
 
-impl StaticNodeListConnectionPool<RoundRobin> {
+impl MultiNodeConnectionPool<RoundRobin> {
     /** Use a round-robin strategy for balancing traffic over the given set of nodes. */
     pub fn round_robin(urls: Vec<Url>) -> Self {
-        let connections: Vec<_> = urls.into_iter().map(Connection::new).collect();
+        let connections: Arc<RwLock<Vec<_>>> =
+            Arc::new(RwLock::new(urls.into_iter().map(Connection::new).collect()));
 
         let strategy = RoundRobin::default();
 
@@ -721,7 +723,7 @@ impl StaticNodeListConnectionPool<RoundRobin> {
 /** The strategy selects an address from a given collection. */
 pub trait Strategy: Send + Sync + Debug {
     /** Try get the next connection. */
-    fn try_next<'a>(&self, connections: &'a [Connection]) -> Result<&'a Connection, Error>;
+    fn try_next<'a>(&self, connections: &'a [Connection]) -> Result<Connection, Error>;
 }
 
 /** A round-robin strategy cycles through nodes sequentially. */
@@ -739,12 +741,12 @@ impl Default for RoundRobin {
 }
 
 impl Strategy for RoundRobin {
-    fn try_next<'a>(&self, connections: &'a [Connection]) -> Result<&'a Connection, Error> {
+    fn try_next<'a>(&self, connections: &'a [Connection]) -> Result<Connection, Error> {
         if connections.is_empty() {
             Err(crate::error::lib("Connection list empty"))
         } else {
             let i = self.index.fetch_add(1, Ordering::Relaxed) % connections.len();
-            Ok(&connections[i])
+            Ok(connections[i].clone())
         }
     }
 }
@@ -755,8 +757,8 @@ pub mod tests {
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     use crate::auth::ClientCertificate;
     use crate::http::transport::{
-        CloudId, Connection, ConnectionPool, RoundRobin, SingleNodeConnectionPool,
-        StaticNodeListConnectionPool, TransportBuilder,
+        CloudId, Connection, ConnectionPool, MultiNodeConnectionPool, RoundRobin,
+        SingleNodeConnectionPool, TransportBuilder,
     };
     use regex::Regex;
     use url::Url;
@@ -907,8 +909,8 @@ pub mod tests {
         assert!(re.is_match(x));
     }
 
-    fn round_robin(addresses: Vec<Url>) -> StaticNodeListConnectionPool<RoundRobin> {
-        StaticNodeListConnectionPool::round_robin(addresses)
+    fn round_robin(addresses: Vec<Url>) -> MultiNodeConnectionPool<RoundRobin> {
+        MultiNodeConnectionPool::round_robin(addresses)
     }
 
     fn expected_addresses() -> Vec<Url> {

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -45,7 +45,7 @@ use std::{
     fmt::Debug,
     io::{self, Write},
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, RwLock,
     },
     time::{Duration, Instant},
@@ -551,10 +551,6 @@ impl Transport {
     {
         // Threads will execute against old connection pool during reseed
         if self.conn_pool.reseedable() {
-            // Set as reseeding prevents another thread from attempting
-            // to reseed during es request and reseed
-            self.conn_pool.reseeding();
-
             let connection = self.conn_pool.next();
             let scheme = &connection.url.scheme();
             // Build node info request
@@ -624,9 +620,6 @@ pub trait ConnectionPool: Debug + dyn_clone::DynClone + Sync + Send {
     fn reseedable(&self) -> bool {
         false
     }
-
-    // NOOP
-    fn reseeding(&self) {}
 
     // NOOP by default
     fn reseed(&self, _connection: Vec<Connection>) {}
@@ -791,11 +784,11 @@ pub struct MultiNodeConnectionPool<LoadBalancing = RoundRobin> {
     inner: Arc<RwLock<MultiNodeConnectionPoolInner>>,
     reseed_frequency: Option<Duration>,
     load_balancing_strategy: LoadBalancing,
+    reseeding: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Clone)]
 pub struct MultiNodeConnectionPoolInner {
-    reseeding: bool,
     last_update: Option<Instant>,
     connections: Vec<Connection>,
 }
@@ -821,12 +814,17 @@ where
             .last_update
             .as_ref()
             .map(|last_update| last_update.elapsed() > reseed_frequency);
-        last_update_is_stale.unwrap_or(true) && !inner.reseeding
-    }
+        let reseedable = last_update_is_stale.unwrap_or(true);
 
-    fn reseeding(&self) {
-        let mut inner = self.inner.write().expect("Lock Poisoned");
-        inner.reseeding = true
+        return if !reseedable {
+            false
+        } else {
+            // Check if refreshing is false if so, sets to true atomically and returns old value (false) meaning refreshable is true
+            // If refreshing is set to true, do nothing and return true, meaning refreshable is false
+            !self
+                .reseeding
+                .compare_and_swap(false, true, Ordering::Relaxed)
+        };
     }
 
     fn reseed(&self, mut connection: Vec<Connection>) {
@@ -834,7 +832,7 @@ where
         inner.last_update = Some(Instant::now());
         inner.connections.clear();
         inner.connections.append(&mut connection);
-        inner.reseeding = false;
+        self.reseeding.store(false, Ordering::Relaxed);
     }
 }
 
@@ -845,16 +843,17 @@ impl MultiNodeConnectionPool<RoundRobin> {
 
         let inner: Arc<RwLock<MultiNodeConnectionPoolInner>> =
             Arc::new(RwLock::new(MultiNodeConnectionPoolInner {
-                reseeding: false,
                 last_update: None,
                 connections,
             }));
+        let reseeding = Arc::new(AtomicBool::new(false));
 
         let load_balancing_strategy = RoundRobin::default();
         Self {
             inner,
             load_balancing_strategy,
             reseed_frequency,
+            reseeding,
         }
     }
 }
@@ -901,6 +900,10 @@ pub mod tests {
     };
     use regex::Regex;
     use std::time::{Duration, Instant};
+    use std::{
+        sync::atomic::Ordering,
+        time::{Duration, Instant},
+    };
     use url::Url;
 
     #[test]
@@ -1071,8 +1074,6 @@ pub mod tests {
             .into_iter()
             .map(Connection::new)
             .collect();
-
-        connection_pool.reseeding();
         connection_pool.reseed(connections);
         for _ in 0..10 {
             for expected in expected_addresses() {
@@ -1083,9 +1084,7 @@ pub mod tests {
         }
         // Check connection pool not reseedable after reseed
         assert!(!connection_pool.reseedable());
-
-        let inner = connection_pool.inner.read().expect("lock poisoned");
-        assert!(!inner.reseeding);
+        assert!(!connection_pool.reseeding.load(Ordering::Relaxed));
     }
 
     #[test]
@@ -1101,6 +1100,7 @@ pub mod tests {
         drop(inner);
 
         assert!(connection_pool.reseedable());
+        assert!(connection_pool.reseeding.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -43,6 +43,10 @@ use std::{
     error, fmt,
     fmt::Debug,
     io::{self, Write},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 use url::Url;
@@ -401,6 +405,15 @@ impl Transport {
         Ok(transport)
     }
 
+    /// Creates a new instance of a [Transport] configured with a
+    /// [StaticNodeListConnectionPool]
+    pub fn static_node_list(urls: Vec<&str>) -> Result<Transport, Error> {
+        let urls = urls.iter().map(|url| Url::parse(url).unwrap()).collect();
+        let conn_pool = StaticNodeListConnectionPool::round_robin(urls);
+        let transport = TransportBuilder::new(conn_pool).build()?;
+        Ok(transport)
+    }
+
     /// Creates a new instance of a [Transport] configured for use with
     /// [Elasticsearch service in Elastic Cloud](https://www.elastic.co/cloud/).
     ///
@@ -672,11 +685,76 @@ impl ConnectionPool for CloudConnectionPool {
     }
 }
 
+/// A Connection Pool that manages a static connection of nodes
+#[derive(Debug, Clone)]
+pub struct StaticNodeListConnectionPool<TStrategy = RoundRobin> {
+    connections: Vec<Connection>,
+    strategy: TStrategy,
+}
+
+impl<TStrategy> ConnectionPool for StaticNodeListConnectionPool<TStrategy>
+where
+    TStrategy: Strategy + Clone,
+{
+    fn next(&self) -> &Connection {
+        self.strategy.try_next(&self.connections).unwrap()
+    }
+}
+
+impl StaticNodeListConnectionPool<RoundRobin> {
+    /** Use a round-robin strategy for balancing traffic over the given set of nodes. */
+    pub fn round_robin(urls: Vec<Url>) -> Self {
+        let connections: Vec<_> = urls.into_iter().map(Connection::new).collect();
+
+        let strategy = RoundRobin::default();
+
+        Self {
+            connections,
+            strategy,
+        }
+    }
+}
+
+/** The strategy selects an address from a given collection. */
+pub trait Strategy: Send + Sync + Debug {
+    /** Try get the next connection. */
+    fn try_next<'a>(&self, connections: &'a [Connection]) -> Result<&'a Connection, Error>;
+}
+
+/** A round-robin strategy cycles through nodes sequentially. */
+#[derive(Clone, Debug)]
+pub struct RoundRobin {
+    index: Arc<AtomicUsize>,
+}
+
+impl Default for RoundRobin {
+    fn default() -> Self {
+        RoundRobin {
+            index: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl Strategy for RoundRobin {
+    fn try_next<'a>(&self, connections: &'a [Connection]) -> Result<&'a Connection, Error> {
+        if connections.is_empty() {
+            Err(crate::error::lib("Connection list empty"))
+        } else {
+            let i = self.index.fetch_add(1, Ordering::Relaxed) % connections.len();
+            Ok(&connections[i])
+        }
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     use crate::auth::ClientCertificate;
+    use crate::http::transport::{
+        CloudId, Connection, ConnectionPool, RoundRobin, SingleNodeConnectionPool,
+        StaticNodeListConnectionPool, TransportBuilder,
+    };
     use regex::Regex;
     use url::Url;
 
@@ -824,5 +902,48 @@ pub mod tests {
         let x: &str = CLIENT_META.as_str();
         println!("{}", x);
         assert!(re.is_match(x));
+    }
+
+    fn round_robin(addresses: Vec<Url>) -> StaticNodeListConnectionPool<RoundRobin> {
+        StaticNodeListConnectionPool::round_robin(addresses)
+    }
+
+    fn expected_addresses() -> Vec<Url> {
+        vec!["http://a:9200/", "http://b:9200/", "http://c:9200/"]
+            .iter()
+            .map(|addr| Url::parse(addr).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn round_robin_next_multi() {
+        let connections = round_robin(expected_addresses());
+
+        for _ in 0..10 {
+            for expected in expected_addresses() {
+                let actual = connections.next();
+
+                assert_eq!(expected.as_str(), actual.url.as_str());
+            }
+        }
+    }
+
+    #[test]
+    fn round_robin_next_single() {
+        let expected = Url::parse("http://a:9200/").unwrap();
+        let connections = round_robin(vec![expected.clone()]);
+
+        for _ in 0..10 {
+            let actual = connections.next();
+
+            assert_eq!(expected.as_str(), actual.url.as_str());
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn round_robin_next_empty_fails() {
+        let connections = round_robin(vec![]);
+        connections.next();
     }
 }

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -370,9 +370,6 @@ mod readme {
 #[macro_use]
 extern crate dyn_clone;
 
-#[macro_use]
-extern crate lazy_static;
-
 pub mod auth;
 pub mod cert;
 pub mod http;

--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -370,6 +370,9 @@ mod readme {
 #[macro_use]
 extern crate dyn_clone;
 
+#[macro_use]
+extern crate lazy_static;
+
 pub mod auth;
 pub mod cert;
 pub mod http;


### PR DESCRIPTION
Closes #57
Based on/supersedes #139 by @srleyva

Initially reviewed by @russcam and @swallez 

---

This PR rebases #139 on top of current master, updates the added dependencies to current versions, and fixes clippy/deprecation warnings present in the diff.

I have maintained the original commit history for ease of picking up review from the existing PR - I believe everything after and including `Add regex parsing bound_address to URL` is unreviewed.

I have a couple of thoughts of potential improvements, but would like to hear from others before I sink any more time into this.