### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: ["labeled", "closed"]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backport:
     name: Backport PR

--- a/.github/workflows/clippy_check.yml
+++ b/.github/workflows/clippy_check.yml
@@ -1,5 +1,9 @@
 on: push
 name: Clippy check
+
+permissions:
+  checks: write
+
 env:
   # workaround current issue with rustfmt-nightly
   CFG_RELEASE_CHANNEL: nightly


### PR DESCRIPTION
InfoSec is changing GITHUB_TOKEN default permissions from read/write to read-only on July 15th. Adding explicit `permissions` blocks to all workflows that require write access.

## Changes
- `.github/workflows/backport.yml`: added `contents: write` and `pull-requests: write`
- `.github/workflows/clippy_check.yml`: added `checks: write`