### PR TITLE
Allow cloning the transport with different credentials

### DIFF
--- a/elasticsearch/src/auth.rs
+++ b/elasticsearch/src/auth.rs
@@ -35,6 +35,8 @@ pub enum Credentials {
     ApiKey(String, String),
     /// An API key as a base64-encoded id and secret
     EncodedApiKey(String),
+    /// An arbitrary value for the Authorization header
+    AuthorizationHeader(String),
 }
 
 #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]

--- a/elasticsearch/src/http/transport.rs
+++ b/elasticsearch/src/http/transport.rs
@@ -543,6 +543,9 @@ impl Transport {
                     header_value.set_sensitive(true);
                     request_builder.header(AUTHORIZATION, header_value)
                 }
+                Credentials::AuthorizationHeader(header) => {
+                    request_builder.header(AUTHORIZATION, header.clone())
+                }
             }
         }
         drop(creds_guard);

--- a/elasticsearch/tests/auth.rs
+++ b/elasticsearch/tests/auth.rs
@@ -116,6 +116,22 @@ async fn bearer_header() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn arbitrary_auth_header() -> anyhow::Result<()> {
+    let server = server::http(move |req| async move {
+        assert_eq!(req.headers()["authorization"], "Foo bar baz");
+        http::Response::default()
+    });
+
+    let builder = client::create_builder(format!("http://{}", server.addr()).as_ref())
+        .auth(Credentials::AuthorizationHeader("Foo bar baz".into()));
+
+    let client = client::create(builder);
+    let _response = client.ping().send().await?;
+
+    Ok(())
+}
+
 // TODO: test PKI authentication. Could configure a HttpsConnector, maybe using https://github.com/sfackler/hyper-openssl?, or send to PKI configured Elasticsearch.
 //#[tokio::test]
 //async fn client_certificate() -> anyhow::Result<()> {


### PR DESCRIPTION
Add `Transport::clone_with_auth()` that clones a transport (http client and connection pool) with a different authentication. The primary use case is for multi-tenant applications where multiple different credentials can be used to connect to the same Elasticsearch cluster.

To make it easier to set any kind of authentication header, this PR also adds a new kind of credentials, `Credentials::AuthorizationHeader` that accepts any string value.