### PR TITLE
fix Cat API example

### DIFF
--- a/elasticsearch/src/lib.rs
+++ b/elasticsearch/src/lib.rs
@@ -188,6 +188,7 @@
 //! let response = client
 //!     .cat()
 //!     .indices(CatIndicesParts::Index(&["*"]))
+//!     .format("json")
 //!     .send()
 //!     .await?;
 //!


### PR DESCRIPTION
The Cat API example in the overview of the docs does not work, since the Cat API returns plain text by default, so the deserialization into a JSON value will fail.

Explicitly telling the API to return JSON fixes this.