### PR TITLE
Use idiomatic dependencies in Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ elasticsearch = "8.0.0-alpha.1"
 The following _optional_ dependencies may also be useful to create requests and read responses
 
 ```toml
-serde = "~1"
-serde_json = "~1"
+serde = "1"
+serde_json = "1"
 ```
 
 ----


### PR DESCRIPTION
In Cargo, it's very very rare that one actually *needs* `^` or `~` deps in Cargo.toml. Default `foo = "1.2.3"` will do the right thing most of the time. In this particular case, all of `^1`, `~1` and `1` would be equivalent, and there's no need to stray from default.