### PR TITLE
Bump textwrap to latest version

### DIFF
--- a/elasticsearch/Cargo.toml
+++ b/elasticsearch/Cargo.toml
@@ -48,7 +48,7 @@ hyper = { version = "0.14", default-features = false, features = ["tcp", "stream
 os_type = "2.2"
 regex="1.4"
 sysinfo = "0.12.0"
-textwrap = "^0.11"
+textwrap = "0.15"
 tokio = { version = "1.0", default-features = false, features = ["macros", "net", "time", "rt-multi-thread"] }
 xml-rs = "^0.8"
 


### PR DESCRIPTION
There has been a few bugfixes since 0.11, so I hope you will be happy to switch to the latest and greatest version.