### PR TITLE
Add credential using a base64 encoded API key

### DIFF
--- a/api_generator/src/generator/code_gen/url/enum_builder.rs
+++ b/api_generator/src/generator/code_gen/url/enum_builder.rs
@@ -357,7 +357,7 @@ mod tests {
                             methods: vec![HttpMethod::Get, HttpMethod::Post],
                             parts: {
                                 let mut map = BTreeMap::new();
-                                map.insert("index".to_string(), Type {i
+                                map.insert("index".to_string(), Type {
                                     ty: TypeKind::List,
                                     description: Some("A comma-separated list of index names to search".to_string()),
                                     options: vec![],

--- a/elasticsearch/src/auth.rs
+++ b/elasticsearch/src/auth.rs
@@ -31,8 +31,10 @@ pub enum Credentials {
     /// This requires the `native-tls` or `rustls-tls` feature to be enabled.
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     Certificate(ClientCertificate),
-    /// An id and api_key to use for API key authentication
+    /// An API key id and secret to use for API key authentication
     ApiKey(String, String),
+    /// An API key as a base64-encoded id and secret
+    EncodedApiKey(String),
 }
 
 #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -41,6 +41,7 @@ use lazy_static::lazy_static;
 use serde::Serialize;
 use serde_json::Value;
 use std::{
+    convert::TryFrom,
     error, fmt,
     fmt::Debug,
     io::{self, Write},
@@ -492,10 +493,14 @@ impl Transport {
                         write!(encoder, "{}:", i).unwrap();
                         write!(encoder, "{}", k).unwrap();
                     }
-                    request_builder.header(
-                        AUTHORIZATION,
-                        HeaderValue::from_bytes(&header_value).unwrap(),
-                    )
+                    let mut header_value = HeaderValue::from_bytes(&header_value).unwrap();
+                    header_value.set_sensitive(true);
+                    request_builder.header(AUTHORIZATION, header_value)
+                }
+                Credentials::EncodedApiKey(k) => {
+                    let mut header_value = HeaderValue::try_from(format!("ApiKey {}", k)).unwrap();
+                    header_value.set_sensitive(true);
+                    request_builder.header(AUTHORIZATION, header_value)
                 }
             }
         }


### PR DESCRIPTION
Add a new `Credentials::EncodedApiKey` variant using a single string containing the base64 encoded API key and secret.

Also sets the `Authorization` header as sensitive, so that its value is redacted in debug output.

Fixes #235